### PR TITLE
docs: add clickable links to skills in README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,26 @@ Modern coding agents (GitHub Copilot CLI, [Claude Code](https://devblogs.microso
 
 Each skill is a self-contained knowledge package with a `SKILL.md` file. **Copy only the skills you need** to your project's `.github/skills/` directory.
 
-| Skill | Location | Description |
-|-------|----------|-------------|
-| `agent-framework-azure-hosted-agents` | `.github/skills/agent-framework-azure-hosted-agents/` | Microsoft Agent Framework SDK for persistent Azure AI Foundry agents with hosted tools and MCP |
-| `azure-ai-agents-python` | `.github/skills/azure-ai-agents-python/` | Low-level Azure AI Agents SDK for agent CRUD, threads, streaming, and tools |
-| `azd-deployment` | `.github/skills/azd-deployment/` | Azure Developer CLI deployment to Container Apps with Bicep |
-| `azure-ai-search-python` | `.github/skills/azure-ai-search-python/` | Azure AI Search SDK patterns, vector/hybrid search, agentic retrieval |
-| `azure-ai-voicelive-skill` | `.github/skills/azure-ai-voicelive-skill/` | Azure AI Voice Live SDK integration |
-| `cosmos-db-python-skill` | `.github/skills/cosmos-db-python-skill/` | Cosmos DB NoSQL with Python/FastAPI, CRUD patterns |
-| `fastapi-router` | `.github/skills/fastapi-router/` | FastAPI routers with CRUD, auth, and response models |
-| `foundry-iq-python` | `.github/skills/foundry-iq-python/` | Agentic retrieval with knowledge bases and Foundry Agent Service |
-| `foundry-nextgen-frontend` | `.github/skills/foundry-nextgen-frontend/` | NextGen Design System UI patterns (Vite + React) |
-| `foundry-sdk-python` | `.github/skills/foundry-sdk-python/` | High-level Azure AI Projects SDK for Foundry integration, versioned agents, and evaluations |
-| `issue-creator` | `.github/skills/issue-creator/` | GitHub issue creation patterns |
-| `mcp-builder` | `.github/skills/mcp-builder/` | Building MCP servers (Python/Node) |
-| `podcast-generation` | `.github/skills/podcast-generation/` | Podcast generation workflows |
-| `pydantic-models` | `.github/skills/pydantic-models/` | Pydantic v2 multi-model patterns (Base/Create/Update/Response) |
-| `react-flow-node` | `.github/skills/react-flow-node/` | React Flow custom nodes with TypeScript and Zustand |
-| `skill-creator` | `.github/skills/skill-creator/` | Guide for creating new skills |
-| `zustand-store` | `.github/skills/zustand-store/` | Zustand stores with TypeScript and subscribeWithSelector |
+| Skill | Description |
+|-------|-------------|
+| [`agent-framework-azure-hosted-agents`](.github/skills/agent-framework-azure-hosted-agents/) | Microsoft Agent Framework SDK for persistent Azure AI Foundry agents with hosted tools and MCP |
+| [`azure-ai-agents-python`](.github/skills/azure-ai-agents-python/) | Low-level Azure AI Agents SDK for agent CRUD, threads, streaming, and tools |
+| [`azure-ai-search-python`](.github/skills/azure-ai-search-python/) | Azure AI Search SDK patterns, vector/hybrid search, agentic retrieval |
+| [`azure-ai-voicelive-skill`](.github/skills/azure-ai-voicelive-skill/) | Azure AI Voice Live SDK integration |
+| [`azd-deployment`](.github/skills/azd-deployment/) | Azure Developer CLI deployment to Container Apps with Bicep |
+| [`cosmos-db-python-skill`](.github/skills/cosmos-db-python-skill/) | Cosmos DB NoSQL with Python/FastAPI, CRUD patterns |
+| [`fastapi-router`](.github/skills/fastapi-router/) | FastAPI routers with CRUD, auth, and response models |
+| [`foundry-iq-agent`](.github/skills/foundry-iq-agent/) | Foundry IQ agent patterns |
+| [`foundry-iq-python`](.github/skills/foundry-iq-python/) | Agentic retrieval with knowledge bases and Foundry Agent Service |
+| [`foundry-nextgen-frontend`](.github/skills/foundry-nextgen-frontend/) | NextGen Design System UI patterns (Vite + React) |
+| [`foundry-sdk-python`](.github/skills/foundry-sdk-python/) | High-level Azure AI Projects SDK for Foundry integration, versioned agents, and evaluations |
+| [`issue-creator`](.github/skills/issue-creator/) | GitHub issue creation patterns |
+| [`mcp-builder`](.github/skills/mcp-builder/) | Building MCP servers (Python/Node) |
+| [`podcast-generation`](.github/skills/podcast-generation/) | Podcast generation workflows |
+| [`pydantic-models`](.github/skills/pydantic-models/) | Pydantic v2 multi-model patterns (Base/Create/Update/Response) |
+| [`react-flow-node`](.github/skills/react-flow-node/) | React Flow custom nodes with TypeScript and Zustand |
+| [`skill-creator`](.github/skills/skill-creator/) | Guide for creating new skills |
+| [`zustand-store`](.github/skills/zustand-store/) | Zustand stores with TypeScript and subscribeWithSelector |
 
 ### Using Skills with Multiple Agents
 


### PR DESCRIPTION
## Summary
- Skill names in the README table are now clickable links to their folders
- Removed redundant "Location" column since skill names now serve as links
- Added missing `foundry-iq-agent` skill to the table
- Sorted skills alphabetically for consistency