### PR TITLE
feat(skills): add multi-language SDK skill catalog with TypeScript and Java

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -146,31 +146,33 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 
 ## Skills
 
-Skills are domain-specific knowledge packages in `.github/skills/`. Each has a `SKILL.md` with:
+Skills are domain-specific knowledge packages. Each has a `SKILL.md` with:
 - **YAML frontmatter** (`name`, `description`) — triggers skill loading
 - **Markdown body** — loaded only when skill activates
 
-### Available Skills
+### Core Skills (Auto-discovered)
 
-| Skill | Purpose |
-|-------|---------|
-| `azure-ai-search-python` | Search SDK patterns, vector/hybrid search, agentic retrieval |
-| `azure-ai-agents-python` | Low-level agents SDK for CRUD, threads, streaming, tools |
-| `azure-ai-voicelive` | Real-time voice AI with Azure AI Voice Live SDK |
-| `foundry-sdk-python` | High-level Foundry project client, versioned agents, evals |
-| `foundry-iq-python` | Agentic retrieval with knowledge bases |
-| `foundry-nextgen-frontend` | NextGen Design System UI patterns (Vite + React) |
-| `agent-framework-azure-hosted-agents` | Agent Framework SDK for persistent Azure agents |
-| `azd-deployment` | Azure Developer CLI deployment to Container Apps with Bicep |
-| `mcp-builder` | Building MCP servers (Python/Node) |
-| `cosmos-db-python-skill` | Cosmos DB NoSQL with Python/FastAPI |
-| `fastapi-router` | FastAPI routers with CRUD, auth, response models |
-| `pydantic-models` | Pydantic v2 multi-model patterns |
-| `zustand-store` | Zustand stores with TypeScript and subscribeWithSelector |
-| `react-flow-node` | React Flow custom nodes with TypeScript |
-| `podcast-generation` | Podcast generation workflows |
-| `skill-creator` | Guide for creating new skills |
-| `github-issue-creator` | Convert raw notes/logs into structured GitHub issues |
+> Location: `.github/skills/` • 16 skills
+
+| Category | Skills |
+|----------|--------|
+| **AI Foundry** | `foundry-sdk-python`, `foundry-iq-python`, `azure-ai-agents-python`, `agent-framework-azure-hosted-agents` |
+| **AI Services** | `azure-ai-search-python`, `azure-ai-voicelive` |
+| **Backend** | `fastapi-router`, `pydantic-models`, `cosmos-db-python-skill` |
+| **Infrastructure** | `azd-deployment`, `azure-resourcemanager-mysql-dotnet`, `azure-resourcemanager-postgresql-dotnet` |
+| **Tooling** | `skill-creator`, `mcp-builder`, `github-issue-creator` |
+| **Other** | `podcast-generation` |
+
+### Extended Catalog
+
+> Location: `skills/{language}/` • 113 skills • See [CATALOG.md](CATALOG.md)
+
+| Language | Skills | Coverage |
+|----------|--------|----------|
+| **Python** | 33 | AI, Data, Messaging, Monitoring, Identity, Security, Integration |
+| **.NET** | 29 | Foundry, AI, Data, Messaging, Identity, Security, Partner |
+| **TypeScript** | 23 | Foundry, AI, Data, Messaging, Frontend, Identity |
+| **Java** | 28 | Foundry, AI, Data, Messaging, Communication, Identity |
 
 ### Skill Selection
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,0 +1,383 @@
+# Skill Catalog
+
+Extended skills organized by language. Copy to your project's `.github/skills/` as needed.
+
+```bash
+cp -r skills/python/messaging/servicebus /path/to/your-project/.github/skills/
+```
+
+---
+
+## Python
+
+> 33 skills in `skills/python/`
+
+### Foundry
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [contentsafety](skills/python/foundry/contentsafety/) | `azure-ai-contentsafety` | Content moderation and safety |
+| [contentunderstanding](skills/python/foundry/contentunderstanding/) | `azure-ai-contentunderstanding` | Document and media understanding |
+| [evaluation](skills/python/foundry/evaluation/) | `azure-ai-evaluation` | AI model evaluation and metrics |
+
+### AI
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [inference](skills/python/ai/inference/) | `azure-ai-inference` | Azure AI Model Inference for chat, embeddings |
+| [ml](skills/python/ai/ml/) | `azure-ai-ml` | Azure Machine Learning SDK v2 |
+| [textanalytics](skills/python/ai/textanalytics/) | `azure-ai-textanalytics` | Text Analytics — NER, sentiment, key phrases |
+| [transcription](skills/python/ai/transcription/) | `azure-cognitiveservices-speech` | Speech-to-text transcription |
+| [translation-document](skills/python/ai/translation-document/) | `azure-ai-translation-document` | Document translation (batch) |
+| [translation-text](skills/python/ai/translation-text/) | `azure-ai-translation-text` | Text translation API |
+| [vision-imageanalysis](skills/python/ai/vision-imageanalysis/) | `azure-ai-vision-imageanalysis` | Image analysis, captions, tags, objects |
+
+### Data
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [blob](skills/python/data/blob/) | `azure-storage-blob` | Blob storage operations, containers, SAS tokens |
+| [cosmos](skills/python/data/cosmos/) | `azure-cosmos` | Cosmos DB NoSQL API operations |
+| [datalake](skills/python/data/datalake/) | `azure-storage-file-datalake` | Data Lake Storage Gen2, hierarchical namespace |
+| [fileshare](skills/python/data/fileshare/) | `azure-storage-file-share` | Azure Files SMB shares |
+| [queue](skills/python/data/queue/) | `azure-storage-queue` | Queue storage for async messaging |
+| [tables](skills/python/data/tables/) | `azure-data-tables` | Azure Tables / Cosmos DB Table API |
+
+### Search
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [documents](skills/python/search/documents/) | `azure-search-documents` | Azure AI Search indexing and querying |
+
+### Messaging
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [eventgrid](skills/python/messaging/eventgrid/) | `azure-eventgrid` | Event Grid publishing and consumption |
+| [eventhub](skills/python/messaging/eventhub/) | `azure-eventhub` | Event Hubs streaming data ingestion |
+| [servicebus](skills/python/messaging/servicebus/) | `azure-servicebus` | Service Bus queues, topics, subscriptions |
+| [webpubsub-service](skills/python/messaging/webpubsub-service/) | `azure-messaging-webpubsubservice` | Web PubSub real-time messaging (server-side) |
+
+### Monitoring
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [ingestion](skills/python/monitoring/ingestion/) | `azure-monitor-ingestion` | Custom logs ingestion via DCR |
+| [opentelemetry](skills/python/monitoring/opentelemetry/) | `azure-monitor-opentelemetry` | OpenTelemetry auto-instrumentation |
+| [opentelemetry-exporter](skills/python/monitoring/opentelemetry-exporter/) | `azure-monitor-opentelemetry-exporter` | Manual OpenTelemetry export |
+| [query](skills/python/monitoring/query/) | `azure-monitor-query` | Log Analytics and Metrics queries |
+
+### Identity
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [azure-identity](skills/python/identity/azure-identity/) | `azure-identity` | DefaultAzureCredential, managed identity, service principals |
+
+### Security
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [keyvault](skills/python/security/keyvault/) | `azure-keyvault-*` | Key Vault secrets, keys, certificates |
+
+### Integration
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [appconfiguration](skills/python/integration/appconfiguration/) | `azure-appconfiguration` | App Configuration key-values, feature flags |
+| [apicenter](skills/python/integration/apicenter/) | `azure-mgmt-apicenter` | API Center for API inventory management |
+| [apimanagement](skills/python/integration/apimanagement/) | `azure-mgmt-apimanagement` | API Management services, APIs, products |
+
+### Compute
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [botservice](skills/python/compute/botservice/) | `azure-mgmt-botservice` | Azure Bot Service management |
+| [fabric](skills/python/compute/fabric/) | `azure-mgmt-fabric` | Microsoft Fabric capacity management |
+
+### Container
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [containerregistry](skills/python/container/containerregistry/) | `azure-containerregistry` | Container Registry operations |
+
+---
+
+## .NET
+
+> 29 skills in `skills/dotnet/`
+
+### Foundry
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [agents-persistent](skills/dotnet/foundry/agents-persistent/) | `Azure.AI.Agents.Persistent` | Persistent Azure AI Foundry agents |
+| [document-intelligence](skills/dotnet/foundry/document-intelligence/) | `Azure.AI.DocumentIntelligence` | Document analysis, extraction, custom models |
+| [projects](skills/dotnet/foundry/projects/) | `Azure.AI.Projects` | Azure AI Projects SDK for Foundry |
+| [voicelive](skills/dotnet/foundry/voicelive/) | `Azure.AI.VoiceLive` | Real-time voice AI |
+
+### AI
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [inference](skills/dotnet/ai/inference/) | `Azure.AI.Inference` | Azure AI Model Inference for chat, embeddings |
+| [openai](skills/dotnet/ai/openai/) | `Azure.AI.OpenAI` | Azure OpenAI SDK for GPT, DALL-E, embeddings |
+| [weightsandbiases](skills/dotnet/ai/weightsandbiases/) | `Azure.ResourceManager.WeightsAndBiases` | ML experiment tracking via Azure |
+
+### Data
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [cosmosdb](skills/dotnet/data/cosmosdb/) | `Azure.ResourceManager.CosmosDB` | Cosmos DB account, database, container management |
+| [fabric](skills/dotnet/data/fabric/) | `Azure.ResourceManager.Fabric` | Microsoft Fabric capacity management |
+| [mysql](skills/dotnet/data/mysql/) | `Azure.ResourceManager.MySql` | Azure Database for MySQL Flexible Server |
+| [postgresql](skills/dotnet/data/postgresql/) | `Azure.ResourceManager.PostgreSql` | Azure Database for PostgreSQL Flexible Server |
+| [redis](skills/dotnet/data/redis/) | `Azure.ResourceManager.Redis` | Azure Cache for Redis management |
+| [sql](skills/dotnet/data/sql/) | `Azure.ResourceManager.Sql` | Azure SQL Database, servers, elastic pools |
+
+### Search
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [documents](skills/dotnet/search/documents/) | `Azure.Search.Documents` | Azure AI Search — vector, hybrid, semantic search |
+
+### Messaging
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [eventgrid](skills/dotnet/messaging/eventgrid/) | `Azure.Messaging.EventGrid` | Event Grid for event-driven architectures |
+| [eventhubs](skills/dotnet/messaging/eventhubs/) | `Azure.Messaging.EventHubs` | Event Hubs for streaming data ingestion |
+| [servicebus](skills/dotnet/messaging/servicebus/) | `Azure.Messaging.ServiceBus` | Service Bus for enterprise messaging |
+
+### Monitoring
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [applicationinsights](skills/dotnet/monitoring/applicationinsights/) | `Azure.ResourceManager.ApplicationInsights` | Application Insights telemetry and diagnostics |
+
+### Identity
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [azure-identity](skills/dotnet/identity/azure-identity/) | `Azure.Identity` | DefaultAzureCredential, managed identity |
+| [authentication-events](skills/dotnet/identity/authentication-events/) | `Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents` | Entra ID authentication event handlers |
+
+### Security
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [keyvault](skills/dotnet/security/keyvault/) | `Azure.Security.KeyVault.Keys` | Key Vault for keys, secrets, certificates |
+
+### Integration
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [apicenter](skills/dotnet/integration/apicenter/) | `Azure.ResourceManager.ApiCenter` | Azure API Center for API inventory |
+| [apimanagement](skills/dotnet/integration/apimanagement/) | `Azure.ResourceManager.ApiManagement` | Azure API Management services |
+
+### Location
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [maps](skills/dotnet/location/maps/) | `Azure.Maps.*` | Azure Maps geocoding, routing, search |
+
+### Compute
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [botservice](skills/dotnet/compute/botservice/) | `Azure.ResourceManager.BotService` | Azure Bot Service management |
+| [durabletask](skills/dotnet/compute/durabletask/) | `Azure.ResourceManager.DurableTask` | Durable Task Scheduler for orchestrations |
+| [playwright](skills/dotnet/compute/playwright/) | `Microsoft.Playwright.Testing` | Azure Playwright Testing for browser automation |
+
+### Partner
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [arize-ai-observability-eval](skills/dotnet/partner/arize-ai-observability-eval/) | `Azure.ResourceManager.Arize` | Arize AI observability & evaluation |
+| [mongodbatlas](skills/dotnet/partner/mongodbatlas/) | `Azure.ResourceManager.MongoCluster` | MongoDB Atlas via Azure Marketplace |
+
+---
+
+## TypeScript
+
+> 23 skills in `skills/typescript/`
+
+### Foundry
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [agents](skills/typescript/foundry/agents/) | `@azure/ai-agents` | Azure AI Agents — CRUD, threads, streaming, tools |
+| [projects](skills/typescript/foundry/projects/) | `@azure/ai-projects` | Azure AI Projects SDK for Foundry |
+| [contentsafety](skills/typescript/foundry/contentsafety/) | `@azure-rest/ai-content-safety` | Content moderation and safety |
+| [document-intelligence](skills/typescript/foundry/document-intelligence/) | `@azure-rest/ai-document-intelligence` | Document analysis, extraction |
+| [voicelive](skills/typescript/foundry/voicelive/) | `@azure/ai-voicelive` | Real-time voice AI with WebSocket |
+| [nextgen-frontend](skills/typescript/foundry/nextgen-frontend/) | — | NextGen Design System UI patterns |
+
+### AI
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [inference](skills/typescript/ai/inference/) | `@azure-rest/ai-inference` | Azure AI Model Inference for chat, embeddings |
+| [translation](skills/typescript/ai/translation/) | `@azure-rest/ai-translation-text` | Text and document translation |
+
+### Data
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [cosmosdb](skills/typescript/data/cosmosdb/) | `@azure/cosmos` | Cosmos DB NoSQL — CRUD, queries, bulk ops |
+| [blob](skills/typescript/data/blob/) | `@azure/storage-blob` | Blob storage — upload, download, containers |
+| [queue](skills/typescript/data/queue/) | `@azure/storage-queue` | Queue storage for async messaging |
+| [fileshare](skills/typescript/data/fileshare/) | `@azure/storage-file-share` | Azure Files SMB shares |
+
+### Search
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [documents](skills/typescript/search/documents/) | `@azure/search-documents` | Azure AI Search — vector, hybrid, semantic |
+
+### Messaging
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [servicebus](skills/typescript/messaging/servicebus/) | `@azure/service-bus` | Service Bus queues, topics, subscriptions |
+| [eventhubs](skills/typescript/messaging/eventhubs/) | `@azure/event-hubs` | Event Hubs streaming data ingestion |
+| [webpubsub](skills/typescript/messaging/webpubsub/) | `@azure/web-pubsub` | Web PubSub real-time messaging |
+
+### Monitoring
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [opentelemetry](skills/typescript/monitoring/opentelemetry/) | `@azure/monitor-opentelemetry` | OpenTelemetry auto-instrumentation |
+
+### Identity
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [azure-identity](skills/typescript/identity/azure-identity/) | `@azure/identity` | DefaultAzureCredential, managed identity |
+
+### Security
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [keyvault](skills/typescript/security/keyvault/) | `@azure/keyvault-keys` | Key Vault for keys, secrets, certificates |
+
+### Integration
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [appconfiguration](skills/typescript/integration/appconfiguration/) | `@azure/app-configuration` | App Configuration key-values, feature flags |
+
+### Compute
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [playwright](skills/typescript/compute/playwright/) | `@azure/microsoft-playwright-testing` | Azure Playwright Testing |
+
+### Frontend
+
+| Skill | Description |
+|-------|-------------|
+| [zustand-store](skills/typescript/frontend/zustand-store/) | Zustand stores with TypeScript and subscribeWithSelector |
+| [react-flow-node](skills/typescript/frontend/react-flow-node/) | React Flow custom nodes with TypeScript |
+
+---
+
+## Java
+
+> 28 skills in `skills/java/`
+
+### Foundry
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [agents](skills/java/foundry/agents/) | `azure-ai-agents` | Azure AI Agents — CRUD, threads, streaming, tools |
+| [agents-persistent](skills/java/foundry/agents-persistent/) | `azure-ai-agents-persistent` | Persistent Azure AI Foundry agents |
+| [inference](skills/java/foundry/inference/) | `azure-ai-inference` | Azure AI Model Inference for chat, embeddings |
+| [projects](skills/java/foundry/projects/) | `azure-ai-projects` | Azure AI Projects SDK for Foundry |
+| [voicelive](skills/java/foundry/voicelive/) | `azure-ai-voicelive` | Real-time voice AI with WebSocket |
+
+### AI
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [anomalydetector](skills/java/ai/anomalydetector/) | `azure-ai-anomalydetector` | Anomaly detection for time-series data |
+| [contentsafety](skills/java/ai/contentsafety/) | `azure-ai-contentsafety` | Content moderation and safety |
+| [formrecognizer](skills/java/ai/formrecognizer/) | `azure-ai-formrecognizer` | Document analysis and extraction |
+| [vision-imageanalysis](skills/java/ai/vision-imageanalysis/) | `azure-ai-vision-imageanalysis` | Image analysis, captions, tags, objects |
+
+### Data
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [blob](skills/java/data/blob/) | `azure-storage-blob` | Blob storage operations, containers |
+| [cosmos](skills/java/data/cosmos/) | `azure-cosmos` | Cosmos DB NoSQL API |
+| [tables](skills/java/data/tables/) | `azure-data-tables` | Azure Tables / Cosmos DB Table API |
+
+### Messaging
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [eventgrid](skills/java/messaging/eventgrid/) | `azure-messaging-eventgrid` | Event Grid publishing and consumption |
+| [eventhubs](skills/java/messaging/eventhubs/) | `azure-messaging-eventhubs` | Event Hubs streaming data ingestion |
+| [webpubsub](skills/java/messaging/webpubsub/) | `azure-messaging-webpubsub` | Web PubSub real-time messaging |
+
+### Communication
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [callautomation](skills/java/communication/callautomation/) | `azure-communication-callautomation` | Call Automation for voice/video |
+| [callingserver](skills/java/communication/callingserver/) | `azure-communication-callingserver` | Calling Server (deprecated) |
+| [chat](skills/java/communication/chat/) | `azure-communication-chat` | Chat threads, messages, participants |
+| [common](skills/java/communication/common/) | `azure-communication-common` | Communication identity and tokens |
+| [sms](skills/java/communication/sms/) | `azure-communication-sms` | SMS messaging |
+
+### Monitoring
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [ingestion](skills/java/monitoring/ingestion/) | `azure-monitor-ingestion` | Custom logs ingestion via DCR |
+| [opentelemetry-exporter](skills/java/monitoring/opentelemetry-exporter/) | `azure-monitor-opentelemetry-exporter` | OpenTelemetry export (deprecated) |
+| [query](skills/java/monitoring/query/) | `azure-monitor-query` | Log Analytics and Metrics queries |
+
+### Identity
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [azure-identity](skills/java/identity/azure-identity/) | `azure-identity` | DefaultAzureCredential, managed identity |
+
+### Security
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [keyvault-keys](skills/java/security/keyvault-keys/) | `azure-security-keyvault-keys` | Key Vault cryptographic keys |
+| [keyvault-secrets](skills/java/security/keyvault-secrets/) | `azure-security-keyvault-secrets` | Key Vault secrets management |
+
+### Integration
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [appconfiguration](skills/java/integration/appconfiguration/) | `azure-data-appconfiguration` | App Configuration key-values, feature flags |
+
+### Compute
+
+| Skill | Package | Description |
+|-------|---------|-------------|
+| [batch](skills/java/compute/batch/) | `azure-compute-batch` | Azure Batch for HPC and parallel jobs |
+
+---
+
+## Using Symlinks
+
+Share skills across projects without duplicating files:
+
+**macOS / Linux:**
+```bash
+ln -s /path/to/agent-skills/skills/python/messaging/servicebus \
+      /path/to/your-project/.github/skills/servicebus
+```
+
+**Windows (PowerShell as Admin):**
+```powershell
+New-Item -ItemType SymbolicLink `
+  -Path "C:\project\.github\skills\servicebus" `
+  -Target "C:\agent-skills\skills\python\messaging\servicebus"
+```

--- a/README.md
+++ b/README.md
@@ -1,33 +1,63 @@
 # Agent Skills
 
-> [!WARNING]
-> **Work in Progress** — This repository is actively being developed.
+Skills, prompts, and MCP configurations for AI coding agents working with Azure SDKs and Microsoft AI Foundry.
 
-A collection of **skills**, **prompts**, **agents**, and **MCP server configurations** designed to supercharge your AI coding agents when working with Microsoft AI SDKs and Azure services.
-
-> **Read the full blog post:** [Context-Driven Development: Agent Skills for Microsoft Foundry and Azure](https://devblogs.microsoft.com/all-things-azure/context-driven-development-agent-skills-for-microsoft-foundry-and-azure/)
-
----
-
-## What's This About?
-
-This repo embraces **context-driven development** — providing AI coding agents with precisely the right context at the right time. The quality of agent output is directly proportional to the quality and relevance of context it receives.
+> **Blog post:** [Context-Driven Development: Agent Skills for Microsoft Foundry and Azure](https://devblogs.microsoft.com/all-things-azure/context-driven-development-agent-skills-for-microsoft-foundry-and-azure/)
 
 ![Context-Driven Development Architecture](https://raw.githubusercontent.com/microsoft/agent-skills/main/assets/agent-skills-image.png)
 
-Modern coding agents (GitHub Copilot CLI, [Claude Code](https://devblogs.microsoft.com/all-things-azure/claude-code-microsoft-foundry-enterprise-ai-coding-agent-setup/), [Codex](https://devblogs.microsoft.com/all-things-azure/codex-azure-openai-integration-fast-secure-code-development/), etc.) are powerful out of the box, but lack domain-specific knowledge about your SDKs, patterns, and best practices. This repo provides the "onboarding guides" that turn general-purpose agents into specialized experts.
+---
+
+## What is This?
+
+Modern coding agents (GitHub Copilot, Claude Code, Codex) are powerful but lack domain-specific knowledge. This repo provides the "onboarding guides" that turn general-purpose agents into Azure SDK experts.
+
+**Context-driven development** = Right context → Right time → Better output.
 
 > [!IMPORTANT]
-> **Don't Use All Skills at Once — Avoid Context Rot**
->
-> Skills are designed to be used selectively. **Context rot** occurs when an agent's context window becomes cluttered with irrelevant information, degrading response quality.
->
-> Loading all skills at once will:
-> - Dilute the agent's attention across unrelated domains
-> - Waste precious context window tokens
-> - Cause the agent to conflate patterns from different frameworks
->
-> **Only copy the specific skills essential for your current project.**
+> **Use skills selectively.** Loading all skills causes context rot—diluted attention, wasted tokens, conflated patterns. Only copy skills essential for your current project.
+
+---
+
+## Quick Start
+
+```bash
+# Copy a skill to your project
+cp -r skills/python/messaging/servicebus /path/to/your-project/.github/skills/
+
+# VS Code Copilot: Auto-discovered from .github/skills/
+# Claude: Reference SKILL.md in project instructions
+```
+
+---
+
+## Skill Catalog
+
+### Core Skills — Auto-discovered
+
+> Location: `.github/skills/` • 16 skills
+
+| Category | Skills |
+|----------|--------|
+| **AI Foundry** | [foundry-sdk-python](.github/skills/foundry-sdk-python/), [foundry-iq-python](.github/skills/foundry-iq-python/), [azure-ai-agents-python](.github/skills/azure-ai-agents-python/), [agent-framework-azure-hosted-agents](.github/skills/agent-framework-azure-hosted-agents/) |
+| **AI Services** | [azure-ai-search-python](.github/skills/azure-ai-search-python/), [azure-ai-voicelive](.github/skills/azure-ai-voicelive/) |
+| **Backend** | [fastapi-router](.github/skills/fastapi-router/), [pydantic-models](.github/skills/pydantic-models/), [cosmos-db-python-skill](.github/skills/cosmos-db-python-skill/) |
+| **Infrastructure** | [azd-deployment](.github/skills/azd-deployment/), [azure-resourcemanager-mysql-dotnet](.github/skills/azure-resourcemanager-mysql-dotnet/), [azure-resourcemanager-postgresql-dotnet](.github/skills/azure-resourcemanager-postgresql-dotnet/) |
+| **Tooling** | [skill-creator](.github/skills/skill-creator/), [mcp-builder](.github/skills/mcp-builder/), [github-issue-creator](.github/skills/github-issue-creator/) |
+| **Other** | [podcast-generation](.github/skills/podcast-generation/) |
+
+### Extended Catalog — Copy as needed
+
+> Location: `skills/{language}/` • 113 skills
+
+| Language | Skills | Coverage |
+|----------|--------|----------|
+| [**Python**](CATALOG.md#python) | 33 | AI, Data, Messaging, Monitoring, Identity, Security, Integration |
+| [**.NET**](CATALOG.md#net) | 29 | Foundry, AI, Data, Messaging, Identity, Security, Partner |
+| [**TypeScript**](CATALOG.md#typescript) | 23 | Foundry, AI, Data, Messaging, Frontend, Identity |
+| [**Java**](CATALOG.md#java) | 28 | Foundry, AI, Data, Messaging, Communication, Identity |
+
+📖 **[Full skill catalog →](CATALOG.md)**
 
 ---
 
@@ -35,426 +65,26 @@ Modern coding agents (GitHub Copilot CLI, [Claude Code](https://devblogs.microso
 
 ```
 .github/
-├── skills/           # Core + Python skills (auto-discovered by agents)
-├── prompts/          # Reusable prompt templates (.prompt.md)
-├── agents/           # Agent persona definitions (.agent.md)
-├── agents.md         # Project-wide agent instructions
-├── copilot-instructions.md
-└── workflows/        # Automated workflows (e.g., docs sync)
+├── skills/              # Core skills (auto-discovered)
+├── prompts/             # Reusable prompt templates
+├── agents/              # Agent persona definitions
+└── copilot-instructions.md
 
-skills/               # Extended skill catalog (copy what you need)
-├── python/           # Python SDK skills organized by product area
-├── dotnet/           # .NET SDK skills organized by product area
-└── typescript/       # TypeScript/frontend skills
+skills/                  # Extended catalog (copy what you need)
+├── python/              # 33 skills
+├── dotnet/              # 29 skills
+├── typescript/          # 23 skills
+└── java/                # 28 skills
 
 .vscode/
-└── mcp.json          # MCP server configurations
+└── mcp.json             # MCP server configurations
 ```
-
----
-
-## Quick Start
-
-1. **Browse the skill catalog** and identify skills relevant to your project
-2. **Copy the skill folder** to your project's `.github/skills/` directory:
-   ```bash
-   cp -r skills/dotnet/messaging/servicebus /path/to/your-project/.github/skills/
-   ```
-3. **Configure your agent** to use the skill files:
-   - **VS Code Copilot:** Skills are auto-discovered from `.github/skills/`
-   - **Claude:** Reference `SKILL.md` files in your project instructions
-4. **(Optional)** Copy `.vscode/mcp.json` to enable MCP servers
-
----
-
-## Skill Catalog
-
-### Core Skills
-
-> Location: `.github/skills/` — Auto-discovered by agents
-
-| Skill | Description |
-|-------|-------------|
-| [skill-creator](.github/skills/skill-creator/) | Guide for creating new skills — based on [Anthropic's skill-creator](https://github.com/anthropics/anthropic-quickstarts/tree/main/skills/skill-creator) |
-| [mcp-builder](.github/skills/mcp-builder/) | Building MCP servers (TypeScript, Python, C#/.NET) |
-| [github-issue-creator](.github/skills/github-issue-creator/) | Convert raw notes, error logs, or screenshots into structured GitHub issues |
-| [azd-deployment](.github/skills/azd-deployment/) | Azure Developer CLI deployment to Container Apps with Bicep |
-
----
-
-### Python Skills (Core)
-
-> Location: `.github/skills/` — Auto-discovered by agents
-
-#### Azure AI & Foundry
-
-| Skill | Description |
-|-------|-------------|
-| [azure-ai-agents-python](.github/skills/azure-ai-agents-python/) | Low-level Azure AI Agents SDK — agent CRUD, threads, streaming, tools |
-| [azure-ai-search-python](.github/skills/azure-ai-search-python/) | Azure AI Search SDK — vector/hybrid search, agentic retrieval |
-| [azure-ai-voicelive](.github/skills/azure-ai-voicelive/) | Real-time voice AI with bidirectional WebSocket communication |
-| [agent-framework-azure-hosted-agents](.github/skills/agent-framework-azure-hosted-agents/) | Microsoft Agent Framework SDK for persistent Azure AI Foundry agents |
-| [foundry-iq-python](.github/skills/foundry-iq-python/) | Agentic retrieval with knowledge bases and Foundry Agent Service |
-| [foundry-sdk-python](.github/skills/foundry-sdk-python/) | High-level Azure AI Projects SDK for Foundry integration and evaluations |
-
-#### Backend & Data
-
-| Skill | Description |
-|-------|-------------|
-| [cosmos-db-python-skill](.github/skills/cosmos-db-python-skill/) | Cosmos DB NoSQL with Python/FastAPI, CRUD patterns |
-| [fastapi-router](.github/skills/fastapi-router/) | FastAPI routers with CRUD, auth, and response models |
-| [pydantic-models](.github/skills/pydantic-models/) | Pydantic v2 multi-model patterns (Base/Create/Update/Response) |
-| [podcast-generation](.github/skills/podcast-generation/) | Podcast generation workflows |
-
----
-
-### Python Skills (Extended)
-
-> Location: `skills/python/` — Copy to your project's `.github/skills/` as needed
-
-<details>
-<summary><strong>Foundry</strong> (3 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [contentsafety](skills/python/foundry/contentsafety/) | `azure-ai-contentsafety` | Content moderation and safety |
-| [contentunderstanding](skills/python/foundry/contentunderstanding/) | `azure-ai-contentunderstanding` | Document and media understanding |
-| [evaluation](skills/python/foundry/evaluation/) | `azure-ai-evaluation` | AI model evaluation and metrics |
-
-</details>
-
-<details>
-<summary><strong>AI</strong> (9 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [inference](skills/python/ai/inference/) | `azure-ai-inference` | Azure AI Model Inference for chat, embeddings |
-| [ml](skills/python/ai/ml/) | `azure-ai-ml` | Azure Machine Learning SDK v2 |
-| [textanalytics](skills/python/ai/textanalytics/) | `azure-ai-textanalytics` | Text Analytics — NER, sentiment, key phrases |
-| [transcription](skills/python/ai/transcription/) | `azure-cognitiveservices-speech` | Speech-to-text transcription |
-| [translation-document](skills/python/ai/translation-document/) | `azure-ai-translation-document` | Document translation (batch) |
-| [translation-text](skills/python/ai/translation-text/) | `azure-ai-translation-text` | Text translation API |
-| [vision-imageanalysis](skills/python/ai/vision-imageanalysis/) | `azure-ai-vision-imageanalysis` | Image analysis, captions, tags, objects |
-| [weightsandbiases](skills/python/ai/weightsandbiases/) | `wandb` | Weights & Biases ML experiment tracking |
-
-</details>
-
-<details>
-<summary><strong>Search</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [documents](skills/python/search/documents/) | `azure-search-documents` | Azure AI Search indexing and querying |
-
-</details>
-
-<details>
-<summary><strong>Data</strong> (8 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [blob](skills/python/data/blob/) | `azure-storage-blob` | Blob storage operations, containers, SAS tokens |
-| [cosmos](skills/python/data/cosmos/) | `azure-cosmos` | Cosmos DB NoSQL API operations |
-| [datalake](skills/python/data/datalake/) | `azure-storage-file-datalake` | Data Lake Storage Gen2, hierarchical namespace |
-| [fileshare](skills/python/data/fileshare/) | `azure-storage-file-share` | Azure Files SMB shares |
-| [queue](skills/python/data/queue/) | `azure-storage-queue` | Queue storage for async messaging |
-| [storage-general](skills/python/data/storage-general/) | `azure-storage-*` | Common storage patterns and utilities |
-| [tables](skills/python/data/tables/) | `azure-data-tables` | Azure Tables / Cosmos DB Table API |
-
-</details>
-
-<details>
-<summary><strong>Identity</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [azure-identity](skills/python/identity/azure-identity/) | `azure-identity` | DefaultAzureCredential, managed identity, service principals |
-
-</details>
-
-<details>
-<summary><strong>Security</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [keyvault](skills/python/security/keyvault/) | `azure-keyvault-*` | Key Vault secrets, keys, certificates |
-
-</details>
-
-<details>
-<summary><strong>Integration</strong> (3 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [appconfiguration](skills/python/integration/appconfiguration/) | `azure-appconfiguration` | App Configuration key-values, feature flags |
-| [apicenter](skills/python/integration/apicenter/) | `azure-mgmt-apicenter` | API Center for API inventory management |
-| [apimanagement](skills/python/integration/apimanagement/) | `azure-mgmt-apimanagement` | API Management services, APIs, products |
-
-</details>
-
-<details>
-<summary><strong>Messaging</strong> (5 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [eventgrid](skills/python/messaging/eventgrid/) | `azure-eventgrid` | Event Grid publishing and consumption |
-| [eventhub](skills/python/messaging/eventhub/) | `azure-eventhub` | Event Hubs streaming data ingestion |
-| [servicebus](skills/python/messaging/servicebus/) | `azure-servicebus` | Service Bus queues, topics, subscriptions |
-| [webpubsub-client](skills/python/messaging/webpubsub-client/) | `azure-messaging-webpubsubclient` | Web PubSub real-time messaging (client-side) |
-| [webpubsub-service](skills/python/messaging/webpubsub-service/) | `azure-messaging-webpubsubservice` | Web PubSub real-time messaging (server-side) |
-
-</details>
-
-<details>
-<summary><strong>Monitoring</strong> (5 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [applicationinsights](skills/python/monitoring/applicationinsights/) | `azure-mgmt-applicationinsights` | Application Insights management |
-| [ingestion](skills/python/monitoring/ingestion/) | `azure-monitor-ingestion` | Custom logs ingestion via DCR |
-| [opentelemetry](skills/python/monitoring/opentelemetry/) | `azure-monitor-opentelemetry` | OpenTelemetry auto-instrumentation |
-| [opentelemetry-exporter](skills/python/monitoring/opentelemetry-exporter/) | `azure-monitor-opentelemetry-exporter` | Manual OpenTelemetry export |
-| [query](skills/python/monitoring/query/) | `azure-monitor-query` | Log Analytics and Metrics queries |
-
-</details>
-
-<details>
-<summary><strong>Compute</strong> (2 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [botservice](skills/python/compute/botservice/) | `azure-mgmt-botservice` | Azure Bot Service management |
-| [fabric](skills/python/compute/fabric/) | `azure-mgmt-fabric` | Microsoft Fabric capacity management |
-
-</details>
-
-<details>
-<summary><strong>Container</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [containerregistry](skills/python/container/containerregistry/) | `azure-containerregistry` | Container Registry operations |
-
-</details>
-
-<details>
-<summary><strong>Partner</strong> (2 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [arize-ai-observability-eval](skills/python/partner/arize-ai-observability-eval/) | `arize` | Arize AI observability & evaluation |
-| [mongodbatlas](skills/python/partner/mongodbatlas/) | `pymongo` | MongoDB Atlas with Python |
-
-</details>
-
----
-
-### .NET Skills
-
-> Location: `skills/dotnet/` — Copy to your project's `.github/skills/` as needed
-
-<details>
-<summary><strong>AI</strong> (3 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [inference](skills/dotnet/ai/inference/) | `Azure.AI.Inference` | Azure AI Model Inference for chat completions, embeddings |
-| [openai](skills/dotnet/ai/openai/) | `Azure.AI.OpenAI` | Azure OpenAI SDK for GPT models, DALL-E, embeddings |
-| [weightsandbiases](skills/dotnet/ai/weightsandbiases/) | `Azure.ResourceManager.WeightsAndBiases` | Weights & Biases ML experiment tracking via Azure |
-
-</details>
-
-<details>
-<summary><strong>Compute</strong> (3 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [botservice](skills/dotnet/compute/botservice/) | `Azure.ResourceManager.BotService` | Azure Bot Service management |
-| [durabletask](skills/dotnet/compute/durabletask/) | `Azure.ResourceManager.DurableTask` | Durable Task Scheduler for orchestrations |
-| [playwright](skills/dotnet/compute/playwright/) | `Microsoft.Playwright.Testing` | Azure Playwright Testing for browser automation |
-
-</details>
-
-<details>
-<summary><strong>Data</strong> (6 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [cosmosdb](skills/dotnet/data/cosmosdb/) | `Azure.ResourceManager.CosmosDB` | Cosmos DB account, database, container management |
-| [fabric](skills/dotnet/data/fabric/) | `Azure.ResourceManager.Fabric` | Microsoft Fabric capacity management |
-| [mysql](skills/dotnet/data/mysql/) | `Azure.ResourceManager.MySql` | Azure Database for MySQL Flexible Server |
-| [postgresql](skills/dotnet/data/postgresql/) | `Azure.ResourceManager.PostgreSql` | Azure Database for PostgreSQL Flexible Server |
-| [redis](skills/dotnet/data/redis/) | `Azure.ResourceManager.Redis` | Azure Cache for Redis management |
-| [sql](skills/dotnet/data/sql/) | `Azure.ResourceManager.Sql` | Azure SQL Database, servers, elastic pools |
-
-**Reference docs available:** cosmosdb, sql
-
-</details>
-
-<details>
-<summary><strong>Foundry</strong> (4 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [agents-persistent](skills/dotnet/foundry/agents-persistent/) | `Azure.AI.Agents.Persistent` | Persistent Azure AI Foundry agents with .NET |
-| [document-intelligence](skills/dotnet/foundry/document-intelligence/) | `Azure.AI.DocumentIntelligence` | Document analysis, extraction, custom models |
-| [projects](skills/dotnet/foundry/projects/) | `Azure.AI.Projects` | Azure AI Projects SDK for Foundry |
-| [voicelive](skills/dotnet/foundry/voicelive/) | `Azure.AI.VoiceLive` | Real-time voice AI with .NET |
-
-</details>
-
-<details>
-<summary><strong>Identity</strong> (2 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [azure-identity](skills/dotnet/identity/azure-identity/) | `Azure.Identity` | DefaultAzureCredential, managed identity, service principals |
-| [authentication-events](skills/dotnet/identity/authentication-events/) | `Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents` | Entra ID authentication event handlers |
-
-</details>
-
-<details>
-<summary><strong>Integration</strong> (2 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [apicenter](skills/dotnet/integration/apicenter/) | `Azure.ResourceManager.ApiCenter` | Azure API Center for API inventory management |
-| [apimanagement](skills/dotnet/integration/apimanagement/) | `Azure.ResourceManager.ApiManagement` | Azure API Management services, APIs, products |
-
-**Reference docs available:** apimanagement
-
-</details>
-
-<details>
-<summary><strong>Location</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [maps](skills/dotnet/location/maps/) | `Azure.Maps.*` | Azure Maps for geocoding, routing, search, rendering |
-
-</details>
-
-<details>
-<summary><strong>Messaging</strong> (3 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [eventgrid](skills/dotnet/messaging/eventgrid/) | `Azure.Messaging.EventGrid` | Event Grid for event-driven architectures |
-| [eventhubs](skills/dotnet/messaging/eventhubs/) | `Azure.Messaging.EventHubs` | Event Hubs for streaming data ingestion |
-| [servicebus](skills/dotnet/messaging/servicebus/) | `Azure.Messaging.ServiceBus` | Service Bus for enterprise messaging |
-
-</details>
-
-<details>
-<summary><strong>Monitoring</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [applicationinsights](skills/dotnet/monitoring/applicationinsights/) | `Azure.ResourceManager.ApplicationInsights` | Application Insights for telemetry and diagnostics |
-
-</details>
-
-<details>
-<summary><strong>Partner</strong> (2 skills)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [arize-ai-observability-eval](skills/dotnet/partner/arize-ai-observability-eval/) | `Azure.ResourceManager.Arize` | Arize AI observability & evaluation via Azure Marketplace |
-| [mongodbatlas](skills/dotnet/partner/mongodbatlas/) | `Azure.ResourceManager.MongoCluster` | MongoDB Atlas organizations via Azure Marketplace |
-
-</details>
-
-<details>
-<summary><strong>Search</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [documents](skills/dotnet/search/documents/) | `Azure.Search.Documents` | Azure AI Search — vector, hybrid, semantic search |
-
-**Reference docs available:** documents (vector-search, semantic-search)
-
-</details>
-
-<details>
-<summary><strong>Security</strong> (1 skill)</summary>
-
-| Skill | Package | Description |
-|-------|---------|-------------|
-| [keyvault](skills/dotnet/security/keyvault/) | `Azure.Security.KeyVault.Keys` | Key Vault for keys, secrets, certificates |
-
-</details>
-
----
-
-### TypeScript Skills
-
-> Location: `skills/typescript/` — Copy to your project's `.github/skills/` as needed
-
-<details>
-<summary><strong>Frontend</strong> (2 skills)</summary>
-
-| Skill | Description |
-|-------|-------------|
-| [zustand-store](skills/typescript/frontend/zustand-store/) | Zustand stores with TypeScript and subscribeWithSelector |
-| [react-flow-node](skills/typescript/frontend/react-flow-node/) | React Flow custom nodes with TypeScript |
-
-</details>
-
-<details>
-<summary><strong>Foundry</strong> (1 skill)</summary>
-
-| Skill | Description |
-|-------|-------------|
-| [nextgen-frontend](skills/typescript/foundry/nextgen-frontend/) | NextGen Design System UI patterns (Vite + React + Framer Motion) |
-
-**Reference docs available:** nextgen-frontend (components, design-tokens, patterns)
-
-</details>
-
----
-
-## Using Skills with Symlinks
-
-If you want to share skills across projects without duplicating files:
-
-<details>
-<summary><strong>macOS / Linux</strong></summary>
-
-```bash
-mkdir -p /path/to/your-project/.github/skills
-ln -s /path/to/agent-skills/skills/dotnet/messaging/servicebus \
-      /path/to/your-project/.github/skills/servicebus
-```
-
-</details>
-
-<details>
-<summary><strong>Windows (Command Prompt as Admin)</strong></summary>
-
-```cmd
-mkdir "C:\project\.github\skills"
-mklink /D "C:\project\.github\skills\servicebus" ^
-          "C:\agent-skills\skills\dotnet\messaging\servicebus"
-```
-
-</details>
-
-<details>
-<summary><strong>Windows (PowerShell as Admin)</strong></summary>
-
-```powershell
-New-Item -ItemType SymbolicLink `
-  -Path "C:\project\.github\skills\servicebus" `
-  -Target "C:\agent-skills\skills\dotnet\messaging\servicebus"
-```
-
-</details>
 
 ---
 
 ## MCP Servers
 
-Pre-configured Model Context Protocol servers in `.vscode/mcp.json`:
+Pre-configured in `.vscode/mcp.json`:
 
 | Category | Servers |
 |----------|---------|
@@ -462,46 +92,20 @@ Pre-configured Model Context Protocol servers in `.vscode/mcp.json`:
 | **Development** | `github`, `playwright`, `terraform`, `eslint` |
 | **Utilities** | `sequentialthinking`, `memory`, `markitdown` |
 
-Copy `.vscode/mcp.json` to your project to enable these integrations.
-
 ---
 
 ## Additional Resources
 
-### Prompts
-
-Reusable prompt templates (`.prompt.md`) for code reviews, component creation, and endpoint scaffolding.
-
-### Agents
-
-Persona definitions (`.agent.md`) that give coding agents specific roles: `backend`, `frontend`, `planner`, etc.
-
-### Scaling to Larger Codebases
-
-For codebases where static skills aren't enough:
-
-- **Graph RAG for Code** — Retrieval-augmented generation over your codebase
-- **AST-based Memory Systems** — Hierarchical graph of your code's abstract syntax tree
-- **Context Graph** — Knowledge graphs tracking component relationships and dependencies
-
----
-
-## Foundry Documentation via Context7
-
-Indexed Microsoft Foundry documentation is available through [Context7](https://context7.com):
-
-**URL:** https://context7.com/microsoft/agent-skills
-
-A GitHub workflow runs weekly to sync the latest Foundry documentation updates.
+- **Prompts** — Reusable templates (`.prompt.md`) for code reviews, component creation
+- **Agents** — Persona definitions (`.agent.md`) for backend, frontend, planner roles
+- **[Context7](https://context7.com/microsoft/agent-skills)** — Indexed Foundry docs (weekly sync)
 
 ---
 
 ## Contributing
 
-This is an evolving collection. Contributions welcome:
-
-- Add new skills for AI SDKs and Azure services
-- Improve existing prompts and agent definitions
+- Add new skills for Azure SDKs
+- Improve existing prompts and agents
 - Share MCP server configurations
 
 ---

--- a/docs/blog.wordpress.xml
+++ b/docs/blog.wordpress.xml
@@ -1,0 +1,176 @@
+Code will be generated, not written. Most enterprise AI workloads are net-new microservices. Modular, greenfield work. Perfect for coding agents.
+
+The catch? Out-of-the-box agents lack domain knowledge about your SDKs and patterns. But frontier LLMs are extraordinarily sample efficient. The patterns you need are already encoded in their latent space from pretraining. All you need is the right activation context. That is what skills do, and Agent Skills ships 127 of them for Azure and Microsoft Foundry development.
+<h2>What's in Agent Skills?</h2>
+<a href="https://github.com/microsoft/agent-skills">github.com/microsoft/agent-skills</a> is a collection of skills, prompts, agents, and MCP configurations that provide the activation context to specialize coding agents for Microsoft Foundry and Azure development.
+
+<a href="https://devblogs.microsoft.com/all-things-azure/wp-content/uploads/sites/83/2026/01/agent-skills-image.webp"><img class="alignnone size-large wp-image-1794" src="https://devblogs.microsoft.com/all-things-azure/wp-content/uploads/sites/83/2026/01/agent-skills-image-1024x544.webp" alt="Agent Skills architecture showing selective context injection" width="1024" height="544" /></a>
+
+The repo contains:
+<ul>
+ 	<li><strong>Skills</strong>: Modular knowledge packages for specific domains (Cosmos DB, Foundry IQ, AZD Deployment, etc.)</li>
+ 	<li><strong>Prompts</strong>: Reusable templates for code reviews, component creation, endpoints</li>
+ 	<li><strong>Agents</strong>: Persona definitions (backend, frontend, planner)</li>
+ 	<li><strong>MCP Servers</strong>: Pre-configured servers for GitHub, Playwright, Microsoft Docs, Context7</li>
+ 	<li><strong>Context7 Integration</strong>: Indexed Foundry documentation at <a href="https://context7.com/microsoft/agent-skills">context7.com/microsoft/agent-skills</a></li>
+</ul>
+<h2>Systems Thinking First, Then Skills</h2>
+Before loading skills into your agent, you need a mental model of what you are building, reducing your unknown-unknowns. Skills amplify your direction, they do not replace it.
+
+My recommendation: do the basic hello world for each SDK you plan to use. For example, for Foundry IQ, walk through the <a href="https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-create-pipeline">agentic retrieval pipeline quickstart</a>. Understand the abstractions at a high level. Know what Cosmos DB containers are, how Azure AI Search indexes work, what a Foundry agent does. You need this picture to prompt and steer the agent effectively.
+
+Beyond that high-level understanding? You probably will not be hand-coding the idiomatic patterns for how you consume these services. The model already has these patterns encoded. Skills surface them. You bring the architecture and intent. The agent brings the implementation details that are already latent in its weights.
+<h2>Avoiding Context Rot</h2>
+<strong>Do not load all skills at once.</strong> Context rot occurs when your agent's context window gets cluttered with irrelevant information, degrading output quality.
+
+Loading everything will:
+<ul>
+ 	<li>Dilute the agent's attention across unrelated domains</li>
+ 	<li>Waste precious context window tokens</li>
+ 	<li>Cause the agent to conflate patterns from different frameworks</li>
+</ul>
+<strong>Only copy the specific skills essential for your current project.</strong> High signal-to-noise ratio is everything.
+
+The same principle applies to MCP servers. Do not enable every server in your config. Too many tools create the same dilution problem. Pick the servers relevant to your current task.
+<h2>Quick Start</h2>
+<h3>Option 1: Install via skills.sh</h3>
+The easiest way to add skills is through <a href="https://skills.sh/microsoft/agent-skills">skills.sh</a>:
+<pre class="prettyprint">npx skills add microsoft/agent-skills
+</pre>
+You can also browse and install individual skills from <a href="https://skillsmp.com/skills/microsoft-agent-skills-github-skills-azure-ai-voicelive-skill-skill-md">skillsmp.com</a>.
+<h3>Option 2: Copy Only the Skills You Need</h3>
+Browse available skills and copy relevant ones to your project:
+<pre class="prettyprint"># Clone the repo
+git clone https://github.com/microsoft/agent-skills.git
+
+# Copy specific skills to your project
+cp -r agent-skills/.github/skills/cosmos-db-python-skill your-project/.github/skills/
+cp -r agent-skills/.github/skills/foundry-iq-python your-project/.github/skills/
+</pre>
+Or use symlinks. For multi-project setups:
+<pre class="prettyprint"># macOS/Linux
+ln -s /path/to/agent-skills/.github/skills/mcp-builder /path/to/your-project/.github/skills/mcp-builder
+
+# Windows (PowerShell as Admin)
+New-Item -ItemType SymbolicLink -Path ".github\skills\mcp-builder" -Target "C:\agent-skills\.github\skills\mcp-builder"
+</pre>
+For sharing skills across different coding agents in the same repo:
+<pre class="prettyprint"># Symlink to multiple agent config directories
+ln -s ../.github/skills .opencode/skills
+ln -s ../.github/skills .claude/skills
+</pre>
+<h3>Configure Your Agent</h3>
+<strong>GitHub Copilot:</strong> Skills are auto-discovered from <code>.github/skills/</code>
+
+<strong>Claude Code:</strong> Reference <code>SKILL.md</code> files in your project instructions or <code>CLAUDE.md</code>
+
+<strong>GitHub Copilot CLI:</strong> Works with the same skill structure
+<h3>Add MCP Servers</h3>
+Copy the MCP configuration to your project:
+<pre class="prettyprint">cp agent-skills/.vscode/mcp.json your-project/.vscode/
+</pre>
+Then remove the servers you do not need. This gives your agent access to:
+<ul>
+ 	<li>Microsoft Learn MCP: Ground agents in official docs</li>
+ 	<li>Context7: Indexed Foundry documentation</li>
+ 	<li>GitHub, Playwright, Terraform servers</li>
+ 	<li>Sequential Thinking, Memory tools</li>
+</ul>
+<h3>(Optional) Use Context7 for Foundry Docs</h3>
+For real-time Foundry documentation access, add the Context7 MCP server or use directly:
+
+<strong>Context7 URL:</strong> <a href="https://context7.com/microsoft/agent-skills">https://context7.com/microsoft/agent-skills</a>
+
+A GitHub workflow runs weekly to sync the latest Foundry documentation updates automatically.
+<h2>Available Skills</h2>
+<strong>127 skills total</strong> — 14 core (auto-discovered) + 113 extended (copy as needed).
+<h3>Core Skills</h3>
+Auto-discovered from <code>.github/skills/</code>:
+<table>
+<tbody>
+<tr>
+<th>Category</th>
+<th>Skills</th>
+</tr>
+<tr>
+<td><strong>AI Foundry</strong></td>
+<td><code>foundry-sdk-python</code>, <code>foundry-iq-python</code>, <code>azure-ai-agents-python</code>, <code>agent-framework-azure-hosted-agents</code></td>
+</tr>
+<tr>
+<td><strong>AI Services</strong></td>
+<td><code>azure-ai-search-python</code>, <code>azure-ai-voicelive</code></td>
+</tr>
+<tr>
+<td><strong>Backend</strong></td>
+<td><code>fastapi-router</code>, <code>pydantic-models</code>, <code>cosmos-db-python-skill</code></td>
+</tr>
+<tr>
+<td><strong>Infrastructure</strong></td>
+<td><code>azd-deployment</code></td>
+</tr>
+<tr>
+<td><strong>Tooling</strong></td>
+<td><code>skill-creator</code>, <code>mcp-builder</code>, <code>github-issue-creator</code></td>
+</tr>
+<tr>
+<td><strong>Other</strong></td>
+<td><code>podcast-generation</code></td>
+</tr>
+</tbody>
+</table>
+<h3>Extended Catalog</h3>
+113 skills in <code>skills/</code> organized by language. Copy what you need:
+<table>
+<tbody>
+<tr>
+<th>Language</th>
+<th>Count</th>
+<th>Coverage</th>
+</tr>
+<tr>
+<td><strong>Python</strong></td>
+<td>33</td>
+<td>AI, Data, Messaging, Monitoring, Identity, Security, Integration</td>
+</tr>
+<tr>
+<td><strong>.NET</strong></td>
+<td>29</td>
+<td>Foundry, AI, Data, Messaging, Identity, Security, Partner</td>
+</tr>
+<tr>
+<td><strong>TypeScript</strong></td>
+<td>23</td>
+<td>Foundry, AI, Data, Messaging, Frontend, Identity</td>
+</tr>
+<tr>
+<td><strong>Java</strong></td>
+<td>28</td>
+<td>Foundry, AI, Data, Messaging, Communication, Identity</td>
+</tr>
+</tbody>
+</table>
+See the full catalog at <a href="https://github.com/microsoft/agent-skills/blob/main/CATALOG.md">CATALOG.md</a>.
+<h2>Scaling Beyond Static Skills</h2>
+For larger codebases where static skills are not enough:
+<ul>
+ 	<li><strong>AST-based Memory Systems</strong>: Hierarchical graph representation of code structure</li>
+ 	<li><strong>Context Graph</strong>: Knowledge graphs tracking component relationships and dependencies</li>
+</ul>
+These help agents maintain understanding without cramming everything into the context window.
+<h2>What's Next</h2>
+This is v1. I will be adding more idiomatic skills for Microsoft SDKs, covering the cloud services and frameworks teams actually use.
+
+I am also testing agent skills with <a href="https://github.com/github/copilot-sdk">copilot-sdk</a> to validate skill quality programmatically. You can see a sample test harness at <a href="https://github.com/microsoft-foundry/copilot-sdk-samples/tree/main/samples/skill-testing/sdk">copilot-sdk-samples/skill-testing</a>.
+
+For now, start with <a href="https://github.com/microsoft/agent-skills">github.com/microsoft/agent-skills</a>, pick only what you need, and keep that signal-to-noise ratio high.
+<h2>Resources</h2>
+<ul>
+ 	<li><a href="https://github.com/microsoft/agent-skills">Agent Skills Repository</a></li>
+ 	<li><a href="https://skills.sh/microsoft/agent-skills">skills.sh: Install Skills</a></li>
+ 	<li><a href="https://skillsmp.com/skills/microsoft-agent-skills-github-skills-azure-ai-voicelive-skill-skill-md">skillsmp.com: Browse Skills</a></li>
+ 	<li><a href="https://context7.com/microsoft/agent-skills">Context7: Foundry Docs</a></li>
+ 	<li><a href="https://github.com/github/copilot-sdk">Copilot SDK</a></li>
+ 	<li><a href="https://devblogs.microsoft.com/all-things-azure/claude-code-microsoft-foundry-enterprise-ai-coding-agent-setup/">Claude Code + Foundry Setup Guide</a></li>
+ 	<li><a href="https://devblogs.microsoft.com/all-things-azure/codex-azure-openai-integration-fast-secure-code-development/">Codex + Azure OpenAI Integration</a></li>
+ 	<li><a href="https://learn.microsoft.com/en-us/azure/ai-foundry/">Microsoft Foundry Docs</a></li>
+</ul>

--- a/references/sas-tokens.md
+++ b/references/sas-tokens.md
@@ -1,0 +1,468 @@
+# Azure Blob Storage SAS Token Patterns
+
+Reference documentation for SAS (Shared Access Signature) token generation with `@azure/storage-blob` TypeScript SDK.
+
+## Installation
+
+```bash
+npm install @azure/storage-blob @azure/identity
+```
+
+## Imports
+
+```typescript
+import {
+  BlobServiceClient,
+  ContainerClient,
+  BlockBlobClient,
+  BlobSASPermissions,
+  ContainerSASPermissions,
+  AccountSASPermissions,
+  AccountSASServices,
+  AccountSASResourceTypes,
+  StorageSharedKeyCredential,
+  generateBlobSASQueryParameters,
+  generateAccountSASQueryParameters,
+  SASProtocol,
+  BlobSASSignatureValues,
+  AccountSASSignatureValues,
+  UserDelegationKey,
+} from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+```
+
+---
+
+## SAS Token Types
+
+| Type | Signed With | Use Case |
+|------|-------------|----------|
+| **User Delegation SAS** | Microsoft Entra credentials | Most secure, recommended |
+| **Service SAS** | Account key | Container or blob access |
+| **Account SAS** | Account key | Multiple services/resources |
+
+---
+
+## Permission Classes
+
+### BlobSASPermissions
+
+Permissions for individual blob access.
+
+```typescript
+// Parse from string
+const blobPermissions = BlobSASPermissions.parse("racwd");
+
+// Or build programmatically
+const permissions = new BlobSASPermissions();
+permissions.read = true;      // r - Read blob content
+permissions.add = true;       // a - Add blocks to append blob
+permissions.create = true;    // c - Create new blob
+permissions.write = true;     // w - Write to blob
+permissions.delete = true;    // d - Delete blob
+permissions.tag = true;       // t - Read/write blob tags
+permissions.move = true;      // m - Move blob
+permissions.execute = true;   // e - Execute blob
+permissions.setImmutabilityPolicy = true; // i - Set immutability policy
+permissions.permanentDelete = true;       // y - Permanent delete
+```
+
+### ContainerSASPermissions
+
+Permissions for container-level access.
+
+```typescript
+// Parse from string
+const containerPermissions = ContainerSASPermissions.parse("racwdl");
+
+// Or build programmatically
+const permissions = new ContainerSASPermissions();
+permissions.read = true;      // r - Read blobs
+permissions.add = true;       // a - Add blocks
+permissions.create = true;    // c - Create blobs
+permissions.write = true;     // w - Write blobs
+permissions.delete = true;    // d - Delete blobs
+permissions.list = true;      // l - List blobs
+permissions.tag = true;       // t - Read/write tags
+permissions.move = true;      // m - Move blobs
+permissions.execute = true;   // e - Execute
+permissions.setImmutabilityPolicy = true;
+permissions.permanentDelete = true;
+permissions.filterByTags = true; // f - Filter by tags
+```
+
+### AccountSASPermissions
+
+Permissions for account-level access.
+
+```typescript
+// Parse from string
+const accountPermissions = AccountSASPermissions.parse("rwdlacupi");
+
+// Permission flags
+// r - Read
+// w - Write
+// d - Delete
+// l - List
+// a - Add
+// c - Create
+// u - Update
+// p - Process (queue messages)
+// i - Set immutability policy
+// t - Tag access
+// f - Filter by tags
+```
+
+---
+
+## Service SAS - Blob Level
+
+Generate SAS for a specific blob using account key.
+
+```typescript
+function generateBlobServiceSAS(
+  containerName: string,
+  blobName: string,
+  accountName: string,
+  accountKey: string,
+  expiresInMinutes: number = 60
+): string {
+  const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+
+  const startsOn = new Date();
+  const expiresOn = new Date(startsOn.valueOf() + expiresInMinutes * 60 * 1000);
+
+  const sasOptions: BlobSASSignatureValues = {
+    containerName,
+    blobName,
+    permissions: BlobSASPermissions.parse("r"), // Read only
+    startsOn,
+    expiresOn,
+    protocol: SASProtocol.Https,
+  };
+
+  const sasToken = generateBlobSASQueryParameters(
+    sasOptions,
+    sharedKeyCredential
+  ).toString();
+
+  return `https://${accountName}.blob.core.windows.net/${containerName}/${blobName}?${sasToken}`;
+}
+```
+
+---
+
+## Service SAS - Container Level
+
+Generate SAS for container access.
+
+```typescript
+function generateContainerServiceSAS(
+  containerName: string,
+  accountName: string,
+  accountKey: string,
+  permissions: string = "rl", // read + list
+  expiresInMinutes: number = 60
+): string {
+  const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+
+  const startsOn = new Date();
+  const expiresOn = new Date(startsOn.valueOf() + expiresInMinutes * 60 * 1000);
+
+  const sasOptions: BlobSASSignatureValues = {
+    containerName,
+    permissions: ContainerSASPermissions.parse(permissions),
+    startsOn,
+    expiresOn,
+    protocol: SASProtocol.HttpsAndHttp,
+  };
+
+  const sasToken = generateBlobSASQueryParameters(
+    sasOptions,
+    sharedKeyCredential
+  ).toString();
+
+  return `https://${accountName}.blob.core.windows.net/${containerName}?${sasToken}`;
+}
+```
+
+---
+
+## Account SAS
+
+Generate SAS with account-level access across services.
+
+```typescript
+function generateAccountSAS(
+  accountName: string,
+  accountKey: string,
+  expiresInMinutes: number = 60
+): string {
+  const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+
+  const sasOptions: AccountSASSignatureValues = {
+    services: AccountSASServices.parse("btqf").toString(),  // blob, table, queue, file
+    resourceTypes: AccountSASResourceTypes.parse("sco").toString(), // service, container, object
+    permissions: AccountSASPermissions.parse("rwdlacupi"),
+    protocol: SASProtocol.Https,
+    startsOn: new Date(),
+    expiresOn: new Date(Date.now() + expiresInMinutes * 60 * 1000),
+  };
+
+  const sasToken = generateAccountSASQueryParameters(
+    sasOptions,
+    sharedKeyCredential
+  ).toString();
+
+  return sasToken;
+}
+
+// Usage
+const sasToken = generateAccountSAS(accountName, accountKey);
+const blobServiceClient = new BlobServiceClient(
+  `https://${accountName}.blob.core.windows.net?${sasToken}`
+);
+```
+
+---
+
+## User Delegation SAS (Recommended)
+
+Most secure option - uses Microsoft Entra credentials instead of account key.
+
+```typescript
+async function generateUserDelegationBlobSAS(
+  accountName: string,
+  containerName: string,
+  blobName: string,
+  permissions: string = "r",
+  expiresInMinutes: number = 10
+): Promise<string> {
+  // Use managed identity or Azure CLI credentials
+  const blobServiceClient = new BlobServiceClient(
+    `https://${accountName}.blob.core.windows.net`,
+    new DefaultAzureCredential()
+  );
+
+  // Time boundaries
+  const TEN_MINUTES = 10 * 60 * 1000;
+  const now = new Date();
+  const startsOn = new Date(now.valueOf() - TEN_MINUTES); // Start slightly before now
+  const expiresOn = new Date(now.valueOf() + expiresInMinutes * 60 * 1000);
+
+  // Get user delegation key (time-limited)
+  const userDelegationKey: UserDelegationKey = await blobServiceClient.getUserDelegationKey(
+    startsOn,
+    expiresOn
+  );
+
+  // Generate SAS with user delegation key
+  const sasOptions: BlobSASSignatureValues = {
+    containerName,
+    blobName,
+    permissions: BlobSASPermissions.parse(permissions),
+    protocol: SASProtocol.HttpsAndHttp,
+    startsOn,
+    expiresOn,
+  };
+
+  const sasToken = generateBlobSASQueryParameters(
+    sasOptions,
+    userDelegationKey,
+    accountName
+  ).toString();
+
+  return `https://${accountName}.blob.core.windows.net/${containerName}/${blobName}?${sasToken}`;
+}
+```
+
+### User Delegation SAS for Container
+
+```typescript
+async function generateUserDelegationContainerSAS(
+  accountName: string,
+  containerName: string,
+  permissions: string = "rl",
+  expiresInMinutes: number = 10
+): Promise<string> {
+  const blobServiceClient = new BlobServiceClient(
+    `https://${accountName}.blob.core.windows.net`,
+    new DefaultAzureCredential()
+  );
+
+  const now = new Date();
+  const startsOn = new Date(now.valueOf() - 10 * 60 * 1000);
+  const expiresOn = new Date(now.valueOf() + expiresInMinutes * 60 * 1000);
+
+  const userDelegationKey = await blobServiceClient.getUserDelegationKey(
+    startsOn,
+    expiresOn
+  );
+
+  const sasToken = generateBlobSASQueryParameters(
+    {
+      containerName,
+      permissions: ContainerSASPermissions.parse(permissions),
+      protocol: SASProtocol.HttpsAndHttp,
+      startsOn,
+      expiresOn,
+    },
+    userDelegationKey,
+    accountName
+  ).toString();
+
+  return `https://${accountName}.blob.core.windows.net/${containerName}?${sasToken}`;
+}
+```
+
+---
+
+## Using SAS Tokens
+
+### Create Client from SAS URL
+
+```typescript
+// Blob client from SAS URL
+const blobClient = new BlockBlobClient(sasUrl);
+await blobClient.uploadData(buffer);
+
+// Container client from SAS URL
+const containerClient = new ContainerClient(sasUrl);
+for await (const blob of containerClient.listBlobsFlat()) {
+  console.log(blob.name);
+}
+
+// Service client from SAS token
+const blobServiceClient = new BlobServiceClient(
+  `https://${accountName}.blob.core.windows.net?${sasToken}`
+);
+```
+
+### Generate SAS URL from Existing Client
+
+```typescript
+async function getSignedUrl(
+  blockBlobClient: BlockBlobClient,
+  expiresInSeconds: number = 3600
+): Promise<string> {
+  // Requires client created with StorageSharedKeyCredential
+  return await blockBlobClient.generateSasUrl({
+    permissions: BlobSASPermissions.parse("r"),
+    startsOn: new Date(),
+    expiresOn: new Date(Date.now() + expiresInSeconds * 1000),
+  });
+}
+```
+
+---
+
+## Stored Access Policies
+
+Use stored access policies for revocable SAS tokens.
+
+```typescript
+async function createStoredAccessPolicy(
+  containerClient: ContainerClient,
+  policyName: string
+): Promise<void> {
+  const startsOn = new Date();
+  const expiresOn = new Date(startsOn.valueOf() + 24 * 60 * 60 * 1000); // 24 hours
+
+  await containerClient.setAccessPolicy(undefined, [
+    {
+      id: policyName,
+      accessPolicy: {
+        startsOn,
+        expiresOn,
+        permissions: "rl", // read + list
+      },
+    },
+  ]);
+}
+
+// Generate SAS using stored policy
+function generateSASWithPolicy(
+  containerName: string,
+  blobName: string,
+  policyName: string,
+  sharedKeyCredential: StorageSharedKeyCredential
+): string {
+  const sasToken = generateBlobSASQueryParameters(
+    {
+      containerName,
+      blobName,
+      identifier: policyName, // Reference stored policy
+    },
+    sharedKeyCredential
+  ).toString();
+
+  return sasToken;
+}
+```
+
+---
+
+## Best Practices
+
+### Security
+
+1. **Prefer User Delegation SAS** - More secure than account key
+2. **Minimum Permissions** - Grant only required permissions
+3. **Short Expiration** - Use shortest practical expiration time
+4. **HTTPS Only** - Use `SASProtocol.Https` in production
+5. **Start Time Buffer** - Set `startsOn` slightly before current time to handle clock skew
+
+### Time Management
+
+```typescript
+// Best practice: Handle clock skew
+const CLOCK_SKEW_BUFFER = 5 * 60 * 1000; // 5 minutes
+const now = new Date();
+const startsOn = new Date(now.valueOf() - CLOCK_SKEW_BUFFER);
+const expiresOn = new Date(now.valueOf() + desiredDuration);
+```
+
+### IP Restrictions
+
+```typescript
+const sasOptions: BlobSASSignatureValues = {
+  containerName,
+  blobName,
+  permissions: BlobSASPermissions.parse("r"),
+  startsOn,
+  expiresOn,
+  ipRange: { start: "168.1.5.60", end: "168.1.5.70" }, // Restrict to IP range
+};
+```
+
+### Content Disposition
+
+```typescript
+const sasOptions: BlobSASSignatureValues = {
+  containerName,
+  blobName,
+  permissions: BlobSASPermissions.parse("r"),
+  expiresOn,
+  contentDisposition: "attachment; filename=download.pdf",
+  contentType: "application/pdf",
+};
+```
+
+---
+
+## Common Permission Patterns
+
+| Use Case | Permissions |
+|----------|-------------|
+| Read-only download | `r` |
+| Upload new file | `cw` |
+| List and read | `rl` |
+| Full blob access | `racwd` |
+| Full container access | `racwdl` |
+
+## References
+
+- [Service SAS Documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/sas-service-create-javascript)
+- [User Delegation SAS Documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-create-user-delegation-sas-javascript)
+- [Account SAS Documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-account-delegation-sas-create-javascript)
+- [SAS Best Practices](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#best-practices-when-using-sas)

--- a/references/semantic-ranking.md
+++ b/references/semantic-ranking.md
@@ -1,0 +1,431 @@
+# Semantic Ranking Reference - @azure/search-documents
+
+> Reference documentation for semantic search and ranking patterns in the Azure AI Search TypeScript SDK.
+> 
+> **SDK Version**: 12.x  
+> **Source**: [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/search/search-documents/src/indexModels.ts#L1078-L1123)
+
+## SemanticSearchOptions Interface
+
+The `SemanticSearchOptions` interface configures semantic ranking behavior within a search request.
+
+```typescript
+interface SemanticSearchOptions {
+  /** Name of the semantic configuration to use */
+  configurationName?: string;
+  
+  /** Error handling: 'partial' (default) or 'fail' */
+  errorMode?: SemanticErrorMode;
+  
+  /** Timeout for semantic enrichment in milliseconds */
+  maxWaitInMilliseconds?: number;
+  
+  /** Extract answers from key passages */
+  answers?: QueryAnswer;
+  
+  /** Extract captions with highlighting */
+  captions?: QueryCaption;
+  
+  /** Generate query rewrites for better recall */
+  queryRewrites?: QueryRewrites;
+  
+  /** Separate query for semantic reranking */
+  semanticQuery?: string;
+  
+  /** Fields to use for semantic search */
+  semanticFields?: string[];
+  
+  /** Enable debugging information */
+  debugMode?: QueryDebugMode;
+}
+```
+
+**Source**: [indexModels.ts#L1078-L1123](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/search/search-documents/src/indexModels.ts#L1078-L1123)
+
+---
+
+## Basic Semantic Search
+
+Enable semantic ranking with `queryType: "semantic"`:
+
+```typescript
+import { SearchClient, AzureKeyCredential } from "@azure/search-documents";
+
+interface Hotel {
+  hotelId: string;
+  hotelName: string;
+  description: string;
+  category: string;
+}
+
+const client = new SearchClient<Hotel>(
+  "https://<service>.search.windows.net",
+  "hotels-index",
+  new AzureKeyCredential("<api-key>")
+);
+
+const results = await client.search("luxury hotel with ocean view", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+  },
+  select: ["hotelId", "hotelName", "description"],
+});
+
+for await (const result of results.results) {
+  console.log(`${result.document.hotelName}`);
+  console.log(`  Score: ${result.score}, Reranker: ${result.rerankerScore}`);
+}
+```
+
+**Note**: Semantic search requires a semantic configuration defined in your index.
+
+---
+
+## Extractive Captions
+
+Extract representative passages with highlighting:
+
+```typescript
+interface ExtractiveQueryCaption {
+  captionType: "extractive";
+  highlight?: boolean;           // Enable highlighting (default: true)
+  maxCaptionLength?: number;     // Max characters per caption
+}
+```
+
+```typescript
+const results = await client.search("What amenities do luxury hotels offer?", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    captions: {
+      captionType: "extractive",
+      highlight: true,
+    },
+  },
+});
+
+for await (const result of results.results) {
+  console.log(`Hotel: ${result.document.hotelName}`);
+  
+  // Access captions from the result
+  if (result.captions) {
+    for (const caption of result.captions) {
+      console.log(`  Caption: ${caption.text}`);
+      console.log(`  Highlighted: ${caption.highlights}`);
+    }
+  }
+}
+```
+
+**Source**: [QueryCaptionResult](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/search/search-documents/src/generated/data/models/index.ts#L336-L349)
+
+---
+
+## Extractive Answers
+
+Extract direct answers for Q&A scenarios:
+
+```typescript
+interface ExtractiveQueryAnswer {
+  answerType: "extractive";
+  count?: number;           // Number of answers (default: 1)
+  threshold?: number;       // Confidence threshold (default: 0.7)
+  maxAnswerLength?: number; // Max characters per answer
+}
+```
+
+```typescript
+const results = await client.search("What are the most luxurious hotels?", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    answers: {
+      answerType: "extractive",
+      count: 3,
+      threshold: 0.7,
+    },
+  },
+  top: 5,
+});
+
+// Answers are returned at the response level, not per-document
+if (results.answers) {
+  for (const answer of results.answers) {
+    console.log(`Answer (score: ${answer.score}):`);
+    console.log(`  Document: ${answer.key}`);
+    console.log(`  Text: ${answer.text}`);
+    console.log(`  Highlighted: ${answer.highlights}`);
+  }
+}
+```
+
+**Source**: [QueryAnswerResult](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/search/search-documents/src/generated/data/models/index.ts#L168-L191)
+
+---
+
+## Query Rewrites
+
+Generate alternative queries to improve recall:
+
+```typescript
+interface GenerativeQueryRewrites {
+  rewritesType: "generative";
+  count?: number;  // Number of rewrites (default: 10)
+}
+```
+
+```typescript
+const results = await client.search("cheap hotels downtown", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    queryRewrites: {
+      rewritesType: "generative",
+      count: 5,
+    },
+  },
+});
+
+// Check what type of rewrite was used
+console.log(`Rewrite type: ${results.semanticQueryRewritesResultType}`);
+```
+
+---
+
+## Semantic + Hybrid Search
+
+Combine semantic ranking with vector search for best results:
+
+```typescript
+const results = await client.search("luxury hotel with spa", {
+  // Enable semantic ranking
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    captions: { captionType: "extractive", highlight: true },
+    answers: { answerType: "extractive", count: 3 },
+  },
+  
+  // Add vector search
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryEmbedding,  // Pre-computed embedding
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 50,
+      },
+    ],
+  },
+  
+  // Text search fields
+  searchFields: ["hotelName", "description"],
+  
+  top: 10,
+  select: ["hotelId", "hotelName", "description", "rating"],
+});
+```
+
+---
+
+## Semantic Query Override
+
+Use a different query for semantic reranking than for retrieval:
+
+```typescript
+const results = await client.search("hotel pool wifi", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    // Use natural language for semantic reranking
+    semanticQuery: "What hotels have a swimming pool and free wifi?",
+  },
+});
+```
+
+---
+
+## Debug Mode
+
+Enable debugging to understand semantic processing:
+
+```typescript
+const results = await client.search("luxury", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    errorMode: "fail",      // Fail on errors instead of partial results
+    debugMode: "semantic",  // Enable semantic debug info
+  },
+});
+
+for await (const result of results.results) {
+  const debug = result.documentDebugInfo?.semantic;
+  if (debug) {
+    console.log(`Title field: ${debug.titleField?.name} (${debug.titleField?.state})`);
+    console.log(`Content fields:`, debug.contentFields);
+    console.log(`Keyword fields:`, debug.keywordFields);
+    console.log(`Reranker input:`, debug.rerankerInput);
+  }
+}
+```
+
+**Debug info includes**:
+- `titleField`: Which field was used as title and its state (used/unused)
+- `contentFields`: Content fields sent to semantic enrichment
+- `keywordFields`: Keyword fields sent to semantic enrichment
+- `rerankerInput`: Raw concatenated strings sent to the reranker
+
+---
+
+## Error Handling
+
+Control semantic search error behavior:
+
+```typescript
+const results = await client.search("query", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    errorMode: "partial",           // Return partial results on error (default)
+    maxWaitInMilliseconds: 5000,    // Timeout after 5 seconds
+  },
+});
+
+// Check for partial results
+if (results.semanticErrorReason) {
+  console.log(`Semantic error: ${results.semanticErrorReason}`);
+  console.log(`Result type: ${results.semanticSearchResultsType}`);
+}
+```
+
+---
+
+## Index Configuration for Semantic Search
+
+Configure semantic search in your index definition:
+
+```typescript
+import { SearchIndexClient, AzureKeyCredential } from "@azure/search-documents";
+
+const indexClient = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
+
+await indexClient.createIndex({
+  name: "hotels-semantic-index",
+  fields: [
+    { name: "hotelId", type: "Edm.String", key: true },
+    { name: "hotelName", type: "Edm.String", searchable: true },
+    { name: "description", type: "Edm.String", searchable: true },
+    { name: "tags", type: "Collection(Edm.String)", searchable: true },
+  ],
+  semanticSearch: {
+    configurations: [
+      {
+        name: "my-semantic-config",
+        prioritizedFields: {
+          titleField: { fieldName: "hotelName" },
+          contentFields: [
+            { fieldName: "description" },
+          ],
+          keywordsFields: [
+            { fieldName: "tags" },
+          ],
+        },
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Complete Example
+
+Full semantic search with all features:
+
+```typescript
+import { SearchClient, AzureKeyCredential } from "@azure/search-documents";
+
+interface Hotel {
+  hotelId: string;
+  hotelName: string;
+  description: string;
+  descriptionVector: number[];
+  category: string;
+  rating: number;
+}
+
+async function semanticHybridSearch(
+  client: SearchClient<Hotel>,
+  query: string,
+  queryVector: number[]
+) {
+  const results = await client.search(query, {
+    // Semantic ranking
+    queryType: "semantic",
+    semanticSearchOptions: {
+      configurationName: "hotel-semantic-config",
+      answers: { answerType: "extractive", count: 3, threshold: 0.7 },
+      captions: { captionType: "extractive", highlight: true },
+      queryRewrites: { rewritesType: "generative", count: 5 },
+      errorMode: "partial",
+      maxWaitInMilliseconds: 10000,
+    },
+    
+    // Vector search
+    vectorSearchOptions: {
+      queries: [
+        {
+          kind: "vector",
+          vector: queryVector,
+          fields: ["descriptionVector"],
+          kNearestNeighborsCount: 50,
+        },
+      ],
+    },
+    
+    // Text search
+    searchFields: ["hotelName", "description"],
+    
+    // Results
+    top: 10,
+    includeTotalCount: true,
+    select: ["hotelId", "hotelName", "description", "rating"],
+  });
+
+  // Process answers (response-level)
+  console.log("=== Answers ===");
+  if (results.answers) {
+    for (const answer of results.answers) {
+      console.log(`[${answer.score.toFixed(2)}] ${answer.text}`);
+    }
+  }
+
+  // Process documents with captions
+  console.log("\n=== Results ===");
+  for await (const result of results.results) {
+    console.log(`\n${result.document.hotelName} (${result.document.rating}★)`);
+    console.log(`  Score: ${result.score}, Reranker: ${result.rerankerScore}`);
+    
+    if (result.captions?.[0]) {
+      console.log(`  Caption: ${result.captions[0].highlights || result.captions[0].text}`);
+    }
+  }
+
+  // Check for errors
+  if (results.semanticErrorReason) {
+    console.log(`\nWarning: ${results.semanticErrorReason}`);
+  }
+}
+```
+
+---
+
+## Related Documentation
+
+- [Vector Search Reference](./vector-search.md)
+- [Azure AI Search Semantic Ranking Overview](https://learn.microsoft.com/azure/search/semantic-search-overview)
+- [Configure Semantic Ranking](https://learn.microsoft.com/azure/search/semantic-how-to-query-request)
+- [Extractive Answers and Captions](https://learn.microsoft.com/azure/search/semantic-answers)

--- a/references/streaming.md
+++ b/references/streaming.md
@@ -1,0 +1,509 @@
+# @azure/ai-agents - Streaming Response Patterns
+
+Reference documentation for streaming responses in the Azure AI Agents TypeScript SDK.
+
+**Source**: [Azure SDK for JS - ai-agents](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/ai/ai-agents)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/ai-agents @azure/identity
+```
+
+---
+
+## Core Streaming Types
+
+```typescript
+import {
+  AgentsClient,
+  // Stream event enums
+  RunStreamEvent,
+  MessageStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  // Data types
+  ThreadRun,
+  MessageDeltaChunk,
+  MessageDeltaTextContent,
+  RunStepDeltaChunk,
+  AgentThread,
+  ThreadMessage,
+  RunStep,
+} from "@azure/ai-agents";
+```
+
+---
+
+## Basic Streaming Example
+
+```typescript
+import {
+  AgentsClient,
+  RunStreamEvent,
+  MessageStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  type ThreadRun,
+  type MessageDeltaChunk,
+  type MessageDeltaTextContent,
+} from "@azure/ai-agents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AgentsClient(
+  process.env["PROJECT_ENDPOINT"]!,
+  new DefaultAzureCredential()
+);
+
+// Create agent and thread
+const agent = await client.createAgent("gpt-4o", {
+  name: "streaming-agent",
+  instructions: "You are a helpful assistant.",
+});
+const thread = await client.threads.create();
+await client.messages.create(thread.id, "user", "Tell me a joke");
+
+// Start streaming run
+const stream = await client.runs.create(thread.id, agent.id).stream();
+
+// Process stream events
+for await (const event of stream) {
+  switch (event.event) {
+    case RunStreamEvent.ThreadRunCreated:
+      console.log(`Run started: ${(event.data as ThreadRun).status}`);
+      break;
+
+    case MessageStreamEvent.ThreadMessageDelta:
+      const delta = event.data as MessageDeltaChunk;
+      delta.delta.content?.forEach((part) => {
+        if (part.type === "text") {
+          const text = (part as MessageDeltaTextContent).text?.value || "";
+          process.stdout.write(text);
+        }
+      });
+      break;
+
+    case RunStreamEvent.ThreadRunCompleted:
+      console.log("\nRun completed");
+      break;
+
+    case ErrorEvent.Error:
+      console.error("Error:", event.data);
+      break;
+
+    case DoneEvent.Done:
+      console.log("Stream finished");
+      break;
+  }
+}
+```
+
+---
+
+## Stream Event Types
+
+### Run Events (`RunStreamEvent`)
+
+| Event | Description | Data Type |
+|-------|-------------|-----------|
+| `ThreadRunCreated` | Run was created | `ThreadRun` |
+| `ThreadRunQueued` | Run is queued | `ThreadRun` |
+| `ThreadRunInProgress` | Run started processing | `ThreadRun` |
+| `ThreadRunRequiresAction` | Run needs tool outputs | `ThreadRun` |
+| `ThreadRunCompleted` | Run finished successfully | `ThreadRun` |
+| `ThreadRunIncomplete` | Run ended incomplete | `ThreadRun` |
+| `ThreadRunFailed` | Run failed | `ThreadRun` |
+| `ThreadRunCancelling` | Run is being cancelled | `ThreadRun` |
+| `ThreadRunCancelled` | Run was cancelled | `ThreadRun` |
+| `ThreadRunExpired` | Run expired | `ThreadRun` |
+
+### Message Events (`MessageStreamEvent`)
+
+| Event | Description | Data Type |
+|-------|-------------|-----------|
+| `ThreadMessageCreated` | Message was created | `ThreadMessage` |
+| `ThreadMessageInProgress` | Message is being generated | `ThreadMessage` |
+| `ThreadMessageDelta` | Message content chunk | `MessageDeltaChunk` |
+| `ThreadMessageCompleted` | Message finished | `ThreadMessage` |
+| `ThreadMessageIncomplete` | Message ended incomplete | `ThreadMessage` |
+
+### Other Events
+
+| Event | Description | Data Type |
+|-------|-------------|-----------|
+| `ErrorEvent.Error` | An error occurred | `string` |
+| `DoneEvent.Done` | Stream completed | `string` |
+
+---
+
+## Processing Delta Events
+
+```typescript
+import {
+  MessageDeltaChunk,
+  MessageDeltaTextContent,
+  MessageDeltaImageFileContent,
+} from "@azure/ai-agents";
+
+for await (const event of stream) {
+  if (event.event === MessageStreamEvent.ThreadMessageDelta) {
+    const delta = event.data as MessageDeltaChunk;
+
+    // Access message metadata
+    console.log(`Message ID: ${delta.id}`);
+
+    // Process content parts
+    delta.delta.content?.forEach((part) => {
+      switch (part.type) {
+        case "text":
+          const textPart = part as MessageDeltaTextContent;
+          const text = textPart.text?.value || "";
+          // Handle text annotations (citations, file paths)
+          textPart.text?.annotations?.forEach((annotation) => {
+            console.log(`Annotation: ${annotation.type}`);
+          });
+          process.stdout.write(text);
+          break;
+
+        case "image_file":
+          const imagePart = part as MessageDeltaImageFileContent;
+          console.log(`Image file: ${imagePart.imageFile?.fileId}`);
+          break;
+      }
+    });
+  }
+}
+```
+
+---
+
+## Streaming with Tools
+
+### Code Interpreter with Streaming
+
+```typescript
+import {
+  AgentsClient,
+  ToolUtility,
+  RunStreamEvent,
+  MessageStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  type ThreadRun,
+  type MessageDeltaChunk,
+  type MessageDeltaTextContent,
+} from "@azure/ai-agents";
+import fs from "node:fs";
+
+// Upload file and create tool
+const fileStream = fs.createReadStream("./data/quarterly_results.csv");
+const file = await client.files.upload(fileStream, "assistants", {
+  fileName: "quarterly_results.csv",
+});
+const codeInterpreterTool = ToolUtility.createCodeInterpreterTool([file.id]);
+
+// Create agent with code interpreter
+const agent = await client.createAgent("gpt-4o", {
+  name: "data-analyst",
+  instructions: "You are a data analyst.",
+  tools: [codeInterpreterTool.definition],
+  toolResources: codeInterpreterTool.resources,
+});
+
+const thread = await client.threads.create();
+await client.messages.create(
+  thread.id,
+  "user",
+  "Create a bar chart from the CSV file."
+);
+
+// Stream the response
+const stream = await client.runs.create(thread.id, agent.id).stream();
+
+for await (const event of stream) {
+  switch (event.event) {
+    case RunStreamEvent.ThreadRunCreated:
+      console.log(`Run status: ${(event.data as ThreadRun).status}`);
+      break;
+
+    case MessageStreamEvent.ThreadMessageDelta:
+      const delta = event.data as MessageDeltaChunk;
+      delta.delta.content?.forEach((part) => {
+        if (part.type === "text") {
+          const text = (part as MessageDeltaTextContent).text?.value || "";
+          process.stdout.write(text);
+        }
+      });
+      break;
+
+    case RunStreamEvent.ThreadRunCompleted:
+      console.log("\nRun completed");
+      break;
+
+    case ErrorEvent.Error:
+      console.log(`Error: ${event.data}`);
+      break;
+
+    case DoneEvent.Done:
+      console.log("Stream completed.");
+      break;
+  }
+}
+```
+
+### Bing Grounding with Streaming
+
+```typescript
+import {
+  AgentsClient,
+  ToolUtility,
+  RunStreamEvent,
+  MessageStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  type ThreadRun,
+  type MessageDeltaChunk,
+  type MessageDeltaTextContent,
+} from "@azure/ai-agents";
+
+const connectionId = process.env["AZURE_BING_CONNECTION_ID"]!;
+const bingTool = ToolUtility.createBingGroundingTool([{ connectionId }]);
+
+const agent = await client.createAgent("gpt-4o", {
+  name: "search-agent",
+  instructions: "You are a helpful agent that searches the web.",
+  tools: [bingTool.definition],
+});
+
+const thread = await client.threads.create();
+await client.messages.create(
+  thread.id,
+  "user",
+  "How does Wikipedia explain Euler's Identity?"
+);
+
+const stream = await client.runs.create(thread.id, agent.id).stream();
+
+for await (const event of stream) {
+  switch (event.event) {
+    case RunStreamEvent.ThreadRunCreated:
+      console.log(`Run status: ${(event.data as ThreadRun).status}`);
+      break;
+
+    case MessageStreamEvent.ThreadMessageDelta:
+      const delta = event.data as MessageDeltaChunk;
+      delta.delta.content?.forEach((part) => {
+        if (part.type === "text") {
+          const text = (part as MessageDeltaTextContent).text?.value || "";
+          process.stdout.write(text);
+        }
+      });
+      break;
+
+    case RunStreamEvent.ThreadRunCompleted:
+      console.log("\nRun completed");
+      break;
+
+    case ErrorEvent.Error:
+      console.log(`Error: ${event.data}`);
+      break;
+
+    case DoneEvent.Done:
+      console.log("Stream completed.");
+      break;
+  }
+}
+```
+
+---
+
+## Error Handling in Streams
+
+```typescript
+import { RestError } from "@azure/core-rest-pipeline";
+
+try {
+  const stream = await client.runs.create(thread.id, agent.id).stream();
+
+  for await (const event of stream) {
+    switch (event.event) {
+      case ErrorEvent.Error:
+        // Handle stream-level errors
+        console.error("Stream error:", event.data);
+        break;
+
+      case RunStreamEvent.ThreadRunFailed:
+        // Handle run failures
+        const failedRun = event.data as ThreadRun;
+        console.error("Run failed:", failedRun.lastError);
+        break;
+
+      case RunStreamEvent.ThreadRunExpired:
+        // Handle expired runs
+        console.error("Run expired");
+        break;
+
+      // ... handle other events
+    }
+  }
+} catch (error) {
+  if (error instanceof RestError) {
+    console.error(`HTTP Error ${error.code}: ${error.message}`);
+  } else {
+    throw error;
+  }
+}
+```
+
+---
+
+## Complete Streaming Example
+
+```typescript
+import {
+  AgentsClient,
+  RunStreamEvent,
+  MessageStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  type ThreadRun,
+  type MessageDeltaChunk,
+  type MessageDeltaTextContent,
+  type ThreadMessage,
+} from "@azure/ai-agents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+async function streamingChat() {
+  const client = new AgentsClient(
+    process.env["PROJECT_ENDPOINT"]!,
+    new DefaultAzureCredential()
+  );
+
+  // Create agent
+  const agent = await client.createAgent("gpt-4o", {
+    name: "chat-assistant",
+    instructions: "You are a helpful assistant.",
+  });
+
+  // Create thread and message
+  const thread = await client.threads.create();
+  await client.messages.create(thread.id, "user", "Tell me about TypeScript.");
+
+  // Start streaming
+  const stream = await client.runs.create(thread.id, agent.id).stream();
+  let fullResponse = "";
+
+  for await (const event of stream) {
+    switch (event.event) {
+      // Run lifecycle events
+      case RunStreamEvent.ThreadRunCreated:
+        console.log("🚀 Run started");
+        break;
+
+      case RunStreamEvent.ThreadRunInProgress:
+        console.log("⏳ Processing...");
+        break;
+
+      case RunStreamEvent.ThreadRunCompleted:
+        console.log("\n✅ Run completed");
+        break;
+
+      case RunStreamEvent.ThreadRunFailed:
+        const failedRun = event.data as ThreadRun;
+        console.error("❌ Run failed:", failedRun.lastError);
+        break;
+
+      // Message events
+      case MessageStreamEvent.ThreadMessageCreated:
+        console.log("📝 Message started");
+        break;
+
+      case MessageStreamEvent.ThreadMessageDelta:
+        const delta = event.data as MessageDeltaChunk;
+        delta.delta.content?.forEach((part) => {
+          if (part.type === "text") {
+            const text = (part as MessageDeltaTextContent).text?.value || "";
+            fullResponse += text;
+            process.stdout.write(text);
+          }
+        });
+        break;
+
+      case MessageStreamEvent.ThreadMessageCompleted:
+        const message = event.data as ThreadMessage;
+        console.log(`\n📄 Message completed (ID: ${message.id})`);
+        break;
+
+      // Error and completion
+      case ErrorEvent.Error:
+        console.error("❌ Error:", event.data);
+        break;
+
+      case DoneEvent.Done:
+        console.log("🏁 Stream finished");
+        break;
+    }
+  }
+
+  // Cleanup
+  await client.deleteAgent(agent.id);
+
+  return fullResponse;
+}
+
+// Run the example
+streamingChat()
+  .then((response) => console.log("\nFull response length:", response.length))
+  .catch(console.error);
+```
+
+---
+
+## AgentEventMessage Interface
+
+The stream yields `AgentEventMessage` objects:
+
+```typescript
+interface AgentEventMessage {
+  /** Event type (RunStreamEvent, MessageStreamEvent, etc.) */
+  event: AgentStreamEvent | string;
+
+  /** Event data - type depends on event */
+  data: AgentEventStreamData;
+}
+
+type AgentEventStreamData =
+  | AgentThread      // Thread events
+  | ThreadRun        // Run events
+  | RunStep          // Run step events
+  | ThreadMessage    // Message events
+  | MessageDeltaChunk    // Message delta events
+  | RunStepDeltaChunk    // Run step delta events
+  | string;              // Error/Done events
+```
+
+---
+
+## Non-Streaming Alternative
+
+For simpler use cases, use polling instead of streaming:
+
+```typescript
+// Create and poll until completion
+const run = await client.runs.createAndPoll(thread.id, agent.id, {
+  pollingOptions: {
+    intervalInMs: 2000,
+  },
+  onResponse: (response) => {
+    console.log(`Status: ${response.parsedBody.status}`);
+  },
+});
+
+// Get final messages
+const messages = client.messages.list(thread.id);
+for await (const message of messages) {
+  console.log(`${message.role}: ${message.content}`);
+}
+```

--- a/references/tools.md
+++ b/references/tools.md
@@ -1,0 +1,368 @@
+# @azure/ai-agents - Tool Integration Patterns
+
+Reference documentation for tool integration in the Azure AI Agents TypeScript SDK.
+
+**Source**: [Azure SDK for JS - ai-agents](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/ai/ai-agents)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/ai-agents @azure/identity
+```
+
+---
+
+## Client Setup
+
+```typescript
+import { AgentsClient, ToolUtility, ToolSet } from "@azure/ai-agents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AgentsClient(
+  process.env["PROJECT_ENDPOINT"]!,
+  new DefaultAzureCredential()
+);
+```
+
+---
+
+## Function Tools
+
+Define custom functions the agent can call. You provide definitions only—implementations run in your code.
+
+```typescript
+import {
+  FunctionToolDefinition,
+  ToolUtility,
+  RequiredToolCall,
+  ToolOutput,
+  SubmitToolOutputsAction,
+  isOutputOfType,
+} from "@azure/ai-agents";
+
+// Define function tools
+const weatherTool = ToolUtility.createFunctionTool({
+  name: "getWeather",
+  description: "Gets the weather for a location.",
+  parameters: {
+    type: "object",
+    properties: {
+      location: { type: "string", description: "City and state, e.g. Seattle, WA" },
+      unit: { type: "string", enum: ["c", "f"] },
+    },
+  },
+});
+
+const cityTool = ToolUtility.createFunctionTool({
+  name: "getUserFavoriteCity",
+  description: "Gets the user's favorite city.",
+  parameters: {},
+});
+
+// Create agent with function tools
+const agent = await client.createAgent("gpt-4o", {
+  name: "weather-bot",
+  instructions: "You are a weather bot. Use provided functions to answer questions.",
+  tools: [weatherTool.definition, cityTool.definition],
+});
+
+// Handle function calls during run polling
+const run = await client.runs.createAndPoll(thread.id, agent.id, {
+  onResponse: async (response) => {
+    const run = response.parsedBody;
+    if (run.status === "requires_action" && run.requiredAction) {
+      if (isOutputOfType<SubmitToolOutputsAction>(run.requiredAction, "submit_tool_outputs")) {
+        const toolCalls = run.requiredAction.submitToolOutputs.toolCalls;
+        const toolOutputs: ToolOutput[] = toolCalls.map((call) => ({
+          toolCallId: call.id,
+          output: JSON.stringify(executeFunction(call)), // Your implementation
+        }));
+        await client.runs.submitToolOutputs(thread.id, run.id, toolOutputs);
+      }
+    }
+  },
+});
+```
+
+---
+
+## Code Interpreter Tool
+
+Execute Python code for data analysis, file processing, and visualization.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+import fs from "node:fs";
+
+// Upload file for code interpreter
+const fileStream = fs.createReadStream("./data/quarterly_results.csv");
+const file = await client.files.upload(fileStream, "assistants", {
+  fileName: "quarterly_results.csv",
+});
+
+// Create code interpreter tool with file
+const codeInterpreterTool = ToolUtility.createCodeInterpreterTool([file.id]);
+
+// Create agent with code interpreter
+const agent = await client.createAgent("gpt-4o", {
+  name: "data-analyst",
+  instructions: "You are a data analyst. Analyze uploaded files and create visualizations.",
+  tools: [codeInterpreterTool.definition],
+  toolResources: codeInterpreterTool.resources,
+});
+
+// Create message with file attachment
+const message = await client.messages.create(
+  thread.id,
+  "user",
+  "Create a bar chart of operating profit by sector from the CSV file.",
+  {
+    attachments: [
+      {
+        fileId: file.id,
+        tools: [codeInterpreterTool.definition],
+      },
+    ],
+  }
+);
+```
+
+---
+
+## File Search Tool
+
+Search through uploaded documents using vector stores.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+import fs from "node:fs";
+
+// Upload file
+const fileStream = fs.createReadStream("./data/product_docs.txt");
+const file = await client.files.upload(fileStream, "assistants", {
+  fileName: "product_docs.txt",
+});
+
+// Create vector store with file
+const vectorStore = await client.vectorStores.create({
+  fileIds: [file.id],
+  name: "product-documentation",
+});
+
+// Create file search tool
+const fileSearchTool = ToolUtility.createFileSearchTool([vectorStore.id]);
+
+// Create agent with file search
+const agent = await client.createAgent("gpt-4o", {
+  name: "doc-search-agent",
+  instructions: "You help users find information in product documentation.",
+  tools: [fileSearchTool.definition],
+  toolResources: fileSearchTool.resources,
+});
+
+// Attach file to message for search
+const message = await client.messages.create(
+  thread.id,
+  "user",
+  "What features does the Smart Eyewear product offer?",
+  {
+    attachments: [
+      {
+        fileId: file.id,
+        tools: [fileSearchTool.definition],
+      },
+    ],
+  }
+);
+```
+
+---
+
+## Bing Grounding Tool
+
+Enable web search via Bing Search API.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+
+const connectionId = process.env["AZURE_BING_CONNECTION_ID"]!;
+
+// Create Bing grounding tool
+const bingTool = ToolUtility.createBingGroundingTool([
+  {
+    connectionId: connectionId,
+    market: "en-US",      // Optional: market locale
+    count: 10,            // Optional: number of results
+    freshness: "Week",    // Optional: "Day", "Week", "Month"
+  },
+]);
+
+// Create agent with Bing search
+const agent = await client.createAgent("gpt-4o", {
+  name: "search-agent",
+  instructions: "You are a helpful agent that can search the web for current information.",
+  tools: [bingTool.definition],
+});
+```
+
+---
+
+## Azure AI Search Tool
+
+Integrate enterprise search with Azure AI Search indexes.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+
+const connectionName = process.env["AZURE_AI_SEARCH_CONNECTION_NAME"]!;
+
+// Create Azure AI Search tool
+const searchTool = ToolUtility.createAzureAISearchTool(
+  connectionName,
+  "products-index",
+  {
+    queryType: "simple",  // "simple", "semantic", "vector", "hybrid"
+    topK: 5,              // Number of results to return
+    filter: "",           // OData filter expression
+  }
+);
+
+// Create agent with Azure AI Search
+const agent = await client.createAgent("gpt-4o", {
+  name: "enterprise-search-agent",
+  instructions: "You help users find information in our product catalog.",
+  tools: [searchTool.definition],
+  toolResources: searchTool.resources,
+});
+```
+
+---
+
+## Using ToolSet for Multiple Tools
+
+Combine multiple tools using the `ToolSet` class.
+
+```typescript
+import { ToolSet } from "@azure/ai-agents";
+
+const toolSet = new ToolSet();
+
+// Add file search tool
+toolSet.addFileSearchTool([vectorStore.id]);
+
+// Add code interpreter tool
+toolSet.addCodeInterpreterTool([dataFile.id]);
+
+// Add Bing grounding tool
+toolSet.addBingGroundingTool([{ connectionId: bingConnectionId }]);
+
+// Create agent with all tools
+const agent = await client.createAgent("gpt-4o", {
+  name: "multi-tool-agent",
+  instructions: "You can search files, analyze data, and search the web.",
+  tools: toolSet.toolDefinitions,
+  toolResources: toolSet.toolResources,
+});
+```
+
+---
+
+## Tool Choice Configuration
+
+Control which tools the agent uses.
+
+```typescript
+// Let the agent decide (default)
+const run1 = await client.runs.create(thread.id, agent.id);
+
+// Force a specific tool
+const run2 = await client.runs.createAndPoll(thread.id, agent.id, {
+  toolChoice: {
+    type: "function",
+    function: { name: "getWeather" },
+  },
+});
+
+// Disable all tools for this run
+const run3 = await client.runs.createAndPoll(thread.id, agent.id, {
+  toolChoice: "none",
+});
+
+// Require at least one tool call
+const run4 = await client.runs.createAndPoll(thread.id, agent.id, {
+  toolChoice: "required",
+});
+```
+
+---
+
+## OpenAPI Tool
+
+Call REST APIs defined by OpenAPI specifications.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+import fs from "node:fs";
+
+// Load OpenAPI spec
+const openApiSpec = JSON.parse(fs.readFileSync("./weather-api.json", "utf-8"));
+
+// Create OpenAPI tool
+const openApiTool = ToolUtility.createOpenApiTool({
+  name: "getWeather",
+  spec: openApiSpec,
+  description: "Retrieve weather information for a location",
+  auth: { type: "anonymous" },
+  default_params: ["format"],
+});
+
+// Create agent with OpenAPI tool
+const agent = await client.createAgent("gpt-4o", {
+  name: "api-agent",
+  instructions: "You can fetch weather data from the weather API.",
+  tools: [openApiTool.definition],
+});
+```
+
+---
+
+## Connected Agents Tool
+
+Connect multiple agents together.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+
+// Create a specialized agent
+const stockAgent = await client.createAgent("gpt-4o", {
+  name: "stock-price-agent",
+  instructions: "Your job is to get stock prices for companies.",
+});
+
+// Create connected agent tool
+const connectedAgentTool = ToolUtility.createConnectedAgentTool(
+  stockAgent.id,
+  "stock_price_bot",
+  "Gets the stock price of a company"
+);
+
+// Create main agent with connected agent
+const mainAgent = await client.createAgent("gpt-4o", {
+  name: "financial-assistant",
+  instructions: "You help with financial questions. Use the connected agent for stock prices.",
+  tools: [connectedAgentTool.definition],
+});
+```
+
+---
+
+## Cleanup
+
+```typescript
+// Delete resources when done
+await client.vectorStores.delete(vectorStore.id);
+await client.files.delete(file.id);
+await client.deleteAgent(agent.id);
+```

--- a/references/vector-search.md
+++ b/references/vector-search.md
@@ -1,0 +1,447 @@
+# Vector Search Reference - @azure/search-documents
+
+> Reference documentation for vector and hybrid search patterns in the Azure AI Search TypeScript SDK.
+> 
+> **SDK Version**: 12.x  
+> **Source**: [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/search/search-documents/src/indexModels.ts#L1147-L1157)
+
+## VectorSearchOptions Interface
+
+The `VectorSearchOptions` interface configures vector search behavior within a search request.
+
+```typescript
+interface VectorSearchOptions<TModel extends object> {
+  /** Array of vector queries to execute */
+  queries: VectorQuery<TModel>[];
+  
+  /** When to apply filters: 'preFilter' (default) or 'postFilter' */
+  filterMode?: VectorFilterMode;
+}
+```
+
+**Source**: [indexModels.ts#L1147-L1157](https://github.com/Azure/azure-sdk-for-js/blob/3d73b62136d4f89a74a325329bb838280f37f0d0/sdk/search/search-documents/src/indexModels.ts#L1147-L1157)
+
+---
+
+## Vector Query Types
+
+The SDK supports four types of vector queries:
+
+| Kind | Description | Use Case |
+|------|-------------|----------|
+| `vector` | Raw vector embedding | Pre-computed embeddings |
+| `text` | Text to be vectorized | Integrated vectorization |
+| `imageUrl` | Image URL to vectorize | Image search |
+| `imageBinary` | Base64 image to vectorize | Image search |
+
+### BaseVectorQuery Properties
+
+All vector query types share these properties:
+
+```typescript
+interface BaseVectorQuery<TModel extends object> {
+  kind: "vector" | "text" | "imageUrl" | "imageBinary";
+  kNearestNeighborsCount?: number;  // Number of nearest neighbors (k)
+  fields?: SearchFieldArray<TModel>; // Vector fields to search
+  exhaustive?: boolean;              // Use exhaustive search (slower, more accurate)
+  weight?: number;                   // Relative weight (default: 1.0)
+  threshold?: VectorThreshold;       // Similarity threshold
+  filterOverride?: string;           // Per-query OData filter
+  perDocumentVectorLimit?: number;   // Max vectors per document (0 = unlimited)
+}
+```
+
+---
+
+## Basic Vector Search
+
+Search using a pre-computed embedding vector:
+
+```typescript
+import { SearchClient, AzureKeyCredential } from "@azure/search-documents";
+
+interface Hotel {
+  hotelId: string;
+  hotelName: string;
+  description: string;
+  descriptionVector: number[];
+}
+
+const client = new SearchClient<Hotel>(
+  "https://<service>.search.windows.net",
+  "hotels-index",
+  new AzureKeyCredential("<api-key>")
+);
+
+// Pre-computed embedding for "luxury hotel with pool"
+const queryVector: number[] = [0.01, -0.02, 0.03, /* ... 1536 dimensions */];
+
+const results = await client.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 10,
+      },
+    ],
+  },
+  select: ["hotelId", "hotelName", "description"],
+});
+
+for await (const result of results.results) {
+  console.log(`${result.document.hotelName} (score: ${result.score})`);
+}
+```
+
+---
+
+## Hybrid Search (Text + Vector)
+
+Combine keyword search with vector search for better relevance:
+
+```typescript
+const results = await client.search("luxury pool spa", {
+  // Text search configuration
+  searchFields: ["hotelName", "description"],
+  queryType: "simple",
+  
+  // Vector search configuration
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 50,
+      },
+    ],
+  },
+  
+  // Return top 10 results
+  top: 10,
+  select: ["hotelId", "hotelName", "description", "rating"],
+});
+```
+
+---
+
+## Integrated Vectorization (Text Query)
+
+Let Azure AI Search vectorize your text query automatically:
+
+```typescript
+// Requires a vectorizer configured in the index
+const results = await client.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "text",
+        text: "What are the most luxurious hotels with ocean views?",
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 10,
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Multi-Vector Search
+
+Search across multiple vector fields simultaneously:
+
+```typescript
+interface MultilingualHotel {
+  hotelId: string;
+  hotelName: string;
+  descriptionVectorEn: number[];
+  descriptionVectorFr: number[];
+}
+
+const client = new SearchClient<MultilingualHotel>(endpoint, indexName, credential);
+
+const results = await client.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: englishEmbedding,
+        fields: ["descriptionVectorEn"],
+        kNearestNeighborsCount: 25,
+        weight: 1.0,
+      },
+      {
+        kind: "vector",
+        vector: frenchEmbedding,
+        fields: ["descriptionVectorFr"],
+        kNearestNeighborsCount: 25,
+        weight: 0.8,  // Lower weight for secondary language
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Vector Filtering
+
+### Global Filter (Pre-Filter)
+
+Apply filter before vector search (default behavior):
+
+```typescript
+const results = await client.search("*", {
+  filter: "rating ge 4 and category eq 'Luxury'",
+  vectorSearchOptions: {
+    filterMode: "preFilter",  // Default - filter first, then vector search
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 10,
+      },
+    ],
+  },
+});
+```
+
+### Post-Filter
+
+Apply filter after vector search (larger candidate set):
+
+```typescript
+const results = await client.search("*", {
+  filter: "rating ge 4",
+  vectorSearchOptions: {
+    filterMode: "postFilter",  // Vector search first, then filter
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 50,  // Request more to account for filtering
+      },
+    ],
+  },
+});
+```
+
+### Per-Query Filter Override
+
+Apply different filters to different vector queries:
+
+```typescript
+const results = await client.search("luxury hotel", {
+  filter: "rating ge 3",  // Global filter
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 20,
+        filterOverride: "city eq 'Seattle'",  // Override for this query only
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Vector Thresholds
+
+Filter results by similarity score:
+
+```typescript
+// Filter by vector similarity metric
+const results = await client.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 50,
+        threshold: {
+          kind: "vectorSimilarity",
+          value: 0.8,  // Only return results with similarity >= 0.8
+        },
+      },
+    ],
+  },
+});
+
+// Filter by search score
+const results2 = await client.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 50,
+        threshold: {
+          kind: "searchScore",
+          value: 0.5,  // Only return results with @search.score >= 0.5
+        },
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Exhaustive Search
+
+Use exhaustive k-NN for ground truth evaluation:
+
+```typescript
+const results = await client.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["descriptionVector"],
+        kNearestNeighborsCount: 10,
+        exhaustive: true,  // Slower but exact results
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Index Configuration for Vector Search
+
+Configure vector search in your index definition:
+
+```typescript
+import { SearchIndexClient, AzureKeyCredential } from "@azure/search-documents";
+
+const indexClient = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
+
+await indexClient.createIndex({
+  name: "hotels-vector-index",
+  fields: [
+    { name: "hotelId", type: "Edm.String", key: true },
+    { name: "hotelName", type: "Edm.String", searchable: true },
+    { name: "description", type: "Edm.String", searchable: true },
+    {
+      name: "descriptionVector",
+      type: "Collection(Edm.Single)",
+      searchable: true,
+      vectorSearchDimensions: 1536,
+      vectorSearchProfileName: "my-vector-profile",
+    },
+  ],
+  vectorSearch: {
+    algorithms: [
+      {
+        name: "my-hnsw-config",
+        kind: "hnsw",
+        parameters: {
+          m: 4,
+          efConstruction: 400,
+          efSearch: 500,
+          metric: "cosine",
+        },
+      },
+    ],
+    profiles: [
+      {
+        name: "my-vector-profile",
+        algorithmConfigurationName: "my-hnsw-config",
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Complete Hybrid Search Example
+
+Full example combining all features:
+
+```typescript
+import { SearchClient, AzureKeyCredential, odata } from "@azure/search-documents";
+
+interface Hotel {
+  hotelId: string;
+  hotelName: string;
+  description: string;
+  descriptionVector: number[];
+  category: string;
+  rating: number;
+  city: string;
+}
+
+async function hybridSearch(
+  client: SearchClient<Hotel>,
+  query: string,
+  queryVector: number[],
+  filters: { minRating?: number; city?: string }
+) {
+  const filterParts: string[] = [];
+  if (filters.minRating) filterParts.push(`rating ge ${filters.minRating}`);
+  if (filters.city) filterParts.push(`city eq '${filters.city}'`);
+  
+  const results = await client.search(query, {
+    // Text search
+    searchFields: ["hotelName", "description"],
+    queryType: "simple",
+    searchMode: "any",
+    
+    // Vector search
+    vectorSearchOptions: {
+      filterMode: "preFilter",
+      queries: [
+        {
+          kind: "vector",
+          vector: queryVector,
+          fields: ["descriptionVector"],
+          kNearestNeighborsCount: 50,
+          weight: 1.5,  // Boost vector results
+        },
+      ],
+    },
+    
+    // Filtering
+    filter: filterParts.length > 0 ? filterParts.join(" and ") : undefined,
+    
+    // Results
+    top: 10,
+    skip: 0,
+    includeTotalCount: true,
+    select: ["hotelId", "hotelName", "description", "rating", "city"],
+    
+    // Facets for filtering UI
+    facets: ["category,count:5", "city,count:10"],
+  });
+
+  console.log(`Total results: ${results.count}`);
+  console.log(`Facets:`, results.facets);
+  
+  for await (const result of results.results) {
+    console.log(`[${result.score}] ${result.document.hotelName}`);
+  }
+}
+```
+
+---
+
+## Related Documentation
+
+- [Semantic Ranking Reference](./semantic-ranking.md)
+- [Azure AI Search Vector Search Overview](https://learn.microsoft.com/azure/search/vector-search-overview)
+- [Vector Search How-To Query](https://learn.microsoft.com/azure/search/vector-search-how-to-query)
+- [Vector Search Filters](https://learn.microsoft.com/azure/search/vector-search-filters)

--- a/skills/java/ai/anomalydetector/SKILL.md
+++ b/skills/java/ai/anomalydetector/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: azure-ai-anomalydetector-java
+description: Build anomaly detection applications with Azure AI Anomaly Detector SDK for Java. Use when implementing univariate/multivariate anomaly detection, time-series analysis, or AI-powered monitoring.
+---
+
+# Azure AI Anomaly Detector SDK for Java
+
+Build anomaly detection applications using the Azure AI Anomaly Detector SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.azure</groupId>
+  <artifactId>azure-ai-anomalydetector</artifactId>
+  <version>3.0.0-beta.6</version>
+</dependency>
+```
+
+## Client Creation
+
+### Sync and Async Clients
+
+```java
+import com.azure.ai.anomalydetector.AnomalyDetectorClientBuilder;
+import com.azure.ai.anomalydetector.MultivariateClient;
+import com.azure.ai.anomalydetector.UnivariateClient;
+import com.azure.core.credential.AzureKeyCredential;
+
+String endpoint = System.getenv("AZURE_ANOMALY_DETECTOR_ENDPOINT");
+String key = System.getenv("AZURE_ANOMALY_DETECTOR_API_KEY");
+
+// Multivariate client for multiple correlated signals
+MultivariateClient multivariateClient = new AnomalyDetectorClientBuilder()
+    .credential(new AzureKeyCredential(key))
+    .endpoint(endpoint)
+    .buildMultivariateClient();
+
+// Univariate client for single variable analysis
+UnivariateClient univariateClient = new AnomalyDetectorClientBuilder()
+    .credential(new AzureKeyCredential(key))
+    .endpoint(endpoint)
+    .buildUnivariateClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+MultivariateClient client = new AnomalyDetectorClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildMultivariateClient();
+```
+
+## Key Concepts
+
+### Univariate Anomaly Detection
+- **Batch Detection**: Analyze entire time series at once
+- **Streaming Detection**: Real-time detection on latest data point
+- **Change Point Detection**: Detect trend changes in time series
+
+### Multivariate Anomaly Detection
+- Detect anomalies across 300+ correlated signals
+- Uses Graph Attention Network for inter-correlations
+- Three-step process: Train → Inference → Results
+
+## Core Patterns
+
+### Univariate Batch Detection
+
+```java
+import com.azure.ai.anomalydetector.models.*;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+List<TimeSeriesPoint> series = List.of(
+    new TimeSeriesPoint(OffsetDateTime.parse("2023-01-01T00:00:00Z"), 1.0),
+    new TimeSeriesPoint(OffsetDateTime.parse("2023-01-02T00:00:00Z"), 2.5),
+    // ... more data points (minimum 12 points required)
+);
+
+UnivariateDetectionOptions options = new UnivariateDetectionOptions(series)
+    .setGranularity(TimeGranularity.DAILY)
+    .setSensitivity(95);
+
+UnivariateEntireDetectionResult result = univariateClient.detectUnivariateEntireSeries(options);
+
+// Check for anomalies
+for (int i = 0; i < result.getIsAnomaly().size(); i++) {
+    if (result.getIsAnomaly().get(i)) {
+        System.out.printf("Anomaly detected at index %d with value %.2f%n",
+            i, series.get(i).getValue());
+    }
+}
+```
+
+### Univariate Last Point Detection (Streaming)
+
+```java
+UnivariateLastDetectionResult lastResult = univariateClient.detectUnivariateLastPoint(options);
+
+if (lastResult.isAnomaly()) {
+    System.out.println("Latest point is an anomaly!");
+    System.out.printf("Expected: %.2f, Upper: %.2f, Lower: %.2f%n",
+        lastResult.getExpectedValue(),
+        lastResult.getUpperMargin(),
+        lastResult.getLowerMargin());
+}
+```
+
+### Change Point Detection
+
+```java
+UnivariateChangePointDetectionOptions changeOptions = 
+    new UnivariateChangePointDetectionOptions(series, TimeGranularity.DAILY);
+
+UnivariateChangePointDetectionResult changeResult = 
+    univariateClient.detectUnivariateChangePoint(changeOptions);
+
+for (int i = 0; i < changeResult.getIsChangePoint().size(); i++) {
+    if (changeResult.getIsChangePoint().get(i)) {
+        System.out.printf("Change point at index %d with confidence %.2f%n",
+            i, changeResult.getConfidenceScores().get(i));
+    }
+}
+```
+
+### Multivariate Model Training
+
+```java
+import com.azure.ai.anomalydetector.models.*;
+import com.azure.core.util.polling.SyncPoller;
+
+// Prepare training request with blob storage data
+ModelInfo modelInfo = new ModelInfo()
+    .setDataSource("https://storage.blob.core.windows.net/container/data.zip?sasToken")
+    .setStartTime(OffsetDateTime.parse("2023-01-01T00:00:00Z"))
+    .setEndTime(OffsetDateTime.parse("2023-06-01T00:00:00Z"))
+    .setSlidingWindow(200)
+    .setDisplayName("MyMultivariateModel");
+
+// Train model (long-running operation)
+AnomalyDetectionModel trainedModel = multivariateClient.trainMultivariateModel(modelInfo);
+
+String modelId = trainedModel.getModelId();
+System.out.println("Model ID: " + modelId);
+
+// Check training status
+AnomalyDetectionModel model = multivariateClient.getMultivariateModel(modelId);
+System.out.println("Status: " + model.getModelInfo().getStatus());
+```
+
+### Multivariate Batch Inference
+
+```java
+MultivariateBatchDetectionOptions detectionOptions = new MultivariateBatchDetectionOptions()
+    .setDataSource("https://storage.blob.core.windows.net/container/inference-data.zip?sasToken")
+    .setStartTime(OffsetDateTime.parse("2023-07-01T00:00:00Z"))
+    .setEndTime(OffsetDateTime.parse("2023-07-31T00:00:00Z"))
+    .setTopContributorCount(10);
+
+MultivariateDetectionResult detectionResult = 
+    multivariateClient.detectMultivariateBatchAnomaly(modelId, detectionOptions);
+
+String resultId = detectionResult.getResultId();
+
+// Poll for results
+MultivariateDetectionResult result = multivariateClient.getBatchDetectionResult(resultId);
+for (AnomalyState state : result.getResults()) {
+    if (state.getValue().isAnomaly()) {
+        System.out.printf("Anomaly at %s, severity: %.2f%n",
+            state.getTimestamp(),
+            state.getValue().getSeverity());
+    }
+}
+```
+
+### Multivariate Last Point Detection
+
+```java
+MultivariateLastDetectionOptions lastOptions = new MultivariateLastDetectionOptions()
+    .setVariables(List.of(
+        new VariableValues("variable1", List.of("timestamp1"), List.of(1.0f)),
+        new VariableValues("variable2", List.of("timestamp1"), List.of(2.5f))
+    ))
+    .setTopContributorCount(5);
+
+MultivariateLastDetectionResult lastResult = 
+    multivariateClient.detectMultivariateLastAnomaly(modelId, lastOptions);
+
+if (lastResult.getValue().isAnomaly()) {
+    System.out.println("Anomaly detected!");
+    // Check contributing variables
+    for (AnomalyContributor contributor : lastResult.getValue().getInterpretation()) {
+        System.out.printf("Variable: %s, Contribution: %.2f%n",
+            contributor.getVariable(),
+            contributor.getContributionScore());
+    }
+}
+```
+
+### Model Management
+
+```java
+// List all models
+PagedIterable<AnomalyDetectionModel> models = multivariateClient.listMultivariateModels();
+for (AnomalyDetectionModel m : models) {
+    System.out.printf("Model: %s, Status: %s%n",
+        m.getModelId(),
+        m.getModelInfo().getStatus());
+}
+
+// Delete a model
+multivariateClient.deleteMultivariateModel(modelId);
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    univariateClient.detectUnivariateEntireSeries(options);
+} catch (HttpResponseException e) {
+    System.out.println("Status code: " + e.getResponse().getStatusCode());
+    System.out.println("Error: " + e.getMessage());
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_ANOMALY_DETECTOR_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+AZURE_ANOMALY_DETECTOR_API_KEY=<your-api-key>
+```
+
+## Best Practices
+
+1. **Minimum Data Points**: Univariate requires at least 12 points; more data improves accuracy
+2. **Granularity Alignment**: Match `TimeGranularity` to your actual data frequency
+3. **Sensitivity Tuning**: Higher values (0-99) detect more anomalies
+4. **Multivariate Training**: Use 200-1000 sliding window based on pattern complexity
+5. **Error Handling**: Always handle `HttpResponseException` for API errors
+
+## Trigger Phrases
+
+- "anomaly detection Java"
+- "detect anomalies time series"
+- "multivariate anomaly Java"
+- "univariate anomaly detection"
+- "streaming anomaly detection"
+- "change point detection"
+- "Azure AI Anomaly Detector"

--- a/skills/java/ai/anomalydetector/references/examples.md
+++ b/skills/java/ai/anomalydetector/references/examples.md
@@ -1,0 +1,686 @@
+# Azure AI Anomaly Detector Java SDK - Examples
+
+Comprehensive code examples for the Azure AI Anomaly Detector SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Univariate Detection](#univariate-detection)
+- [Univariate Streaming Detection](#univariate-streaming-detection)
+- [Change Point Detection](#change-point-detection)
+- [Multivariate Model Training](#multivariate-model-training)
+- [Multivariate Batch Inference](#multivariate-batch-inference)
+- [Multivariate Last Point Detection](#multivariate-last-point-detection)
+- [Model Management](#model-management)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-anomalydetector</artifactId>
+    <version>3.0.0-beta.6</version>
+</dependency>
+
+<!-- For DefaultAzureCredential -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### With API Key
+
+```java
+import com.azure.ai.anomalydetector.AnomalyDetectorClientBuilder;
+import com.azure.ai.anomalydetector.MultivariateClient;
+import com.azure.ai.anomalydetector.UnivariateClient;
+import com.azure.core.credential.AzureKeyCredential;
+
+String endpoint = System.getenv("AZURE_ANOMALY_DETECTOR_ENDPOINT");
+String key = System.getenv("AZURE_ANOMALY_DETECTOR_API_KEY");
+
+// Univariate client for single variable analysis
+UnivariateClient univariateClient = new AnomalyDetectorClientBuilder()
+    .credential(new AzureKeyCredential(key))
+    .endpoint(endpoint)
+    .buildUnivariateClient();
+
+// Multivariate client for multiple correlated signals
+MultivariateClient multivariateClient = new AnomalyDetectorClientBuilder()
+    .credential(new AzureKeyCredential(key))
+    .endpoint(endpoint)
+    .buildMultivariateClient();
+```
+
+### With DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+UnivariateClient univariateClient = new AnomalyDetectorClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildUnivariateClient();
+
+MultivariateClient multivariateClient = new AnomalyDetectorClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildMultivariateClient();
+```
+
+### Async Clients
+
+```java
+import com.azure.ai.anomalydetector.UnivariateAsyncClient;
+import com.azure.ai.anomalydetector.MultivariateAsyncClient;
+
+UnivariateAsyncClient univariateAsyncClient = new AnomalyDetectorClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildUnivariateAsyncClient();
+
+MultivariateAsyncClient multivariateAsyncClient = new AnomalyDetectorClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildMultivariateAsyncClient();
+```
+
+## Univariate Detection
+
+### Batch Detection (Entire Series)
+
+Detect anomalies across an entire time series at once.
+
+```java
+import com.azure.ai.anomalydetector.models.*;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+// Prepare time series data (minimum 12 points required)
+List<TimeSeriesPoint> series = new ArrayList<>();
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-01T00:00:00Z"), 826.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-02T00:00:00Z"), 799.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-03T00:00:00Z"), 890.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-04T00:00:00Z"), 900.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-05T00:00:00Z"), 961.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-06T00:00:00Z"), 935.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-07T00:00:00Z"), 894.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-08T00:00:00Z"), 855.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-09T00:00:00Z"), 809.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-10T00:00:00Z"), 810.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-11T00:00:00Z"), 766.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-12T00:00:00Z"), 805.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-13T00:00:00Z"), 821.0));
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-14T00:00:00Z"), 2000.0)); // Anomaly!
+series.add(new TimeSeriesPoint(OffsetDateTime.parse("2023-01-15T00:00:00Z"), 888.0));
+
+// Configure detection options
+UnivariateDetectionOptions options = new UnivariateDetectionOptions(series)
+    .setGranularity(TimeGranularity.DAILY)
+    .setSensitivity(95);  // Higher = more sensitive (0-99)
+
+// Detect anomalies
+UnivariateEntireDetectionResult result = univariateClient.detectUnivariateEntireSeries(options);
+
+// Process results
+System.out.println("=== Anomaly Detection Results ===");
+System.out.println("Period: " + result.getPeriod());
+
+for (int i = 0; i < result.getIsAnomaly().size(); i++) {
+    if (result.getIsAnomaly().get(i)) {
+        TimeSeriesPoint point = series.get(i);
+        System.out.printf("ANOMALY at %s: value=%.2f, expected=%.2f, upper=%.2f, lower=%.2f%n",
+            point.getTimestamp(),
+            point.getValue(),
+            result.getExpectedValues().get(i),
+            result.getUpperMargins().get(i),
+            result.getLowerMargins().get(i));
+    }
+}
+
+// Check positive/negative anomalies
+for (int i = 0; i < result.getIsPositiveAnomaly().size(); i++) {
+    if (result.getIsPositiveAnomaly().get(i)) {
+        System.out.printf("Positive anomaly (spike) at index %d%n", i);
+    }
+    if (result.getIsNegativeAnomaly().get(i)) {
+        System.out.printf("Negative anomaly (dip) at index %d%n", i);
+    }
+}
+```
+
+### Custom Period and Sensitivity
+
+```java
+UnivariateDetectionOptions options = new UnivariateDetectionOptions(series)
+    .setGranularity(TimeGranularity.HOURLY)
+    .setCustomInterval(4)           // Custom interval for non-standard granularity
+    .setSensitivity(85)             // Lower sensitivity = fewer anomalies
+    .setImputeMode(ImputeMode.AUTO) // Handle missing values
+    .setImputeFixedValue(0.0);      // Fixed value for imputation (if FIXED mode)
+
+UnivariateEntireDetectionResult result = univariateClient.detectUnivariateEntireSeries(options);
+```
+
+## Univariate Streaming Detection
+
+### Last Point Detection (Real-time)
+
+Detect if the most recent data point is an anomaly.
+
+```java
+// Add your latest data point to the series
+series.add(new TimeSeriesPoint(OffsetDateTime.now(), 1500.0));
+
+UnivariateDetectionOptions options = new UnivariateDetectionOptions(series)
+    .setGranularity(TimeGranularity.DAILY)
+    .setSensitivity(95);
+
+UnivariateLastDetectionResult result = univariateClient.detectUnivariateLastPoint(options);
+
+System.out.println("=== Last Point Detection ===");
+System.out.println("Is Anomaly: " + result.isAnomaly());
+System.out.println("Is Positive Anomaly: " + result.isPositiveAnomaly());
+System.out.println("Is Negative Anomaly: " + result.isNegativeAnomaly());
+System.out.printf("Expected Value: %.2f%n", result.getExpectedValue());
+System.out.printf("Upper Margin: %.2f%n", result.getUpperMargin());
+System.out.printf("Lower Margin: %.2f%n", result.getLowerMargin());
+System.out.println("Severity: " + result.getSeverity());
+
+if (result.isAnomaly()) {
+    System.out.println("⚠️ ALERT: Anomaly detected in latest data point!");
+}
+```
+
+### Streaming Detection Pattern
+
+```java
+public class StreamingAnomalyDetector {
+    
+    private final UnivariateClient client;
+    private final List<TimeSeriesPoint> buffer;
+    private final int windowSize;
+    
+    public StreamingAnomalyDetector(UnivariateClient client, int windowSize) {
+        this.client = client;
+        this.buffer = new ArrayList<>();
+        this.windowSize = windowSize;
+    }
+    
+    public boolean processDataPoint(OffsetDateTime timestamp, double value) {
+        // Add new point
+        buffer.add(new TimeSeriesPoint(timestamp, value));
+        
+        // Keep window size manageable
+        if (buffer.size() > windowSize) {
+            buffer.remove(0);
+        }
+        
+        // Need minimum 12 points for detection
+        if (buffer.size() < 12) {
+            return false;
+        }
+        
+        // Detect anomaly
+        UnivariateDetectionOptions options = new UnivariateDetectionOptions(buffer)
+            .setGranularity(TimeGranularity.MINUTELY)
+            .setSensitivity(90);
+        
+        UnivariateLastDetectionResult result = client.detectUnivariateLastPoint(options);
+        
+        return result.isAnomaly();
+    }
+}
+```
+
+## Change Point Detection
+
+Detect trend changes in time series data.
+
+```java
+UnivariateChangePointDetectionOptions changeOptions = 
+    new UnivariateChangePointDetectionOptions(series, TimeGranularity.DAILY);
+
+UnivariateChangePointDetectionResult result = 
+    univariateClient.detectUnivariateChangePoint(changeOptions);
+
+System.out.println("=== Change Point Detection ===");
+System.out.println("Period: " + result.getPeriod());
+
+int changePointCount = 0;
+for (int i = 0; i < result.getIsChangePoint().size(); i++) {
+    if (result.getIsChangePoint().get(i)) {
+        changePointCount++;
+        TimeSeriesPoint point = series.get(i);
+        System.out.printf("Change point at %s (confidence: %.2f)%n",
+            point.getTimestamp(),
+            result.getConfidenceScores().get(i));
+    }
+}
+System.out.printf("Total change points detected: %d%n", changePointCount);
+```
+
+## Multivariate Model Training
+
+Train a model on multiple correlated variables.
+
+### Prepare Training Data
+
+Data must be in a ZIP file in Azure Blob Storage with CSV files for each variable:
+
+```
+training-data.zip
+├── variable1.csv
+├── variable2.csv
+└── variable3.csv
+```
+
+Each CSV format:
+```csv
+timestamp,value
+2023-01-01T00:00:00Z,100.5
+2023-01-01T01:00:00Z,102.3
+...
+```
+
+### Train Model
+
+```java
+import com.azure.ai.anomalydetector.models.*;
+import java.time.OffsetDateTime;
+
+String blobSasUrl = "https://storage.blob.core.windows.net/container/training-data.zip?sasToken";
+
+ModelInfo modelInfo = new ModelInfo()
+    .setDataSource(blobSasUrl)
+    .setStartTime(OffsetDateTime.parse("2023-01-01T00:00:00Z"))
+    .setEndTime(OffsetDateTime.parse("2023-06-01T00:00:00Z"))
+    .setSlidingWindow(200)  // Window size for pattern detection
+    .setAlignPolicy(new AlignPolicy()
+        .setAlignMode(AlignMode.OUTER)
+        .setFillNAMethod(FillNAMethod.LINEAR))
+    .setDisplayName("MyMultivariateModel");
+
+// Start training (long-running operation)
+AnomalyDetectionModel trainedModel = multivariateClient.trainMultivariateModel(modelInfo);
+
+String modelId = trainedModel.getModelId();
+System.out.println("Model ID: " + modelId);
+
+// Poll for training completion
+AnomalyDetectionModel model;
+do {
+    Thread.sleep(10000); // Wait 10 seconds
+    model = multivariateClient.getMultivariateModel(modelId);
+    System.out.println("Training status: " + model.getModelInfo().getStatus());
+} while (model.getModelInfo().getStatus() == ModelStatus.CREATED 
+      || model.getModelInfo().getStatus() == ModelStatus.RUNNING);
+
+if (model.getModelInfo().getStatus() == ModelStatus.READY) {
+    System.out.println("Model trained successfully!");
+    System.out.println("Variables used: " + model.getModelInfo().getVariableStates().size());
+} else {
+    System.err.println("Training failed: " + model.getModelInfo().getErrors());
+}
+```
+
+## Multivariate Batch Inference
+
+Detect anomalies across multiple variables at once.
+
+```java
+String inferenceDataUrl = "https://storage.blob.core.windows.net/container/inference-data.zip?sasToken";
+
+MultivariateBatchDetectionOptions detectionOptions = new MultivariateBatchDetectionOptions()
+    .setDataSource(inferenceDataUrl)
+    .setStartTime(OffsetDateTime.parse("2023-07-01T00:00:00Z"))
+    .setEndTime(OffsetDateTime.parse("2023-07-31T00:00:00Z"))
+    .setTopContributorCount(10);  // Top contributing variables to show
+
+// Start batch detection
+MultivariateDetectionResult detectionResult = 
+    multivariateClient.detectMultivariateBatchAnomaly(modelId, detectionOptions);
+
+String resultId = detectionResult.getResultId();
+System.out.println("Detection started, result ID: " + resultId);
+
+// Poll for results
+MultivariateDetectionResult result;
+do {
+    Thread.sleep(5000);
+    result = multivariateClient.getBatchDetectionResult(resultId);
+    System.out.println("Detection status: " + result.getSummary().getStatus());
+} while (result.getSummary().getStatus() == MultivariateBatchDetectionStatus.CREATED
+      || result.getSummary().getStatus() == MultivariateBatchDetectionStatus.RUNNING);
+
+// Process results
+if (result.getSummary().getStatus() == MultivariateBatchDetectionStatus.READY) {
+    System.out.println("=== Multivariate Anomaly Detection Results ===");
+    
+    int anomalyCount = 0;
+    for (AnomalyState state : result.getResults()) {
+        if (state.getValue().isAnomaly()) {
+            anomalyCount++;
+            System.out.printf("Anomaly at %s, severity: %.4f%n",
+                state.getTimestamp(),
+                state.getValue().getSeverity());
+            
+            // Show contributing variables
+            if (state.getValue().getInterpretation() != null) {
+                System.out.println("  Contributing variables:");
+                for (AnomalyInterpretation interp : state.getValue().getInterpretation()) {
+                    System.out.printf("    - %s: %.4f%n",
+                        interp.getVariable(),
+                        interp.getContributionScore());
+                }
+            }
+        }
+    }
+    System.out.printf("Total anomalies detected: %d%n", anomalyCount);
+}
+```
+
+## Multivariate Last Point Detection
+
+Real-time detection for multivariate data.
+
+```java
+import java.util.Arrays;
+
+// Prepare latest data point for each variable
+List<VariableValues> variables = Arrays.asList(
+    new VariableValues("temperature", 
+        Arrays.asList("2023-07-15T12:00:00Z"), 
+        Arrays.asList(85.5f)),
+    new VariableValues("pressure", 
+        Arrays.asList("2023-07-15T12:00:00Z"), 
+        Arrays.asList(1013.2f)),
+    new VariableValues("humidity", 
+        Arrays.asList("2023-07-15T12:00:00Z"), 
+        Arrays.asList(65.0f))
+);
+
+MultivariateLastDetectionOptions lastOptions = new MultivariateLastDetectionOptions()
+    .setVariables(variables)
+    .setTopContributorCount(5);
+
+MultivariateLastDetectionResult lastResult = 
+    multivariateClient.detectMultivariateLastAnomaly(modelId, lastOptions);
+
+System.out.println("=== Multivariate Last Point Detection ===");
+System.out.println("Is Anomaly: " + lastResult.getValue().isAnomaly());
+System.out.printf("Severity: %.4f%n", lastResult.getValue().getSeverity());
+System.out.printf("Score: %.4f%n", lastResult.getValue().getScore());
+
+if (lastResult.getValue().isAnomaly()) {
+    System.out.println("Contributing variables:");
+    for (AnomalyInterpretation interp : lastResult.getValue().getInterpretation()) {
+        System.out.printf("  - %s: contribution=%.4f, value=%.2f, expected=%.2f%n",
+            interp.getVariable(),
+            interp.getContributionScore(),
+            interp.getCorrelationChanges().getChangedValues().get(0),
+            interp.getCorrelationChanges().getExpectedValues().get(0));
+    }
+}
+```
+
+## Model Management
+
+### List Models
+
+```java
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<AnomalyDetectionModel> models = multivariateClient.listMultivariateModels();
+
+System.out.println("=== Available Models ===");
+for (AnomalyDetectionModel m : models) {
+    System.out.printf("Model: %s, Status: %s, Created: %s%n",
+        m.getModelId(),
+        m.getModelInfo().getStatus(),
+        m.getCreatedTime());
+}
+```
+
+### Get Model Details
+
+```java
+AnomalyDetectionModel model = multivariateClient.getMultivariateModel(modelId);
+
+System.out.println("=== Model Details ===");
+System.out.println("Model ID: " + model.getModelId());
+System.out.println("Display Name: " + model.getModelInfo().getDisplayName());
+System.out.println("Status: " + model.getModelInfo().getStatus());
+System.out.println("Created: " + model.getCreatedTime());
+System.out.println("Last Updated: " + model.getLastUpdatedTime());
+System.out.println("Sliding Window: " + model.getModelInfo().getSlidingWindow());
+
+// Variable states
+System.out.println("Variables:");
+for (VariableState vs : model.getModelInfo().getVariableStates()) {
+    System.out.printf("  - %s: effective=%d, missing=%.2f%%%n",
+        vs.getVariable(),
+        vs.getEffectiveCount(),
+        vs.getMissingRatio() * 100);
+}
+```
+
+### Delete Model
+
+```java
+multivariateClient.deleteMultivariateModel(modelId);
+System.out.println("Model deleted: " + modelId);
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    UnivariateDetectionOptions options = new UnivariateDetectionOptions(series)
+        .setGranularity(TimeGranularity.DAILY);
+    
+    univariateClient.detectUnivariateEntireSeries(options);
+    
+} catch (HttpResponseException e) {
+    int statusCode = e.getResponse().getStatusCode();
+    System.err.println("HTTP Status: " + statusCode);
+    System.err.println("Error: " + e.getMessage());
+    
+    switch (statusCode) {
+        case 400:
+            System.err.println("Bad request - check data format and minimum points (12 required)");
+            break;
+        case 401:
+            System.err.println("Unauthorized - check API key");
+            break;
+        case 404:
+            System.err.println("Model not found");
+            break;
+        case 429:
+            System.err.println("Rate limited - implement retry with backoff");
+            break;
+        default:
+            System.err.println("Unexpected error");
+    }
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+## Complete Application Example
+
+```java
+import com.azure.ai.anomalydetector.AnomalyDetectorClientBuilder;
+import com.azure.ai.anomalydetector.UnivariateClient;
+import com.azure.ai.anomalydetector.models.*;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+public class MetricsAnomalyDetector {
+    
+    private final UnivariateClient client;
+    private final int sensitivity;
+    
+    public MetricsAnomalyDetector(int sensitivity) {
+        this.client = new AnomalyDetectorClientBuilder()
+            .endpoint(System.getenv("AZURE_ANOMALY_DETECTOR_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildUnivariateClient();
+        this.sensitivity = sensitivity;
+    }
+    
+    public List<AnomalyResult> detectAnomalies(List<MetricDataPoint> metrics) {
+        // Convert to time series points
+        List<TimeSeriesPoint> series = new ArrayList<>();
+        for (MetricDataPoint metric : metrics) {
+            series.add(new TimeSeriesPoint(metric.timestamp, metric.value));
+        }
+        
+        // Detect anomalies
+        UnivariateDetectionOptions options = new UnivariateDetectionOptions(series)
+            .setGranularity(TimeGranularity.MINUTELY)
+            .setSensitivity(sensitivity);
+        
+        UnivariateEntireDetectionResult result = client.detectUnivariateEntireSeries(options);
+        
+        // Build results
+        List<AnomalyResult> anomalies = new ArrayList<>();
+        for (int i = 0; i < result.getIsAnomaly().size(); i++) {
+            if (result.getIsAnomaly().get(i)) {
+                anomalies.add(new AnomalyResult(
+                    metrics.get(i).timestamp,
+                    metrics.get(i).value,
+                    result.getExpectedValues().get(i),
+                    result.getUpperMargins().get(i),
+                    result.getLowerMargins().get(i),
+                    result.getIsPositiveAnomaly().get(i) ? "SPIKE" : "DIP"
+                ));
+            }
+        }
+        
+        return anomalies;
+    }
+    
+    public boolean isLatestPointAnomaly(List<MetricDataPoint> metrics) {
+        List<TimeSeriesPoint> series = new ArrayList<>();
+        for (MetricDataPoint metric : metrics) {
+            series.add(new TimeSeriesPoint(metric.timestamp, metric.value));
+        }
+        
+        UnivariateDetectionOptions options = new UnivariateDetectionOptions(series)
+            .setGranularity(TimeGranularity.MINUTELY)
+            .setSensitivity(sensitivity);
+        
+        UnivariateLastDetectionResult result = client.detectUnivariateLastPoint(options);
+        return result.isAnomaly();
+    }
+    
+    // Data classes
+    public static class MetricDataPoint {
+        public final OffsetDateTime timestamp;
+        public final double value;
+        
+        public MetricDataPoint(OffsetDateTime timestamp, double value) {
+            this.timestamp = timestamp;
+            this.value = value;
+        }
+    }
+    
+    public static class AnomalyResult {
+        public final OffsetDateTime timestamp;
+        public final double actualValue;
+        public final double expectedValue;
+        public final double upperBound;
+        public final double lowerBound;
+        public final String type;
+        
+        public AnomalyResult(OffsetDateTime timestamp, double actualValue, 
+                           double expectedValue, double upperBound, 
+                           double lowerBound, String type) {
+            this.timestamp = timestamp;
+            this.actualValue = actualValue;
+            this.expectedValue = expectedValue;
+            this.upperBound = upperBound;
+            this.lowerBound = lowerBound;
+            this.type = type;
+        }
+        
+        @Override
+        public String toString() {
+            return String.format("[%s] %s: actual=%.2f, expected=%.2f (bounds: %.2f - %.2f)",
+                timestamp, type, actualValue, expectedValue, lowerBound, upperBound);
+        }
+    }
+    
+    public static void main(String[] args) {
+        MetricsAnomalyDetector detector = new MetricsAnomalyDetector(90);
+        
+        // Generate sample data with an anomaly
+        List<MetricDataPoint> metrics = new ArrayList<>();
+        OffsetDateTime baseTime = OffsetDateTime.now().minusHours(1);
+        Random random = new Random();
+        
+        for (int i = 0; i < 60; i++) {
+            double value = 100 + random.nextGaussian() * 5;
+            
+            // Inject anomaly at minute 45
+            if (i == 45) {
+                value = 200;
+            }
+            
+            metrics.add(new MetricDataPoint(
+                baseTime.plus(i, ChronoUnit.MINUTES),
+                value
+            ));
+        }
+        
+        // Detect anomalies
+        List<AnomalyResult> anomalies = detector.detectAnomalies(metrics);
+        
+        System.out.println("=== Detected Anomalies ===");
+        for (AnomalyResult anomaly : anomalies) {
+            System.out.println(anomaly);
+        }
+        
+        // Check latest point
+        boolean isLatestAnomaly = detector.isLatestPointAnomaly(metrics);
+        System.out.println("\nLatest point is anomaly: " + isLatestAnomaly);
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_ANOMALY_DETECTOR_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+AZURE_ANOMALY_DETECTOR_API_KEY=<your-api-key>
+
+# For DefaultAzureCredential
+AZURE_CLIENT_ID=<service-principal-client-id>
+AZURE_CLIENT_SECRET=<service-principal-secret>
+AZURE_TENANT_ID=<tenant-id>
+```
+
+## Best Practices
+
+1. **Minimum data points** — Univariate requires at least 12 points; more data improves accuracy
+2. **Match granularity** — Set `TimeGranularity` to match your actual data frequency
+3. **Tune sensitivity** — Higher values (0-99) detect more anomalies; tune based on use case
+4. **Multivariate training** — Use 200-1000 sliding window based on pattern complexity
+5. **Handle missing data** — Use `ImputeMode` to handle gaps in time series
+6. **Use streaming for real-time** — `detectUnivariateLastPoint` for continuous monitoring
+7. **Check contributing variables** — For multivariate, analyze which variables caused the anomaly
+8. **Implement retry logic** — Handle rate limiting with exponential backoff

--- a/skills/java/ai/contentsafety/SKILL.md
+++ b/skills/java/ai/contentsafety/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: azure-ai-contentsafety-java
+description: Build content moderation applications with Azure AI Content Safety SDK for Java. Use when implementing text/image analysis, blocklist management, or harm detection for hate, violence, sexual content, and self-harm.
+---
+
+# Azure AI Content Safety SDK for Java
+
+Build content moderation applications using the Azure AI Content Safety SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-contentsafety</artifactId>
+    <version>1.1.0-beta.1</version>
+</dependency>
+```
+
+## Client Creation
+
+### With API Key
+
+```java
+import com.azure.ai.contentsafety.ContentSafetyClient;
+import com.azure.ai.contentsafety.ContentSafetyClientBuilder;
+import com.azure.ai.contentsafety.BlocklistClient;
+import com.azure.ai.contentsafety.BlocklistClientBuilder;
+import com.azure.core.credential.KeyCredential;
+
+String endpoint = System.getenv("CONTENT_SAFETY_ENDPOINT");
+String key = System.getenv("CONTENT_SAFETY_KEY");
+
+ContentSafetyClient contentSafetyClient = new ContentSafetyClientBuilder()
+    .credential(new KeyCredential(key))
+    .endpoint(endpoint)
+    .buildClient();
+
+BlocklistClient blocklistClient = new BlocklistClientBuilder()
+    .credential(new KeyCredential(key))
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+ContentSafetyClient client = new ContentSafetyClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+## Key Concepts
+
+### Harm Categories
+| Category | Description |
+|----------|-------------|
+| Hate | Discriminatory language based on identity groups |
+| Sexual | Sexual content, relationships, acts |
+| Violence | Physical harm, weapons, injury |
+| Self-harm | Self-injury, suicide-related content |
+
+### Severity Levels
+- Text: 0-7 scale (default outputs 0, 2, 4, 6)
+- Image: 0, 2, 4, 6 (trimmed scale)
+
+## Core Patterns
+
+### Analyze Text
+
+```java
+import com.azure.ai.contentsafety.models.*;
+
+AnalyzeTextResult result = contentSafetyClient.analyzeText(
+    new AnalyzeTextOptions("This is text to analyze"));
+
+for (TextCategoriesAnalysis category : result.getCategoriesAnalysis()) {
+    System.out.printf("Category: %s, Severity: %d%n",
+        category.getCategory(),
+        category.getSeverity());
+}
+```
+
+### Analyze Text with Options
+
+```java
+AnalyzeTextOptions options = new AnalyzeTextOptions("Text to analyze")
+    .setCategories(Arrays.asList(
+        TextCategory.HATE,
+        TextCategory.VIOLENCE))
+    .setOutputType(AnalyzeTextOutputType.EIGHT_SEVERITY_LEVELS);
+
+AnalyzeTextResult result = contentSafetyClient.analyzeText(options);
+```
+
+### Analyze Text with Blocklist
+
+```java
+AnalyzeTextOptions options = new AnalyzeTextOptions("I h*te you and want to k*ll you")
+    .setBlocklistNames(Arrays.asList("my-blocklist"))
+    .setHaltOnBlocklistHit(true);
+
+AnalyzeTextResult result = contentSafetyClient.analyzeText(options);
+
+if (result.getBlocklistsMatch() != null) {
+    for (TextBlocklistMatch match : result.getBlocklistsMatch()) {
+        System.out.printf("Blocklist: %s, Item: %s, Text: %s%n",
+            match.getBlocklistName(),
+            match.getBlocklistItemId(),
+            match.getBlocklistItemText());
+    }
+}
+```
+
+### Analyze Image
+
+```java
+import com.azure.ai.contentsafety.models.*;
+import com.azure.core.util.BinaryData;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+// From file
+byte[] imageBytes = Files.readAllBytes(Paths.get("image.png"));
+ContentSafetyImageData imageData = new ContentSafetyImageData()
+    .setContent(BinaryData.fromBytes(imageBytes));
+
+AnalyzeImageResult result = contentSafetyClient.analyzeImage(
+    new AnalyzeImageOptions(imageData));
+
+for (ImageCategoriesAnalysis category : result.getCategoriesAnalysis()) {
+    System.out.printf("Category: %s, Severity: %d%n",
+        category.getCategory(),
+        category.getSeverity());
+}
+```
+
+### Analyze Image from URL
+
+```java
+ContentSafetyImageData imageData = new ContentSafetyImageData()
+    .setBlobUrl("https://example.com/image.jpg");
+
+AnalyzeImageResult result = contentSafetyClient.analyzeImage(
+    new AnalyzeImageOptions(imageData));
+```
+
+## Blocklist Management
+
+### Create or Update Blocklist
+
+```java
+import com.azure.core.http.rest.RequestOptions;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import java.util.Map;
+
+Map<String, String> description = Map.of("description", "Custom blocklist");
+BinaryData resource = BinaryData.fromObject(description);
+
+Response<BinaryData> response = blocklistClient.createOrUpdateTextBlocklistWithResponse(
+    "my-blocklist", resource, new RequestOptions());
+
+if (response.getStatusCode() == 201) {
+    System.out.println("Blocklist created");
+} else if (response.getStatusCode() == 200) {
+    System.out.println("Blocklist updated");
+}
+```
+
+### Add Block Items
+
+```java
+import com.azure.ai.contentsafety.models.*;
+import java.util.Arrays;
+
+List<TextBlocklistItem> items = Arrays.asList(
+    new TextBlocklistItem("badword1").setDescription("Offensive term"),
+    new TextBlocklistItem("badword2").setDescription("Another term")
+);
+
+AddOrUpdateTextBlocklistItemsResult result = blocklistClient.addOrUpdateBlocklistItems(
+    "my-blocklist",
+    new AddOrUpdateTextBlocklistItemsOptions(items));
+
+for (TextBlocklistItem item : result.getBlocklistItems()) {
+    System.out.printf("Added: %s (ID: %s)%n",
+        item.getText(),
+        item.getBlocklistItemId());
+}
+```
+
+### List Blocklists
+
+```java
+PagedIterable<TextBlocklist> blocklists = blocklistClient.listTextBlocklists();
+
+for (TextBlocklist blocklist : blocklists) {
+    System.out.printf("Blocklist: %s, Description: %s%n",
+        blocklist.getName(),
+        blocklist.getDescription());
+}
+```
+
+### Get Blocklist
+
+```java
+TextBlocklist blocklist = blocklistClient.getTextBlocklist("my-blocklist");
+System.out.println("Name: " + blocklist.getName());
+```
+
+### List Block Items
+
+```java
+PagedIterable<TextBlocklistItem> items = 
+    blocklistClient.listTextBlocklistItems("my-blocklist");
+
+for (TextBlocklistItem item : items) {
+    System.out.printf("ID: %s, Text: %s%n",
+        item.getBlocklistItemId(),
+        item.getText());
+}
+```
+
+### Remove Block Items
+
+```java
+List<String> itemIds = Arrays.asList("item-id-1", "item-id-2");
+
+blocklistClient.removeBlocklistItems(
+    "my-blocklist",
+    new RemoveTextBlocklistItemsOptions(itemIds));
+```
+
+### Delete Blocklist
+
+```java
+blocklistClient.deleteTextBlocklist("my-blocklist");
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    contentSafetyClient.analyzeText(new AnalyzeTextOptions("test"));
+} catch (HttpResponseException e) {
+    System.out.println("Status: " + e.getResponse().getStatusCode());
+    System.out.println("Error: " + e.getMessage());
+    // Common codes: InvalidRequestBody, ResourceNotFound, TooManyRequests
+}
+```
+
+## Environment Variables
+
+```bash
+CONTENT_SAFETY_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+CONTENT_SAFETY_KEY=<your-api-key>
+```
+
+## Best Practices
+
+1. **Blocklist Delay**: Changes take ~5 minutes to take effect
+2. **Category Selection**: Only request needed categories to reduce latency
+3. **Severity Thresholds**: Typically block severity >= 4 for strict moderation
+4. **Batch Processing**: Process multiple items in parallel for throughput
+5. **Caching**: Cache blocklist results where appropriate
+
+## Trigger Phrases
+
+- "content safety Java"
+- "content moderation Azure"
+- "analyze text safety"
+- "image moderation Java"
+- "blocklist management"
+- "hate speech detection"
+- "harmful content filter"

--- a/skills/java/ai/contentsafety/references/examples.md
+++ b/skills/java/ai/contentsafety/references/examples.md
@@ -1,0 +1,500 @@
+# Azure AI Content Safety SDK for Java - Examples
+
+Comprehensive code examples for the Azure AI Content Safety SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Analyzing Text Content](#analyzing-text-content)
+- [Analyzing Image Content](#analyzing-image-content)
+- [Handling Analysis Results](#handling-analysis-results)
+- [Blocklist Management](#blocklist-management)
+- [Async Client Patterns](#async-client-patterns)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-contentsafety</artifactId>
+    <version>1.0.16</version>
+</dependency>
+
+<!-- For DefaultAzureCredential authentication -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### With API Key Credential
+
+```java
+import com.azure.ai.contentsafety.ContentSafetyClient;
+import com.azure.ai.contentsafety.ContentSafetyClientBuilder;
+import com.azure.ai.contentsafety.BlocklistClient;
+import com.azure.ai.contentsafety.BlocklistClientBuilder;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.util.Configuration;
+
+String endpoint = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_ENDPOINT");
+String key = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_KEY");
+
+// Content Safety client
+ContentSafetyClient contentSafetyClient = new ContentSafetyClientBuilder()
+    .credential(new KeyCredential(key))
+    .endpoint(endpoint)
+    .buildClient();
+
+// Blocklist client
+BlocklistClient blocklistClient = new BlocklistClientBuilder()
+    .credential(new KeyCredential(key))
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+### With DefaultAzureCredential (Microsoft Entra ID)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// Set environment variables: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
+ContentSafetyClient contentSafetyClient = new ContentSafetyClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildClient();
+
+BlocklistClient blocklistClient = new BlocklistClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+## Analyzing Text Content
+
+```java
+import com.azure.ai.contentsafety.ContentSafetyClient;
+import com.azure.ai.contentsafety.ContentSafetyClientBuilder;
+import com.azure.ai.contentsafety.models.AnalyzeTextOptions;
+import com.azure.ai.contentsafety.models.AnalyzeTextResult;
+import com.azure.ai.contentsafety.models.TextCategoriesAnalysis;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.util.Configuration;
+
+public class AnalyzeText {
+    public static void main(String[] args) {
+        String endpoint = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_ENDPOINT");
+        String key = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_KEY");
+
+        ContentSafetyClient contentSafetyClient = new ContentSafetyClientBuilder()
+            .credential(new KeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        // Analyze text
+        AnalyzeTextResult response = contentSafetyClient.analyzeText(
+            new AnalyzeTextOptions("This is text example")
+        );
+
+        // Process results - iterate through harm categories
+        for (TextCategoriesAnalysis result : response.getCategoriesAnalysis()) {
+            System.out.println(result.getCategory() + " severity: " + result.getSeverity());
+        }
+    }
+}
+```
+
+## Analyzing Image Content
+
+```java
+import com.azure.ai.contentsafety.ContentSafetyClient;
+import com.azure.ai.contentsafety.ContentSafetyClientBuilder;
+import com.azure.ai.contentsafety.models.AnalyzeImageOptions;
+import com.azure.ai.contentsafety.models.AnalyzeImageResult;
+import com.azure.ai.contentsafety.models.ContentSafetyImageData;
+import com.azure.ai.contentsafety.models.ImageCategoriesAnalysis;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.Configuration;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class AnalyzeImage {
+    public static void main(String[] args) throws IOException {
+        String endpoint = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_ENDPOINT");
+        String key = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_KEY");
+
+        ContentSafetyClient contentSafetyClient = new ContentSafetyClientBuilder()
+            .credential(new KeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        // Load image from file
+        ContentSafetyImageData image = new ContentSafetyImageData();
+        String cwd = System.getProperty("user.dir");
+        String source = "/src/samples/resources/image.png";
+        image.setContent(BinaryData.fromBytes(Files.readAllBytes(Paths.get(cwd, source))));
+
+        // Analyze image
+        AnalyzeImageResult response = contentSafetyClient.analyzeImage(
+            new AnalyzeImageOptions(image)
+        );
+
+        // Process results - iterate through harm categories
+        for (ImageCategoriesAnalysis result : response.getCategoriesAnalysis()) {
+            System.out.println(result.getCategory() + " severity: " + result.getSeverity());
+        }
+    }
+}
+```
+
+## Handling Analysis Results
+
+### Severity Levels and Content Moderation
+
+```java
+import com.azure.ai.contentsafety.ContentSafetyClient;
+import com.azure.ai.contentsafety.ContentSafetyClientBuilder;
+import com.azure.ai.contentsafety.models.*;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.util.Configuration;
+
+public class HandleAnalysisResults {
+    
+    // Severity thresholds for content moderation decisions
+    private static final int SEVERITY_SAFE = 0;
+    private static final int SEVERITY_LOW = 2;
+    private static final int SEVERITY_MEDIUM = 4;
+    private static final int SEVERITY_HIGH = 6;
+    
+    public static void main(String[] args) {
+        String endpoint = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_ENDPOINT");
+        String key = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_KEY");
+
+        ContentSafetyClient client = new ContentSafetyClientBuilder()
+            .credential(new KeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        String textToAnalyze = "Sample text to analyze for harmful content";
+        
+        AnalyzeTextResult result = client.analyzeText(new AnalyzeTextOptions(textToAnalyze));
+        
+        // Process each harm category
+        for (TextCategoriesAnalysis categoryResult : result.getCategoriesAnalysis()) {
+            TextCategory category = categoryResult.getCategory();
+            Integer severity = categoryResult.getSeverity();
+            
+            System.out.println("Category: " + category);
+            System.out.println("Severity: " + severity);
+            
+            // Make moderation decisions based on severity
+            // Categories: HATE, SEXUAL, VIOLENCE, SELF_HARM
+            String action = determineModerationAction(severity);
+            System.out.println("Recommended Action: " + action);
+            System.out.println("---");
+        }
+        
+        // Check if content should be blocked
+        boolean shouldBlock = shouldBlockContent(result);
+        System.out.println("Block Content: " + shouldBlock);
+    }
+    
+    private static String determineModerationAction(Integer severity) {
+        if (severity == null) {
+            return "UNKNOWN";
+        }
+        
+        if (severity <= SEVERITY_SAFE) {
+            return "ALLOW - Content is safe";
+        } else if (severity <= SEVERITY_LOW) {
+            return "REVIEW - Low severity, may need human review";
+        } else if (severity <= SEVERITY_MEDIUM) {
+            return "FLAG - Medium severity, requires attention";
+        } else {
+            return "BLOCK - High severity, should be blocked";
+        }
+    }
+    
+    private static boolean shouldBlockContent(AnalyzeTextResult result) {
+        for (TextCategoriesAnalysis categoryResult : result.getCategoriesAnalysis()) {
+            Integer severity = categoryResult.getSeverity();
+            if (severity != null && severity >= SEVERITY_MEDIUM) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+```
+
+## Blocklist Management
+
+### Create or Update Blocklist
+
+```java
+import com.azure.ai.contentsafety.BlocklistClient;
+import com.azure.ai.contentsafety.BlocklistClientBuilder;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.http.rest.RequestOptions;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+String endpoint = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_ENDPOINT");
+String key = Configuration.getGlobalConfiguration().get("CONTENT_SAFETY_KEY");
+
+BlocklistClient blocklistClient = new BlocklistClientBuilder()
+    .credential(new KeyCredential(key))
+    .endpoint(endpoint)
+    .buildClient();
+
+// Create or update blocklist
+String blocklistName = "TestBlocklist";
+Map<String, String> description = new HashMap<>();
+description.put("description", "Test Blocklist");
+BinaryData resource = BinaryData.fromObject(description);
+RequestOptions requestOptions = new RequestOptions();
+
+Response<BinaryData> response = blocklistClient
+    .createOrUpdateTextBlocklistWithResponse(blocklistName, resource, requestOptions);
+
+if (response.getStatusCode() == 201) {
+    System.out.println("Blocklist " + blocklistName + " created.");
+} else if (response.getStatusCode() == 200) {
+    System.out.println("Blocklist " + blocklistName + " updated.");
+}
+```
+
+### Add Blocklist Items
+
+```java
+import com.azure.ai.contentsafety.models.AddOrUpdateTextBlocklistItemsOptions;
+import com.azure.ai.contentsafety.models.AddOrUpdateTextBlocklistItemsResult;
+import com.azure.ai.contentsafety.models.TextBlocklistItem;
+
+import java.util.Arrays;
+import java.util.List;
+
+String blockItemText1 = "k*ll";
+String blockItemText2 = "h*te";
+List<TextBlocklistItem> blockItems = Arrays.asList(
+    new TextBlocklistItem(blockItemText1).setDescription("Kill word"),
+    new TextBlocklistItem(blockItemText2).setDescription("Hate word")
+);
+
+AddOrUpdateTextBlocklistItemsResult addedBlockItems = blocklistClient.addOrUpdateBlocklistItems(
+    blocklistName,
+    new AddOrUpdateTextBlocklistItemsOptions(blockItems)
+);
+
+if (addedBlockItems != null && addedBlockItems.getBlocklistItems() != null) {
+    System.out.println("BlockItems added:");
+    for (TextBlocklistItem addedBlockItem : addedBlockItems.getBlocklistItems()) {
+        System.out.println("BlockItemId: " + addedBlockItem.getBlocklistItemId() 
+            + ", Text: " + addedBlockItem.getText() 
+            + ", Description: " + addedBlockItem.getDescription());
+    }
+}
+```
+
+### Analyze Text with Blocklist
+
+```java
+import com.azure.ai.contentsafety.ContentSafetyClient;
+import com.azure.ai.contentsafety.models.AnalyzeTextOptions;
+import com.azure.ai.contentsafety.models.AnalyzeTextResult;
+import com.azure.ai.contentsafety.models.TextBlocklistMatch;
+
+import java.util.Arrays;
+
+// Note: After editing blocklist, wait ~5 minutes for changes to take effect
+AnalyzeTextOptions request = new AnalyzeTextOptions("I h*te you and I want to k*ll you");
+request.setBlocklistNames(Arrays.asList(blocklistName));
+request.setHaltOnBlocklistHit(true);  // Stop analysis on first blocklist match
+
+AnalyzeTextResult analyzeTextResult = contentSafetyClient.analyzeText(request);
+
+// Check for blocklist matches
+if (analyzeTextResult.getBlocklistsMatch() != null) {
+    System.out.println("Blocklist matches found:");
+    for (TextBlocklistMatch match : analyzeTextResult.getBlocklistsMatch()) {
+        System.out.println("BlocklistName: " + match.getBlocklistName());
+        System.out.println("BlocklistItemId: " + match.getBlocklistItemId());
+        System.out.println("BlocklistItemText: " + match.getBlocklistItemText());
+    }
+}
+```
+
+### Remove Blocklist Items
+
+```java
+import com.azure.ai.contentsafety.models.RemoveTextBlocklistItemsOptions;
+
+import java.util.Arrays;
+import java.util.List;
+
+List<String> blocklistItemIdsToRemove = Arrays.asList(
+    "blocklistItemId1",
+    "blocklistItemId2"
+);
+
+blocklistClient.removeBlocklistItems(
+    blocklistName,
+    new RemoveTextBlocklistItemsOptions(blocklistItemIdsToRemove)
+);
+
+System.out.println("Blocklist items removed.");
+```
+
+### List Blocklists and Items
+
+```java
+import com.azure.ai.contentsafety.models.TextBlocklist;
+import com.azure.ai.contentsafety.models.TextBlocklistItem;
+import com.azure.core.http.rest.PagedIterable;
+
+// List all blocklists
+PagedIterable<TextBlocklist> blocklists = blocklistClient.listTextBlocklists();
+for (TextBlocklist blocklist : blocklists) {
+    System.out.println("Blocklist: " + blocklist.getName());
+    System.out.println("Description: " + blocklist.getDescription());
+}
+
+// List items in a blocklist
+PagedIterable<TextBlocklistItem> items = blocklistClient.listTextBlocklistItems(blocklistName);
+for (TextBlocklistItem item : items) {
+    System.out.println("Item ID: " + item.getBlocklistItemId());
+    System.out.println("Text: " + item.getText());
+    System.out.println("Description: " + item.getDescription());
+}
+```
+
+### Delete Blocklist
+
+```java
+blocklistClient.deleteTextBlocklist(blocklistName);
+System.out.println("Blocklist " + blocklistName + " deleted.");
+```
+
+## Async Client Patterns
+
+### Async Content Safety Client
+
+```java
+import com.azure.ai.contentsafety.ContentSafetyAsyncClient;
+import com.azure.ai.contentsafety.ContentSafetyClientBuilder;
+import com.azure.ai.contentsafety.models.AnalyzeTextOptions;
+import com.azure.core.credential.KeyCredential;
+
+ContentSafetyAsyncClient asyncClient = new ContentSafetyClientBuilder()
+    .credential(new KeyCredential(key))
+    .endpoint(endpoint)
+    .buildAsyncClient();
+
+// Async text analysis
+asyncClient.analyzeText(new AnalyzeTextOptions("Text to analyze"))
+    .subscribe(
+        result -> {
+            result.getCategoriesAnalysis().forEach(category -> {
+                System.out.println(category.getCategory() + ": " + category.getSeverity());
+            });
+        },
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Analysis completed")
+    );
+```
+
+### Async Blocklist Client
+
+```java
+import com.azure.ai.contentsafety.BlocklistAsyncClient;
+import com.azure.ai.contentsafety.BlocklistClientBuilder;
+
+BlocklistAsyncClient asyncBlocklistClient = new BlocklistClientBuilder()
+    .credential(new KeyCredential(key))
+    .endpoint(endpoint)
+    .buildAsyncClient();
+
+// Async list blocklists
+asyncBlocklistClient.listTextBlocklists()
+    .subscribe(
+        blocklist -> System.out.println("Found blocklist: " + blocklist.getName()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.ai.contentsafety.models.AnalyzeTextOptions;
+
+public class ContentSafetyErrorHandling {
+    public static void analyzeWithErrorHandling(ContentSafetyClient client, String text) {
+        try {
+            var result = client.analyzeText(new AnalyzeTextOptions(text));
+            // Process result
+            result.getCategoriesAnalysis().forEach(category -> {
+                System.out.println(category.getCategory() + ": " + category.getSeverity());
+            });
+        } catch (HttpResponseException e) {
+            int statusCode = e.getResponse().getStatusCode();
+            System.err.println("HTTP Status: " + statusCode);
+            System.err.println("Error: " + e.getMessage());
+            
+            switch (statusCode) {
+                case 400:
+                    System.err.println("Bad request - check input parameters");
+                    break;
+                case 401:
+                    System.err.println("Unauthorized - check API key");
+                    break;
+                case 403:
+                    System.err.println("Forbidden - check permissions");
+                    break;
+                case 404:
+                    System.err.println("Resource not found");
+                    break;
+                case 429:
+                    System.err.println("Rate limited - slow down requests");
+                    break;
+                default:
+                    if (statusCode >= 500) {
+                        System.err.println("Server error - retry later");
+                    }
+            }
+        } catch (Exception e) {
+            System.err.println("Unexpected error: " + e.getMessage());
+        }
+    }
+}
+```
+
+### Async Error Handling
+
+```java
+asyncClient.analyzeText(new AnalyzeTextOptions(text))
+    .subscribe(
+        result -> {
+            // Process result
+        },
+        error -> {
+            if (error instanceof HttpResponseException) {
+                HttpResponseException httpError = (HttpResponseException) error;
+                System.err.println("HTTP error: " + httpError.getResponse().getStatusCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        }
+    );
+```

--- a/skills/java/ai/formrecognizer/SKILL.md
+++ b/skills/java/ai/formrecognizer/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: azure-ai-formrecognizer-java
+description: Build document analysis applications with Azure Document Intelligence (Form Recognizer) SDK for Java. Use when extracting text, tables, key-value pairs from documents, receipts, invoices, or building custom document models.
+---
+
+# Azure Document Intelligence (Form Recognizer) SDK for Java
+
+Build document analysis applications using the Azure AI Document Intelligence SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-formrecognizer</artifactId>
+    <version>4.2.0-beta.1</version>
+</dependency>
+```
+
+## Client Creation
+
+### DocumentAnalysisClient
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.DocumentAnalysisClient;
+import com.azure.ai.formrecognizer.documentanalysis.DocumentAnalysisClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+DocumentAnalysisClient client = new DocumentAnalysisClientBuilder()
+    .credential(new AzureKeyCredential("{key}"))
+    .endpoint("{endpoint}")
+    .buildClient();
+```
+
+### DocumentModelAdministrationClient
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.administration.DocumentModelAdministrationClient;
+import com.azure.ai.formrecognizer.documentanalysis.administration.DocumentModelAdministrationClientBuilder;
+
+DocumentModelAdministrationClient adminClient = new DocumentModelAdministrationClientBuilder()
+    .credential(new AzureKeyCredential("{key}"))
+    .endpoint("{endpoint}")
+    .buildClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+DocumentAnalysisClient client = new DocumentAnalysisClientBuilder()
+    .endpoint("{endpoint}")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Prebuilt Models
+
+| Model ID | Purpose |
+|----------|---------|
+| `prebuilt-layout` | Extract text, tables, selection marks |
+| `prebuilt-document` | General document with key-value pairs |
+| `prebuilt-receipt` | Receipt data extraction |
+| `prebuilt-invoice` | Invoice field extraction |
+| `prebuilt-businessCard` | Business card parsing |
+| `prebuilt-idDocument` | ID document (passport, license) |
+| `prebuilt-tax.us.w2` | US W2 tax forms |
+
+## Core Patterns
+
+### Extract Layout
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.models.*;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.SyncPoller;
+import java.io.File;
+
+File document = new File("document.pdf");
+BinaryData documentData = BinaryData.fromFile(document.toPath());
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocument("prebuilt-layout", documentData);
+
+AnalyzeResult result = poller.getFinalResult();
+
+// Process pages
+for (DocumentPage page : result.getPages()) {
+    System.out.printf("Page %d: %.2f x %.2f %s%n",
+        page.getPageNumber(),
+        page.getWidth(),
+        page.getHeight(),
+        page.getUnit());
+    
+    // Lines
+    for (DocumentLine line : page.getLines()) {
+        System.out.println("Line: " + line.getContent());
+    }
+    
+    // Selection marks (checkboxes)
+    for (DocumentSelectionMark mark : page.getSelectionMarks()) {
+        System.out.printf("Checkbox: %s (confidence: %.2f)%n",
+            mark.getSelectionMarkState(),
+            mark.getConfidence());
+    }
+}
+
+// Tables
+for (DocumentTable table : result.getTables()) {
+    System.out.printf("Table: %d rows x %d columns%n",
+        table.getRowCount(),
+        table.getColumnCount());
+    
+    for (DocumentTableCell cell : table.getCells()) {
+        System.out.printf("Cell[%d,%d]: %s%n",
+            cell.getRowIndex(),
+            cell.getColumnIndex(),
+            cell.getContent());
+    }
+}
+```
+
+### Analyze from URL
+
+```java
+String documentUrl = "https://example.com/invoice.pdf";
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("prebuilt-invoice", documentUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+```
+
+### Analyze Receipt
+
+```java
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("prebuilt-receipt", receiptUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument doc : result.getDocuments()) {
+    Map<String, DocumentField> fields = doc.getFields();
+    
+    DocumentField merchantName = fields.get("MerchantName");
+    if (merchantName != null && merchantName.getType() == DocumentFieldType.STRING) {
+        System.out.printf("Merchant: %s (confidence: %.2f)%n",
+            merchantName.getValueAsString(),
+            merchantName.getConfidence());
+    }
+    
+    DocumentField transactionDate = fields.get("TransactionDate");
+    if (transactionDate != null && transactionDate.getType() == DocumentFieldType.DATE) {
+        System.out.printf("Date: %s%n", transactionDate.getValueAsDate());
+    }
+    
+    DocumentField items = fields.get("Items");
+    if (items != null && items.getType() == DocumentFieldType.LIST) {
+        for (DocumentField item : items.getValueAsList()) {
+            Map<String, DocumentField> itemFields = item.getValueAsMap();
+            System.out.printf("Item: %s, Price: %.2f%n",
+                itemFields.get("Name").getValueAsString(),
+                itemFields.get("Price").getValueAsDouble());
+        }
+    }
+}
+```
+
+### General Document Analysis
+
+```java
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("prebuilt-document", documentUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+
+// Key-value pairs
+for (DocumentKeyValuePair kvp : result.getKeyValuePairs()) {
+    System.out.printf("Key: %s => Value: %s%n",
+        kvp.getKey().getContent(),
+        kvp.getValue() != null ? kvp.getValue().getContent() : "null");
+}
+```
+
+## Custom Models
+
+### Build Custom Model
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.administration.models.*;
+
+String blobContainerUrl = "{SAS_URL_of_training_data}";
+String prefix = "training-docs/";
+
+SyncPoller<OperationResult, DocumentModelDetails> poller = adminClient.beginBuildDocumentModel(
+    blobContainerUrl,
+    DocumentModelBuildMode.TEMPLATE,
+    prefix,
+    new BuildDocumentModelOptions()
+        .setModelId("my-custom-model")
+        .setDescription("Custom invoice model"),
+    Context.NONE);
+
+DocumentModelDetails model = poller.getFinalResult();
+
+System.out.println("Model ID: " + model.getModelId());
+System.out.println("Created: " + model.getCreatedOn());
+
+model.getDocumentTypes().forEach((docType, details) -> {
+    System.out.println("Document type: " + docType);
+    details.getFieldSchema().forEach((field, schema) -> {
+        System.out.printf("  Field: %s (%s)%n", field, schema.getType());
+    });
+});
+```
+
+### Analyze with Custom Model
+
+```java
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("my-custom-model", documentUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument doc : result.getDocuments()) {
+    System.out.printf("Document type: %s (confidence: %.2f)%n",
+        doc.getDocType(),
+        doc.getConfidence());
+    
+    doc.getFields().forEach((name, field) -> {
+        System.out.printf("Field '%s': %s (confidence: %.2f)%n",
+            name,
+            field.getContent(),
+            field.getConfidence());
+    });
+}
+```
+
+### Compose Models
+
+```java
+List<String> modelIds = Arrays.asList("model-1", "model-2", "model-3");
+
+SyncPoller<OperationResult, DocumentModelDetails> poller = 
+    adminClient.beginComposeDocumentModel(
+        modelIds,
+        new ComposeDocumentModelOptions()
+            .setModelId("composed-model")
+            .setDescription("Composed from multiple models"));
+
+DocumentModelDetails composedModel = poller.getFinalResult();
+```
+
+### Manage Models
+
+```java
+// List models
+PagedIterable<DocumentModelSummary> models = adminClient.listDocumentModels();
+for (DocumentModelSummary summary : models) {
+    System.out.printf("Model: %s, Created: %s%n",
+        summary.getModelId(),
+        summary.getCreatedOn());
+}
+
+// Get model details
+DocumentModelDetails model = adminClient.getDocumentModel("model-id");
+
+// Delete model
+adminClient.deleteDocumentModel("model-id");
+
+// Check resource limits
+ResourceDetails resources = adminClient.getResourceDetails();
+System.out.printf("Models: %d / %d%n",
+    resources.getCustomDocumentModelCount(),
+    resources.getCustomDocumentModelLimit());
+```
+
+## Document Classification
+
+### Build Classifier
+
+```java
+Map<String, ClassifierDocumentTypeDetails> docTypes = new HashMap<>();
+docTypes.put("invoice", new ClassifierDocumentTypeDetails()
+    .setAzureBlobSource(new AzureBlobContentSource(containerUrl).setPrefix("invoices/")));
+docTypes.put("receipt", new ClassifierDocumentTypeDetails()
+    .setAzureBlobSource(new AzureBlobContentSource(containerUrl).setPrefix("receipts/")));
+
+SyncPoller<OperationResult, DocumentClassifierDetails> poller = 
+    adminClient.beginBuildDocumentClassifier(docTypes,
+        new BuildDocumentClassifierOptions().setClassifierId("my-classifier"));
+
+DocumentClassifierDetails classifier = poller.getFinalResult();
+```
+
+### Classify Document
+
+```java
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginClassifyDocumentFromUrl("my-classifier", documentUrl, Context.NONE);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument doc : result.getDocuments()) {
+    System.out.printf("Classified as: %s (confidence: %.2f)%n",
+        doc.getDocType(),
+        doc.getConfidence());
+}
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    client.beginAnalyzeDocumentFromUrl("prebuilt-receipt", "invalid-url");
+} catch (HttpResponseException e) {
+    System.out.println("Status: " + e.getResponse().getStatusCode());
+    System.out.println("Error: " + e.getMessage());
+}
+```
+
+## Environment Variables
+
+```bash
+FORM_RECOGNIZER_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+FORM_RECOGNIZER_KEY=<your-api-key>
+```
+
+## Trigger Phrases
+
+- "document intelligence Java"
+- "form recognizer SDK"
+- "extract text from PDF"
+- "OCR document Java"
+- "analyze invoice receipt"
+- "custom document model"
+- "document classification"

--- a/skills/java/ai/formrecognizer/references/examples.md
+++ b/skills/java/ai/formrecognizer/references/examples.md
@@ -1,0 +1,795 @@
+# Azure Document Intelligence (Form Recognizer) Java SDK - Examples
+
+Comprehensive code examples for the Azure AI Document Intelligence SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Prebuilt Models](#prebuilt-models)
+- [Layout Analysis](#layout-analysis)
+- [Receipt Analysis](#receipt-analysis)
+- [Invoice Analysis](#invoice-analysis)
+- [ID Document Analysis](#id-document-analysis)
+- [Custom Models](#custom-models)
+- [Document Classification](#document-classification)
+- [Model Management](#model-management)
+- [Async Patterns](#async-patterns)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-formrecognizer</artifactId>
+    <version>4.2.0-beta.1</version>
+</dependency>
+
+<!-- For DefaultAzureCredential -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### With API Key
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.DocumentAnalysisClient;
+import com.azure.ai.formrecognizer.documentanalysis.DocumentAnalysisClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+String endpoint = System.getenv("FORM_RECOGNIZER_ENDPOINT");
+String key = System.getenv("FORM_RECOGNIZER_KEY");
+
+DocumentAnalysisClient client = new DocumentAnalysisClientBuilder()
+    .credential(new AzureKeyCredential(key))
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+### With DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+DocumentAnalysisClient client = new DocumentAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.DocumentAnalysisAsyncClient;
+
+DocumentAnalysisAsyncClient asyncClient = new DocumentAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+### Administration Client
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.administration.DocumentModelAdministrationClient;
+import com.azure.ai.formrecognizer.documentanalysis.administration.DocumentModelAdministrationClientBuilder;
+
+DocumentModelAdministrationClient adminClient = new DocumentModelAdministrationClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Prebuilt Models
+
+| Model ID | Purpose |
+|----------|---------|
+| `prebuilt-layout` | Extract text, tables, selection marks |
+| `prebuilt-document` | General document with key-value pairs |
+| `prebuilt-receipt` | Receipt data extraction |
+| `prebuilt-invoice` | Invoice field extraction |
+| `prebuilt-businessCard` | Business card parsing |
+| `prebuilt-idDocument` | ID document (passport, license) |
+| `prebuilt-tax.us.w2` | US W2 tax forms |
+
+## Layout Analysis
+
+### Extract Layout from File
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.models.*;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.SyncPoller;
+import java.io.File;
+
+File document = new File("document.pdf");
+BinaryData documentData = BinaryData.fromFile(document.toPath());
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocument("prebuilt-layout", documentData);
+
+AnalyzeResult result = poller.getFinalResult();
+
+// Process pages
+for (DocumentPage page : result.getPages()) {
+    System.out.printf("Page %d: %.2f x %.2f %s%n",
+        page.getPageNumber(),
+        page.getWidth(),
+        page.getHeight(),
+        page.getUnit());
+    
+    // Extract lines
+    for (DocumentLine line : page.getLines()) {
+        System.out.println("Line: " + line.getContent());
+    }
+    
+    // Extract words with confidence
+    for (DocumentWord word : page.getWords()) {
+        System.out.printf("Word: '%s' (confidence: %.2f)%n",
+            word.getContent(),
+            word.getConfidence());
+    }
+    
+    // Selection marks (checkboxes)
+    for (DocumentSelectionMark mark : page.getSelectionMarks()) {
+        System.out.printf("Checkbox: %s (confidence: %.2f)%n",
+            mark.getSelectionMarkState(),
+            mark.getConfidence());
+    }
+}
+
+// Process tables
+for (DocumentTable table : result.getTables()) {
+    System.out.printf("Table: %d rows x %d columns%n",
+        table.getRowCount(),
+        table.getColumnCount());
+    
+    for (DocumentTableCell cell : table.getCells()) {
+        System.out.printf("Cell[%d,%d]: %s%n",
+            cell.getRowIndex(),
+            cell.getColumnIndex(),
+            cell.getContent());
+    }
+}
+```
+
+### Extract Layout from URL
+
+```java
+String documentUrl = "https://example.com/document.pdf";
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("prebuilt-layout", documentUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+```
+
+## Receipt Analysis
+
+```java
+String receiptUrl = "https://example.com/receipt.jpg";
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("prebuilt-receipt", receiptUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument doc : result.getDocuments()) {
+    Map<String, DocumentField> fields = doc.getFields();
+    
+    // Merchant name
+    DocumentField merchantName = fields.get("MerchantName");
+    if (merchantName != null && merchantName.getType() == DocumentFieldType.STRING) {
+        System.out.printf("Merchant: %s (confidence: %.2f)%n",
+            merchantName.getValueAsString(),
+            merchantName.getConfidence());
+    }
+    
+    // Transaction date
+    DocumentField transactionDate = fields.get("TransactionDate");
+    if (transactionDate != null && transactionDate.getType() == DocumentFieldType.DATE) {
+        System.out.printf("Date: %s%n", transactionDate.getValueAsDate());
+    }
+    
+    // Total amount
+    DocumentField total = fields.get("Total");
+    if (total != null && total.getType() == DocumentFieldType.DOUBLE) {
+        System.out.printf("Total: $%.2f%n", total.getValueAsDouble());
+    }
+    
+    // Line items
+    DocumentField items = fields.get("Items");
+    if (items != null && items.getType() == DocumentFieldType.LIST) {
+        System.out.println("Items:");
+        for (DocumentField item : items.getValueAsList()) {
+            Map<String, DocumentField> itemFields = item.getValueAsMap();
+            
+            DocumentField name = itemFields.get("Name");
+            DocumentField price = itemFields.get("Price");
+            DocumentField quantity = itemFields.get("Quantity");
+            
+            System.out.printf("  - %s x%s: $%.2f%n",
+                name != null ? name.getValueAsString() : "Unknown",
+                quantity != null ? quantity.getValueAsDouble().intValue() : 1,
+                price != null ? price.getValueAsDouble() : 0.0);
+        }
+    }
+}
+```
+
+## Invoice Analysis
+
+```java
+String invoiceUrl = "https://example.com/invoice.pdf";
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("prebuilt-invoice", invoiceUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument invoice : result.getDocuments()) {
+    Map<String, DocumentField> fields = invoice.getFields();
+    
+    // Vendor information
+    DocumentField vendorName = fields.get("VendorName");
+    DocumentField vendorAddress = fields.get("VendorAddress");
+    
+    System.out.println("=== Vendor ===");
+    if (vendorName != null) {
+        System.out.println("Name: " + vendorName.getValueAsString());
+    }
+    if (vendorAddress != null) {
+        System.out.println("Address: " + vendorAddress.getContent());
+    }
+    
+    // Customer information
+    DocumentField customerName = fields.get("CustomerName");
+    DocumentField customerAddress = fields.get("CustomerAddress");
+    
+    System.out.println("=== Customer ===");
+    if (customerName != null) {
+        System.out.println("Name: " + customerName.getValueAsString());
+    }
+    
+    // Invoice details
+    DocumentField invoiceId = fields.get("InvoiceId");
+    DocumentField invoiceDate = fields.get("InvoiceDate");
+    DocumentField dueDate = fields.get("DueDate");
+    
+    System.out.println("=== Invoice Details ===");
+    if (invoiceId != null) {
+        System.out.println("Invoice ID: " + invoiceId.getValueAsString());
+    }
+    if (invoiceDate != null) {
+        System.out.println("Invoice Date: " + invoiceDate.getValueAsDate());
+    }
+    if (dueDate != null) {
+        System.out.println("Due Date: " + dueDate.getValueAsDate());
+    }
+    
+    // Amounts
+    DocumentField subTotal = fields.get("SubTotal");
+    DocumentField totalTax = fields.get("TotalTax");
+    DocumentField invoiceTotal = fields.get("InvoiceTotal");
+    DocumentField amountDue = fields.get("AmountDue");
+    
+    System.out.println("=== Amounts ===");
+    if (subTotal != null) {
+        System.out.printf("Subtotal: $%.2f%n", subTotal.getValueAsDouble());
+    }
+    if (totalTax != null) {
+        System.out.printf("Tax: $%.2f%n", totalTax.getValueAsDouble());
+    }
+    if (invoiceTotal != null) {
+        System.out.printf("Total: $%.2f%n", invoiceTotal.getValueAsDouble());
+    }
+    
+    // Line items
+    DocumentField items = fields.get("Items");
+    if (items != null && items.getType() == DocumentFieldType.LIST) {
+        System.out.println("=== Line Items ===");
+        for (DocumentField item : items.getValueAsList()) {
+            Map<String, DocumentField> itemFields = item.getValueAsMap();
+            
+            String description = getStringValue(itemFields.get("Description"));
+            Double quantity = getDoubleValue(itemFields.get("Quantity"));
+            Double unitPrice = getDoubleValue(itemFields.get("UnitPrice"));
+            Double amount = getDoubleValue(itemFields.get("Amount"));
+            
+            System.out.printf("  %s | Qty: %.0f | Unit: $%.2f | Amount: $%.2f%n",
+                description, quantity, unitPrice, amount);
+        }
+    }
+}
+
+// Helper methods
+private static String getStringValue(DocumentField field) {
+    return field != null ? field.getValueAsString() : "";
+}
+
+private static Double getDoubleValue(DocumentField field) {
+    return field != null ? field.getValueAsDouble() : 0.0;
+}
+```
+
+## ID Document Analysis
+
+```java
+String idDocumentUrl = "https://example.com/drivers-license.jpg";
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("prebuilt-idDocument", idDocumentUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument idDoc : result.getDocuments()) {
+    Map<String, DocumentField> fields = idDoc.getFields();
+    
+    // Document type
+    System.out.println("Document Type: " + idDoc.getDocType());
+    
+    // Personal information
+    DocumentField firstName = fields.get("FirstName");
+    DocumentField lastName = fields.get("LastName");
+    DocumentField dateOfBirth = fields.get("DateOfBirth");
+    DocumentField sex = fields.get("Sex");
+    
+    System.out.println("=== Personal Information ===");
+    if (firstName != null) System.out.println("First Name: " + firstName.getValueAsString());
+    if (lastName != null) System.out.println("Last Name: " + lastName.getValueAsString());
+    if (dateOfBirth != null) System.out.println("DOB: " + dateOfBirth.getValueAsDate());
+    if (sex != null) System.out.println("Sex: " + sex.getValueAsString());
+    
+    // Document information
+    DocumentField documentNumber = fields.get("DocumentNumber");
+    DocumentField expirationDate = fields.get("DateOfExpiration");
+    DocumentField address = fields.get("Address");
+    DocumentField region = fields.get("Region");
+    DocumentField country = fields.get("CountryRegion");
+    
+    System.out.println("=== Document Information ===");
+    if (documentNumber != null) System.out.println("Document #: " + documentNumber.getValueAsString());
+    if (expirationDate != null) System.out.println("Expires: " + expirationDate.getValueAsDate());
+    if (address != null) System.out.println("Address: " + address.getContent());
+    if (region != null) System.out.println("Region: " + region.getValueAsString());
+    if (country != null) System.out.println("Country: " + country.getValueAsString());
+}
+```
+
+## Custom Models
+
+### Build Custom Model
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.administration.models.*;
+import com.azure.core.util.Context;
+
+String blobContainerUrl = "https://storage.blob.core.windows.net/training-data?sasToken";
+String prefix = "invoices/";
+
+SyncPoller<OperationResult, DocumentModelDetails> poller = adminClient.beginBuildDocumentModel(
+    blobContainerUrl,
+    DocumentModelBuildMode.TEMPLATE,
+    prefix,
+    new BuildDocumentModelOptions()
+        .setModelId("my-custom-invoice-model")
+        .setDescription("Custom model for company invoices"),
+    Context.NONE);
+
+DocumentModelDetails model = poller.getFinalResult();
+
+System.out.println("Model ID: " + model.getModelId());
+System.out.println("Description: " + model.getDescription());
+System.out.println("Created: " + model.getCreatedOn());
+
+// Show document types and fields
+model.getDocumentTypes().forEach((docType, details) -> {
+    System.out.println("\nDocument type: " + docType);
+    details.getFieldSchema().forEach((field, schema) -> {
+        System.out.printf("  Field: %s (%s)%n", field, schema.getType());
+    });
+});
+```
+
+### Analyze with Custom Model
+
+```java
+String documentUrl = "https://example.com/new-invoice.pdf";
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginAnalyzeDocumentFromUrl("my-custom-invoice-model", documentUrl);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument doc : result.getDocuments()) {
+    System.out.printf("Document type: %s (confidence: %.2f)%n",
+        doc.getDocType(),
+        doc.getConfidence());
+    
+    doc.getFields().forEach((name, field) -> {
+        System.out.printf("Field '%s': %s (confidence: %.2f)%n",
+            name,
+            field.getContent(),
+            field.getConfidence());
+    });
+}
+```
+
+### Compose Multiple Models
+
+```java
+import java.util.Arrays;
+import java.util.List;
+
+List<String> modelIds = Arrays.asList(
+    "invoice-model-2023",
+    "invoice-model-2024",
+    "receipt-model"
+);
+
+SyncPoller<OperationResult, DocumentModelDetails> poller = 
+    adminClient.beginComposeDocumentModel(
+        modelIds,
+        new ComposeDocumentModelOptions()
+            .setModelId("composed-financial-model")
+            .setDescription("Composed model for invoices and receipts"));
+
+DocumentModelDetails composedModel = poller.getFinalResult();
+System.out.println("Composed model ID: " + composedModel.getModelId());
+```
+
+## Document Classification
+
+### Build Classifier
+
+```java
+import java.util.HashMap;
+import java.util.Map;
+
+String containerUrl = "https://storage.blob.core.windows.net/training-data?sasToken";
+
+Map<String, ClassifierDocumentTypeDetails> docTypes = new HashMap<>();
+
+docTypes.put("invoice", new ClassifierDocumentTypeDetails()
+    .setAzureBlobSource(new AzureBlobContentSource(containerUrl)
+        .setPrefix("invoices/")));
+
+docTypes.put("receipt", new ClassifierDocumentTypeDetails()
+    .setAzureBlobSource(new AzureBlobContentSource(containerUrl)
+        .setPrefix("receipts/")));
+
+docTypes.put("purchase-order", new ClassifierDocumentTypeDetails()
+    .setAzureBlobSource(new AzureBlobContentSource(containerUrl)
+        .setPrefix("purchase-orders/")));
+
+SyncPoller<OperationResult, DocumentClassifierDetails> poller = 
+    adminClient.beginBuildDocumentClassifier(
+        docTypes,
+        new BuildDocumentClassifierOptions()
+            .setClassifierId("financial-doc-classifier")
+            .setDescription("Classifier for financial documents"));
+
+DocumentClassifierDetails classifier = poller.getFinalResult();
+System.out.println("Classifier ID: " + classifier.getClassifierId());
+System.out.println("Document types: " + classifier.getDocumentTypes().keySet());
+```
+
+### Classify Document
+
+```java
+String documentUrl = "https://example.com/unknown-document.pdf";
+
+SyncPoller<OperationResult, AnalyzeResult> poller = 
+    client.beginClassifyDocumentFromUrl("financial-doc-classifier", documentUrl, Context.NONE);
+
+AnalyzeResult result = poller.getFinalResult();
+
+for (AnalyzedDocument doc : result.getDocuments()) {
+    System.out.printf("Classified as: %s (confidence: %.2f)%n",
+        doc.getDocType(),
+        doc.getConfidence());
+    
+    // Get bounding regions for the classified content
+    if (doc.getBoundingRegions() != null) {
+        for (BoundingRegion region : doc.getBoundingRegions()) {
+            System.out.printf("  Page %d%n", region.getPageNumber());
+        }
+    }
+}
+```
+
+## Model Management
+
+### List Models
+
+```java
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<DocumentModelSummary> models = adminClient.listDocumentModels();
+
+System.out.println("Available models:");
+for (DocumentModelSummary summary : models) {
+    System.out.printf("  %s - Created: %s%n",
+        summary.getModelId(),
+        summary.getCreatedOn());
+}
+```
+
+### Get Model Details
+
+```java
+DocumentModelDetails model = adminClient.getDocumentModel("my-custom-model");
+
+System.out.println("Model ID: " + model.getModelId());
+System.out.println("Description: " + model.getDescription());
+System.out.println("Created: " + model.getCreatedOn());
+System.out.println("Expiration: " + model.getExpiresOn());
+```
+
+### Delete Model
+
+```java
+adminClient.deleteDocumentModel("old-model-id");
+System.out.println("Model deleted successfully");
+```
+
+### Check Resource Limits
+
+```java
+ResourceDetails resources = adminClient.getResourceDetails();
+
+System.out.println("=== Resource Limits ===");
+System.out.printf("Custom models: %d / %d%n",
+    resources.getCustomDocumentModelCount(),
+    resources.getCustomDocumentModelLimit());
+```
+
+### List Classifiers
+
+```java
+PagedIterable<DocumentClassifierDetails> classifiers = adminClient.listDocumentClassifiers();
+
+for (DocumentClassifierDetails classifier : classifiers) {
+    System.out.printf("Classifier: %s, Types: %s%n",
+        classifier.getClassifierId(),
+        classifier.getDocumentTypes().keySet());
+}
+```
+
+## Async Patterns
+
+### Async Document Analysis
+
+```java
+import reactor.core.publisher.Mono;
+
+DocumentAnalysisAsyncClient asyncClient = new DocumentAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+
+String documentUrl = "https://example.com/document.pdf";
+
+asyncClient.beginAnalyzeDocumentFromUrl("prebuilt-invoice", documentUrl)
+    .flatMap(poller -> poller.getFinalResult())
+    .subscribe(
+        result -> {
+            System.out.println("Analysis complete!");
+            for (AnalyzedDocument doc : result.getDocuments()) {
+                System.out.println("Document type: " + doc.getDocType());
+            }
+        },
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Done")
+    );
+
+// Block for demo purposes
+Thread.sleep(30000);
+```
+
+### Parallel Analysis
+
+```java
+import reactor.core.publisher.Flux;
+import java.util.Arrays;
+import java.util.List;
+
+List<String> documentUrls = Arrays.asList(
+    "https://example.com/invoice1.pdf",
+    "https://example.com/invoice2.pdf",
+    "https://example.com/invoice3.pdf"
+);
+
+Flux.fromIterable(documentUrls)
+    .flatMap(url -> asyncClient.beginAnalyzeDocumentFromUrl("prebuilt-invoice", url)
+        .flatMap(poller -> poller.getFinalResult())
+        .map(result -> new DocumentResult(url, result)))
+    .subscribe(
+        docResult -> System.out.printf("Processed: %s - %d documents%n",
+            docResult.url, docResult.result.getDocuments().size()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+
+// Helper class
+class DocumentResult {
+    String url;
+    AnalyzeResult result;
+    
+    DocumentResult(String url, AnalyzeResult result) {
+        this.url = url;
+        this.result = result;
+    }
+}
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    SyncPoller<OperationResult, AnalyzeResult> poller = 
+        client.beginAnalyzeDocumentFromUrl("prebuilt-receipt", "invalid-url");
+    poller.getFinalResult();
+} catch (HttpResponseException e) {
+    System.err.println("HTTP Status: " + e.getResponse().getStatusCode());
+    System.err.println("Error Message: " + e.getMessage());
+    
+    // Handle specific errors
+    int statusCode = e.getResponse().getStatusCode();
+    if (statusCode == 400) {
+        System.err.println("Bad request - check document URL or format");
+    } else if (statusCode == 401) {
+        System.err.println("Unauthorized - check credentials");
+    } else if (statusCode == 404) {
+        System.err.println("Model not found");
+    } else if (statusCode == 429) {
+        System.err.println("Rate limited - retry with backoff");
+    }
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+## Complete Application Example
+
+```java
+import com.azure.ai.formrecognizer.documentanalysis.DocumentAnalysisClient;
+import com.azure.ai.formrecognizer.documentanalysis.DocumentAnalysisClientBuilder;
+import com.azure.ai.formrecognizer.documentanalysis.models.*;
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.util.Map;
+
+public class InvoiceProcessor {
+    
+    private final DocumentAnalysisClient client;
+    
+    public InvoiceProcessor() {
+        this.client = new DocumentAnalysisClientBuilder()
+            .endpoint(System.getenv("FORM_RECOGNIZER_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+    }
+    
+    public InvoiceData processInvoice(String invoiceUrl) {
+        SyncPoller<OperationResult, AnalyzeResult> poller = 
+            client.beginAnalyzeDocumentFromUrl("prebuilt-invoice", invoiceUrl);
+        
+        AnalyzeResult result = poller.getFinalResult();
+        
+        if (result.getDocuments().isEmpty()) {
+            throw new RuntimeException("No invoice found in document");
+        }
+        
+        AnalyzedDocument invoice = result.getDocuments().get(0);
+        Map<String, DocumentField> fields = invoice.getFields();
+        
+        return new InvoiceData(
+            getStringField(fields, "InvoiceId"),
+            getStringField(fields, "VendorName"),
+            getStringField(fields, "CustomerName"),
+            getDateField(fields, "InvoiceDate"),
+            getDateField(fields, "DueDate"),
+            getDoubleField(fields, "SubTotal"),
+            getDoubleField(fields, "TotalTax"),
+            getDoubleField(fields, "InvoiceTotal"),
+            invoice.getConfidence()
+        );
+    }
+    
+    private String getStringField(Map<String, DocumentField> fields, String name) {
+        DocumentField field = fields.get(name);
+        return field != null ? field.getValueAsString() : null;
+    }
+    
+    private java.time.LocalDate getDateField(Map<String, DocumentField> fields, String name) {
+        DocumentField field = fields.get(name);
+        return field != null ? field.getValueAsDate() : null;
+    }
+    
+    private Double getDoubleField(Map<String, DocumentField> fields, String name) {
+        DocumentField field = fields.get(name);
+        return field != null ? field.getValueAsDouble() : null;
+    }
+    
+    // Data class for invoice
+    public static class InvoiceData {
+        public final String invoiceId;
+        public final String vendorName;
+        public final String customerName;
+        public final java.time.LocalDate invoiceDate;
+        public final java.time.LocalDate dueDate;
+        public final Double subTotal;
+        public final Double tax;
+        public final Double total;
+        public final double confidence;
+        
+        public InvoiceData(String invoiceId, String vendorName, String customerName,
+                          java.time.LocalDate invoiceDate, java.time.LocalDate dueDate,
+                          Double subTotal, Double tax, Double total, double confidence) {
+            this.invoiceId = invoiceId;
+            this.vendorName = vendorName;
+            this.customerName = customerName;
+            this.invoiceDate = invoiceDate;
+            this.dueDate = dueDate;
+            this.subTotal = subTotal;
+            this.tax = tax;
+            this.total = total;
+            this.confidence = confidence;
+        }
+        
+        @Override
+        public String toString() {
+            return String.format(
+                "Invoice %s from %s to %s: $%.2f (confidence: %.2f)",
+                invoiceId, vendorName, customerName, total, confidence
+            );
+        }
+    }
+    
+    public static void main(String[] args) {
+        InvoiceProcessor processor = new InvoiceProcessor();
+        
+        String invoiceUrl = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/sample-invoice.pdf";
+        
+        try {
+            InvoiceData invoice = processor.processInvoice(invoiceUrl);
+            System.out.println(invoice);
+        } catch (Exception e) {
+            System.err.println("Failed to process invoice: " + e.getMessage());
+        }
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+FORM_RECOGNIZER_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+FORM_RECOGNIZER_KEY=<your-api-key>
+
+# For DefaultAzureCredential
+AZURE_CLIENT_ID=<service-principal-client-id>
+AZURE_CLIENT_SECRET=<service-principal-secret>
+AZURE_TENANT_ID=<tenant-id>
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** — Prefer managed identity over API keys in production
+2. **Choose the right model** — Use prebuilt models when possible; custom models for specialized documents
+3. **Handle polling properly** — Use `getFinalResult()` for synchronous waits
+4. **Check confidence scores** — Validate extracted data based on confidence thresholds
+5. **Process in batches** — Use async client for parallel processing of multiple documents
+6. **Implement retry logic** — Handle rate limiting (429) with exponential backoff
+7. **Clean up resources** — Delete unused custom models to stay within limits
+8. **Use classification first** — For mixed document types, classify before extraction

--- a/skills/java/ai/vision-imageanalysis/SKILL.md
+++ b/skills/java/ai/vision-imageanalysis/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: azure-ai-vision-imageanalysis-java
+description: Build image analysis applications with Azure AI Vision SDK for Java. Use when implementing image captioning, OCR text extraction, object detection, tagging, or smart cropping.
+---
+
+# Azure AI Vision Image Analysis SDK for Java
+
+Build image analysis applications using the Azure AI Vision Image Analysis SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-vision-imageanalysis</artifactId>
+    <version>1.1.0-beta.1</version>
+</dependency>
+```
+
+## Client Creation
+
+### With API Key
+
+```java
+import com.azure.ai.vision.imageanalysis.ImageAnalysisClient;
+import com.azure.ai.vision.imageanalysis.ImageAnalysisClientBuilder;
+import com.azure.core.credential.KeyCredential;
+
+String endpoint = System.getenv("VISION_ENDPOINT");
+String key = System.getenv("VISION_KEY");
+
+ImageAnalysisClient client = new ImageAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new KeyCredential(key))
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.ai.vision.imageanalysis.ImageAnalysisAsyncClient;
+
+ImageAnalysisAsyncClient asyncClient = new ImageAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new KeyCredential(key))
+    .buildAsyncClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+ImageAnalysisClient client = new ImageAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Visual Features
+
+| Feature | Description |
+|---------|-------------|
+| `CAPTION` | Generate human-readable image description |
+| `DENSE_CAPTIONS` | Captions for up to 10 regions |
+| `READ` | OCR - Extract text from images |
+| `TAGS` | Content tags for objects, scenes, actions |
+| `OBJECTS` | Detect objects with bounding boxes |
+| `SMART_CROPS` | Smart thumbnail regions |
+| `PEOPLE` | Detect people with locations |
+
+## Core Patterns
+
+### Generate Caption
+
+```java
+import com.azure.ai.vision.imageanalysis.models.*;
+import com.azure.core.util.BinaryData;
+import java.io.File;
+import java.util.Arrays;
+
+// From file
+BinaryData imageData = BinaryData.fromFile(new File("image.jpg").toPath());
+
+ImageAnalysisResult result = client.analyze(
+    imageData,
+    Arrays.asList(VisualFeatures.CAPTION),
+    new ImageAnalysisOptions().setGenderNeutralCaption(true));
+
+System.out.printf("Caption: \"%s\" (confidence: %.4f)%n",
+    result.getCaption().getText(),
+    result.getCaption().getConfidence());
+```
+
+### Generate Caption from URL
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    "https://example.com/image.jpg",
+    Arrays.asList(VisualFeatures.CAPTION),
+    new ImageAnalysisOptions().setGenderNeutralCaption(true));
+
+System.out.printf("Caption: \"%s\"%n", result.getCaption().getText());
+```
+
+### Extract Text (OCR)
+
+```java
+ImageAnalysisResult result = client.analyze(
+    BinaryData.fromFile(new File("document.jpg").toPath()),
+    Arrays.asList(VisualFeatures.READ),
+    null);
+
+for (DetectedTextBlock block : result.getRead().getBlocks()) {
+    for (DetectedTextLine line : block.getLines()) {
+        System.out.printf("Line: '%s'%n", line.getText());
+        System.out.printf("  Bounding polygon: %s%n", line.getBoundingPolygon());
+        
+        for (DetectedTextWord word : line.getWords()) {
+            System.out.printf("  Word: '%s' (confidence: %.4f)%n",
+                word.getText(),
+                word.getConfidence());
+        }
+    }
+}
+```
+
+### Detect Objects
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.OBJECTS),
+    null);
+
+for (DetectedObject obj : result.getObjects()) {
+    System.out.printf("Object: %s (confidence: %.4f)%n",
+        obj.getTags().get(0).getName(),
+        obj.getTags().get(0).getConfidence());
+    
+    ImageBoundingBox box = obj.getBoundingBox();
+    System.out.printf("  Location: x=%d, y=%d, w=%d, h=%d%n",
+        box.getX(), box.getY(), box.getWidth(), box.getHeight());
+}
+```
+
+### Get Tags
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.TAGS),
+    null);
+
+for (DetectedTag tag : result.getTags()) {
+    System.out.printf("Tag: %s (confidence: %.4f)%n",
+        tag.getName(),
+        tag.getConfidence());
+}
+```
+
+### Detect People
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.PEOPLE),
+    null);
+
+for (DetectedPerson person : result.getPeople()) {
+    ImageBoundingBox box = person.getBoundingBox();
+    System.out.printf("Person at x=%d, y=%d (confidence: %.4f)%n",
+        box.getX(), box.getY(), person.getConfidence());
+}
+```
+
+### Smart Cropping
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.SMART_CROPS),
+    new ImageAnalysisOptions().setSmartCropsAspectRatios(Arrays.asList(1.0, 1.5)));
+
+for (CropRegion crop : result.getSmartCrops()) {
+    System.out.printf("Crop region: aspect=%.2f, x=%d, y=%d, w=%d, h=%d%n",
+        crop.getAspectRatio(),
+        crop.getBoundingBox().getX(),
+        crop.getBoundingBox().getY(),
+        crop.getBoundingBox().getWidth(),
+        crop.getBoundingBox().getHeight());
+}
+```
+
+### Dense Captions
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.DENSE_CAPTIONS),
+    new ImageAnalysisOptions().setGenderNeutralCaption(true));
+
+for (DenseCaption caption : result.getDenseCaptions()) {
+    System.out.printf("Caption: \"%s\" (confidence: %.4f)%n",
+        caption.getText(),
+        caption.getConfidence());
+    System.out.printf("  Region: x=%d, y=%d, w=%d, h=%d%n",
+        caption.getBoundingBox().getX(),
+        caption.getBoundingBox().getY(),
+        caption.getBoundingBox().getWidth(),
+        caption.getBoundingBox().getHeight());
+}
+```
+
+### Multiple Features
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(
+        VisualFeatures.CAPTION,
+        VisualFeatures.TAGS,
+        VisualFeatures.OBJECTS,
+        VisualFeatures.READ),
+    new ImageAnalysisOptions()
+        .setGenderNeutralCaption(true)
+        .setLanguage("en"));
+
+// Access all results
+System.out.println("Caption: " + result.getCaption().getText());
+System.out.println("Tags: " + result.getTags().size());
+System.out.println("Objects: " + result.getObjects().size());
+System.out.println("Text blocks: " + result.getRead().getBlocks().size());
+```
+
+### Async Analysis
+
+```java
+asyncClient.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.CAPTION),
+    null)
+    .subscribe(
+        result -> System.out.println("Caption: " + result.getCaption().getText()),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Complete")
+    );
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    client.analyzeFromUrl(imageUrl, Arrays.asList(VisualFeatures.CAPTION), null);
+} catch (HttpResponseException e) {
+    System.out.println("Status: " + e.getResponse().getStatusCode());
+    System.out.println("Error: " + e.getMessage());
+}
+```
+
+## Environment Variables
+
+```bash
+VISION_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+VISION_KEY=<your-api-key>
+```
+
+## Image Requirements
+
+- Formats: JPEG, PNG, GIF, BMP, WEBP, ICO, TIFF, MPO
+- Size: < 20 MB
+- Dimensions: 50x50 to 16000x16000 pixels
+
+## Regional Availability
+
+Caption and Dense Captions require GPU-supported regions. Check [supported regions](https://learn.microsoft.com/azure/ai-services/computer-vision/concept-describe-images-40) before deployment.
+
+## Trigger Phrases
+
+- "image analysis Java"
+- "Azure Vision SDK"
+- "image captioning"
+- "OCR image text extraction"
+- "object detection image"
+- "smart crop thumbnail"
+- "detect people image"

--- a/skills/java/ai/vision-imageanalysis/references/examples.md
+++ b/skills/java/ai/vision-imageanalysis/references/examples.md
@@ -1,0 +1,718 @@
+# Azure AI Vision Image Analysis Java SDK - Examples
+
+Comprehensive code examples for the Azure AI Vision Image Analysis SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Visual Features](#visual-features)
+- [Generate Caption](#generate-caption)
+- [Extract Text (OCR)](#extract-text-ocr)
+- [Detect Objects](#detect-objects)
+- [Get Tags](#get-tags)
+- [Detect People](#detect-people)
+- [Smart Cropping](#smart-cropping)
+- [Dense Captions](#dense-captions)
+- [Multiple Features](#multiple-features)
+- [Async Patterns](#async-patterns)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-vision-imageanalysis</artifactId>
+    <version>1.1.0-beta.1</version>
+</dependency>
+
+<!-- For DefaultAzureCredential -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### With API Key
+
+```java
+import com.azure.ai.vision.imageanalysis.ImageAnalysisClient;
+import com.azure.ai.vision.imageanalysis.ImageAnalysisClientBuilder;
+import com.azure.core.credential.KeyCredential;
+
+String endpoint = System.getenv("VISION_ENDPOINT");
+String key = System.getenv("VISION_KEY");
+
+ImageAnalysisClient client = new ImageAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new KeyCredential(key))
+    .buildClient();
+```
+
+### With DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+ImageAnalysisClient client = new ImageAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.ai.vision.imageanalysis.ImageAnalysisAsyncClient;
+
+ImageAnalysisAsyncClient asyncClient = new ImageAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+## Visual Features
+
+| Feature | Description |
+|---------|-------------|
+| `CAPTION` | Generate human-readable image description |
+| `DENSE_CAPTIONS` | Captions for up to 10 regions |
+| `READ` | OCR - Extract text from images |
+| `TAGS` | Content tags for objects, scenes, actions |
+| `OBJECTS` | Detect objects with bounding boxes |
+| `SMART_CROPS` | Smart thumbnail regions |
+| `PEOPLE` | Detect people with locations |
+
+## Generate Caption
+
+### From File
+
+```java
+import com.azure.ai.vision.imageanalysis.models.*;
+import com.azure.core.util.BinaryData;
+import java.io.File;
+import java.util.Arrays;
+
+// Load image from file
+File imageFile = new File("photo.jpg");
+BinaryData imageData = BinaryData.fromFile(imageFile.toPath());
+
+// Analyze with caption
+ImageAnalysisResult result = client.analyze(
+    imageData,
+    Arrays.asList(VisualFeatures.CAPTION),
+    new ImageAnalysisOptions().setGenderNeutralCaption(true));
+
+// Get caption
+CaptionResult caption = result.getCaption();
+System.out.printf("Caption: \"%s\" (confidence: %.4f)%n",
+    caption.getText(),
+    caption.getConfidence());
+```
+
+### From URL
+
+```java
+String imageUrl = "https://example.com/photo.jpg";
+
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.CAPTION),
+    new ImageAnalysisOptions().setGenderNeutralCaption(true));
+
+System.out.printf("Caption: \"%s\"%n", result.getCaption().getText());
+```
+
+### With Language
+
+```java
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.CAPTION),
+    new ImageAnalysisOptions()
+        .setGenderNeutralCaption(true)
+        .setLanguage("en"));  // Supported: en, es, fr, de, it, pt, ja, ko, zh
+```
+
+## Extract Text (OCR)
+
+```java
+File documentImage = new File("document.jpg");
+BinaryData imageData = BinaryData.fromFile(documentImage.toPath());
+
+ImageAnalysisResult result = client.analyze(
+    imageData,
+    Arrays.asList(VisualFeatures.READ),
+    null);
+
+ReadResult readResult = result.getRead();
+
+System.out.println("=== Extracted Text ===");
+for (DetectedTextBlock block : readResult.getBlocks()) {
+    System.out.println("Block:");
+    
+    for (DetectedTextLine line : block.getLines()) {
+        System.out.printf("  Line: '%s'%n", line.getText());
+        
+        // Get bounding polygon
+        List<ImagePoint> polygon = line.getBoundingPolygon();
+        System.out.printf("    Bounding polygon: [");
+        for (ImagePoint point : polygon) {
+            System.out.printf("(%d,%d) ", point.getX(), point.getY());
+        }
+        System.out.println("]");
+        
+        // Get individual words
+        for (DetectedTextWord word : line.getWords()) {
+            System.out.printf("    Word: '%s' (confidence: %.4f)%n",
+                word.getText(),
+                word.getConfidence());
+        }
+    }
+}
+```
+
+### Extract Text from URL
+
+```java
+String documentUrl = "https://example.com/receipt.jpg";
+
+ImageAnalysisResult result = client.analyzeFromUrl(
+    documentUrl,
+    Arrays.asList(VisualFeatures.READ),
+    null);
+
+// Collect all text
+StringBuilder fullText = new StringBuilder();
+for (DetectedTextBlock block : result.getRead().getBlocks()) {
+    for (DetectedTextLine line : block.getLines()) {
+        fullText.append(line.getText()).append("\n");
+    }
+}
+
+System.out.println("Full extracted text:");
+System.out.println(fullText.toString());
+```
+
+## Detect Objects
+
+```java
+String imageUrl = "https://example.com/street-scene.jpg";
+
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.OBJECTS),
+    null);
+
+System.out.println("=== Detected Objects ===");
+for (DetectedObject obj : result.getObjects()) {
+    // Get the primary tag (highest confidence)
+    DetectedTag primaryTag = obj.getTags().get(0);
+    
+    System.out.printf("Object: %s (confidence: %.4f)%n",
+        primaryTag.getName(),
+        primaryTag.getConfidence());
+    
+    // Get bounding box
+    ImageBoundingBox box = obj.getBoundingBox();
+    System.out.printf("  Location: x=%d, y=%d, width=%d, height=%d%n",
+        box.getX(), box.getY(), box.getWidth(), box.getHeight());
+    
+    // Additional tags for this object
+    if (obj.getTags().size() > 1) {
+        System.out.println("  Additional tags:");
+        for (int i = 1; i < obj.getTags().size(); i++) {
+            DetectedTag tag = obj.getTags().get(i);
+            System.out.printf("    - %s (%.4f)%n", tag.getName(), tag.getConfidence());
+        }
+    }
+}
+
+System.out.printf("Total objects detected: %d%n", result.getObjects().size());
+```
+
+## Get Tags
+
+```java
+String imageUrl = "https://example.com/nature.jpg";
+
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.TAGS),
+    null);
+
+System.out.println("=== Image Tags ===");
+
+// Sort by confidence
+List<DetectedTag> sortedTags = new ArrayList<>(result.getTags());
+sortedTags.sort((a, b) -> Double.compare(b.getConfidence(), a.getConfidence()));
+
+for (DetectedTag tag : sortedTags) {
+    System.out.printf("%-20s (confidence: %.4f)%n",
+        tag.getName(),
+        tag.getConfidence());
+}
+
+// Filter high-confidence tags (>80%)
+System.out.println("\nHigh-confidence tags (>80%):");
+for (DetectedTag tag : sortedTags) {
+    if (tag.getConfidence() > 0.80) {
+        System.out.println("  - " + tag.getName());
+    }
+}
+```
+
+## Detect People
+
+```java
+String imageUrl = "https://example.com/group-photo.jpg";
+
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.PEOPLE),
+    null);
+
+System.out.println("=== Detected People ===");
+System.out.printf("Number of people: %d%n", result.getPeople().size());
+
+int personIndex = 1;
+for (DetectedPerson person : result.getPeople()) {
+    ImageBoundingBox box = person.getBoundingBox();
+    
+    System.out.printf("Person %d:%n", personIndex++);
+    System.out.printf("  Confidence: %.4f%n", person.getConfidence());
+    System.out.printf("  Location: x=%d, y=%d, width=%d, height=%d%n",
+        box.getX(), box.getY(), box.getWidth(), box.getHeight());
+    
+    // Calculate center point
+    int centerX = box.getX() + box.getWidth() / 2;
+    int centerY = box.getY() + box.getHeight() / 2;
+    System.out.printf("  Center: (%d, %d)%n", centerX, centerY);
+}
+```
+
+## Smart Cropping
+
+```java
+String imageUrl = "https://example.com/landscape.jpg";
+
+// Request crops with specific aspect ratios
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.SMART_CROPS),
+    new ImageAnalysisOptions()
+        .setSmartCropsAspectRatios(Arrays.asList(1.0, 1.5, 0.75)));  // 1:1, 3:2, 3:4
+
+System.out.println("=== Smart Crop Regions ===");
+for (CropRegion crop : result.getSmartCrops()) {
+    ImageBoundingBox box = crop.getBoundingBox();
+    
+    System.out.printf("Aspect ratio: %.2f%n", crop.getAspectRatio());
+    System.out.printf("  Region: x=%d, y=%d, width=%d, height=%d%n",
+        box.getX(), box.getY(), box.getWidth(), box.getHeight());
+}
+```
+
+### Use Smart Crops for Thumbnails
+
+```java
+// Get square thumbnail region
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.SMART_CROPS),
+    new ImageAnalysisOptions()
+        .setSmartCropsAspectRatios(Arrays.asList(1.0)));  // Square
+
+CropRegion squareCrop = result.getSmartCrops().get(0);
+ImageBoundingBox box = squareCrop.getBoundingBox();
+
+// Use these coordinates to crop your image
+System.out.printf("Thumbnail region: x=%d, y=%d, size=%dx%d%n",
+    box.getX(), box.getY(), box.getWidth(), box.getHeight());
+```
+
+## Dense Captions
+
+```java
+String imageUrl = "https://example.com/complex-scene.jpg";
+
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.DENSE_CAPTIONS),
+    new ImageAnalysisOptions().setGenderNeutralCaption(true));
+
+System.out.println("=== Dense Captions ===");
+int regionIndex = 1;
+for (DenseCaption caption : result.getDenseCaptions()) {
+    ImageBoundingBox box = caption.getBoundingBox();
+    
+    System.out.printf("Region %d:%n", regionIndex++);
+    System.out.printf("  Caption: \"%s\"%n", caption.getText());
+    System.out.printf("  Confidence: %.4f%n", caption.getConfidence());
+    System.out.printf("  Location: x=%d, y=%d, width=%d, height=%d%n",
+        box.getX(), box.getY(), box.getWidth(), box.getHeight());
+}
+```
+
+## Multiple Features
+
+Analyze with multiple features in a single request.
+
+```java
+String imageUrl = "https://example.com/photo.jpg";
+
+ImageAnalysisResult result = client.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(
+        VisualFeatures.CAPTION,
+        VisualFeatures.TAGS,
+        VisualFeatures.OBJECTS,
+        VisualFeatures.PEOPLE,
+        VisualFeatures.READ),
+    new ImageAnalysisOptions()
+        .setGenderNeutralCaption(true)
+        .setLanguage("en"));
+
+// Caption
+System.out.println("=== Caption ===");
+System.out.printf("\"%s\" (%.4f)%n",
+    result.getCaption().getText(),
+    result.getCaption().getConfidence());
+
+// Tags
+System.out.println("\n=== Tags ===");
+for (DetectedTag tag : result.getTags()) {
+    if (tag.getConfidence() > 0.7) {
+        System.out.printf("  %s (%.2f)%n", tag.getName(), tag.getConfidence());
+    }
+}
+
+// Objects
+System.out.println("\n=== Objects ===");
+System.out.printf("  Count: %d%n", result.getObjects().size());
+for (DetectedObject obj : result.getObjects()) {
+    System.out.printf("  - %s%n", obj.getTags().get(0).getName());
+}
+
+// People
+System.out.println("\n=== People ===");
+System.out.printf("  Count: %d%n", result.getPeople().size());
+
+// Text
+System.out.println("\n=== Text ===");
+int lineCount = 0;
+for (DetectedTextBlock block : result.getRead().getBlocks()) {
+    lineCount += block.getLines().size();
+}
+System.out.printf("  Lines of text: %d%n", lineCount);
+
+// Metadata
+System.out.println("\n=== Image Metadata ===");
+System.out.printf("  Dimensions: %d x %d%n",
+    result.getMetadata().getWidth(),
+    result.getMetadata().getHeight());
+System.out.printf("  Model: %s%n", result.getModelVersion());
+```
+
+## Async Patterns
+
+### Basic Async Analysis
+
+```java
+ImageAnalysisAsyncClient asyncClient = new ImageAnalysisClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+
+String imageUrl = "https://example.com/photo.jpg";
+
+asyncClient.analyzeFromUrl(
+    imageUrl,
+    Arrays.asList(VisualFeatures.CAPTION, VisualFeatures.TAGS),
+    new ImageAnalysisOptions().setGenderNeutralCaption(true))
+    .subscribe(
+        result -> {
+            System.out.println("Caption: " + result.getCaption().getText());
+            System.out.println("Tags: " + result.getTags().size());
+        },
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Analysis complete")
+    );
+
+// Keep application running
+Thread.sleep(10000);
+```
+
+### Parallel Analysis
+
+```java
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+List<String> imageUrls = Arrays.asList(
+    "https://example.com/image1.jpg",
+    "https://example.com/image2.jpg",
+    "https://example.com/image3.jpg"
+);
+
+Flux.fromIterable(imageUrls)
+    .flatMap(url -> asyncClient.analyzeFromUrl(
+        url,
+        Arrays.asList(VisualFeatures.CAPTION),
+        null)
+        .map(result -> new ImageResult(url, result.getCaption().getText())))
+    .subscribe(
+        imageResult -> System.out.printf("%s: %s%n", 
+            imageResult.url, imageResult.caption),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+
+// Helper class
+class ImageResult {
+    String url;
+    String caption;
+    
+    ImageResult(String url, String caption) {
+        this.url = url;
+        this.caption = caption;
+    }
+}
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    ImageAnalysisResult result = client.analyzeFromUrl(
+        "invalid-url",
+        Arrays.asList(VisualFeatures.CAPTION),
+        null);
+        
+} catch (HttpResponseException e) {
+    int statusCode = e.getResponse().getStatusCode();
+    System.err.println("HTTP Status: " + statusCode);
+    System.err.println("Error: " + e.getMessage());
+    
+    switch (statusCode) {
+        case 400:
+            System.err.println("Bad request - check image URL or format");
+            break;
+        case 401:
+            System.err.println("Unauthorized - check API key");
+            break;
+        case 404:
+            System.err.println("Resource not found");
+            break;
+        case 415:
+            System.err.println("Unsupported media type - check image format");
+            break;
+        case 429:
+            System.err.println("Rate limited - retry with backoff");
+            break;
+        default:
+            System.err.println("Unexpected error");
+    }
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+## Complete Application Example
+
+```java
+import com.azure.ai.vision.imageanalysis.ImageAnalysisClient;
+import com.azure.ai.vision.imageanalysis.ImageAnalysisClientBuilder;
+import com.azure.ai.vision.imageanalysis.models.*;
+import com.azure.core.util.BinaryData;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.io.File;
+import java.util.*;
+
+public class ImageAnalyzer {
+    
+    private final ImageAnalysisClient client;
+    
+    public ImageAnalyzer() {
+        this.client = new ImageAnalysisClientBuilder()
+            .endpoint(System.getenv("VISION_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+    }
+    
+    public ImageAnalysisReport analyzeImage(String imagePath) {
+        File imageFile = new File(imagePath);
+        BinaryData imageData = BinaryData.fromFile(imageFile.toPath());
+        
+        ImageAnalysisResult result = client.analyze(
+            imageData,
+            Arrays.asList(
+                VisualFeatures.CAPTION,
+                VisualFeatures.TAGS,
+                VisualFeatures.OBJECTS,
+                VisualFeatures.PEOPLE,
+                VisualFeatures.READ),
+            new ImageAnalysisOptions()
+                .setGenderNeutralCaption(true)
+                .setLanguage("en"));
+        
+        return buildReport(imagePath, result);
+    }
+    
+    public ImageAnalysisReport analyzeImageUrl(String imageUrl) {
+        ImageAnalysisResult result = client.analyzeFromUrl(
+            imageUrl,
+            Arrays.asList(
+                VisualFeatures.CAPTION,
+                VisualFeatures.TAGS,
+                VisualFeatures.OBJECTS,
+                VisualFeatures.PEOPLE,
+                VisualFeatures.READ),
+            new ImageAnalysisOptions()
+                .setGenderNeutralCaption(true)
+                .setLanguage("en"));
+        
+        return buildReport(imageUrl, result);
+    }
+    
+    private ImageAnalysisReport buildReport(String source, ImageAnalysisResult result) {
+        // Extract caption
+        String caption = result.getCaption().getText();
+        double captionConfidence = result.getCaption().getConfidence();
+        
+        // Extract high-confidence tags
+        List<String> tags = new ArrayList<>();
+        for (DetectedTag tag : result.getTags()) {
+            if (tag.getConfidence() > 0.7) {
+                tags.add(tag.getName());
+            }
+        }
+        
+        // Extract objects
+        List<String> objects = new ArrayList<>();
+        for (DetectedObject obj : result.getObjects()) {
+            objects.add(obj.getTags().get(0).getName());
+        }
+        
+        // Count people
+        int peopleCount = result.getPeople().size();
+        
+        // Extract text
+        StringBuilder extractedText = new StringBuilder();
+        for (DetectedTextBlock block : result.getRead().getBlocks()) {
+            for (DetectedTextLine line : block.getLines()) {
+                extractedText.append(line.getText()).append("\n");
+            }
+        }
+        
+        return new ImageAnalysisReport(
+            source,
+            caption,
+            captionConfidence,
+            tags,
+            objects,
+            peopleCount,
+            extractedText.toString().trim(),
+            result.getMetadata().getWidth(),
+            result.getMetadata().getHeight()
+        );
+    }
+    
+    // Report class
+    public static class ImageAnalysisReport {
+        public final String source;
+        public final String caption;
+        public final double captionConfidence;
+        public final List<String> tags;
+        public final List<String> objects;
+        public final int peopleCount;
+        public final String extractedText;
+        public final int width;
+        public final int height;
+        
+        public ImageAnalysisReport(String source, String caption, double captionConfidence,
+                                   List<String> tags, List<String> objects, int peopleCount,
+                                   String extractedText, int width, int height) {
+            this.source = source;
+            this.caption = caption;
+            this.captionConfidence = captionConfidence;
+            this.tags = tags;
+            this.objects = objects;
+            this.peopleCount = peopleCount;
+            this.extractedText = extractedText;
+            this.width = width;
+            this.height = height;
+        }
+        
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("=== Image Analysis Report ===\n");
+            sb.append(String.format("Source: %s\n", source));
+            sb.append(String.format("Dimensions: %dx%d\n", width, height));
+            sb.append(String.format("Caption: \"%s\" (%.2f%%)\n", caption, captionConfidence * 100));
+            sb.append(String.format("Tags: %s\n", String.join(", ", tags)));
+            sb.append(String.format("Objects: %s\n", String.join(", ", objects)));
+            sb.append(String.format("People detected: %d\n", peopleCount));
+            if (!extractedText.isEmpty()) {
+                sb.append(String.format("Extracted text:\n%s\n", extractedText));
+            }
+            return sb.toString();
+        }
+    }
+    
+    public static void main(String[] args) {
+        ImageAnalyzer analyzer = new ImageAnalyzer();
+        
+        // Analyze from URL
+        String imageUrl = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/landmark.jpg";
+        
+        try {
+            ImageAnalysisReport report = analyzer.analyzeImageUrl(imageUrl);
+            System.out.println(report);
+        } catch (Exception e) {
+            System.err.println("Analysis failed: " + e.getMessage());
+        }
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+VISION_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+VISION_KEY=<your-api-key>
+
+# For DefaultAzureCredential
+AZURE_CLIENT_ID=<service-principal-client-id>
+AZURE_CLIENT_SECRET=<service-principal-secret>
+AZURE_TENANT_ID=<tenant-id>
+```
+
+## Image Requirements
+
+- **Formats**: JPEG, PNG, GIF, BMP, WEBP, ICO, TIFF, MPO
+- **Size**: Less than 20 MB
+- **Dimensions**: 50x50 to 16000x16000 pixels
+
+## Regional Availability
+
+Caption and Dense Captions require GPU-supported regions. Check [supported regions](https://learn.microsoft.com/azure/ai-services/computer-vision/concept-describe-images-40) before deployment.
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** — Prefer managed identity over API keys
+2. **Combine features** — Request multiple features in one call for efficiency
+3. **Check confidence scores** — Filter results based on confidence thresholds
+4. **Use async for batches** — Process multiple images in parallel
+5. **Handle regional limits** — Caption features require specific regions
+6. **Optimize image size** — Resize large images before sending
+7. **Enable gender-neutral captions** — Use inclusive language in captions
+8. **Implement retry logic** — Handle rate limiting with exponential backoff

--- a/skills/java/communication/callautomation/SKILL.md
+++ b/skills/java/communication/callautomation/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: azure-communication-callautomation-java
+description: Build call automation workflows with Azure Communication Services Call Automation Java SDK. Use when implementing IVR systems, call routing, call recording, DTMF recognition, text-to-speech, or AI-powered call flows.
+---
+
+# Azure Communication Call Automation (Java)
+
+Build server-side call automation workflows including IVR systems, call routing, recording, and AI-powered interactions.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-callautomation</artifactId>
+    <version>1.6.0</version>
+</dependency>
+```
+
+## Client Creation
+
+```java
+import com.azure.communication.callautomation.CallAutomationClient;
+import com.azure.communication.callautomation.CallAutomationClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// With DefaultAzureCredential
+CallAutomationClient client = new CallAutomationClientBuilder()
+    .endpoint("https://<resource>.communication.azure.com")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+// With connection string
+CallAutomationClient client = new CallAutomationClientBuilder()
+    .connectionString("<connection-string>")
+    .buildClient();
+```
+
+## Key Concepts
+
+| Class | Purpose |
+|-------|---------|
+| `CallAutomationClient` | Make calls, answer/reject incoming calls, redirect calls |
+| `CallConnection` | Actions in established calls (add participants, terminate) |
+| `CallMedia` | Media operations (play audio, recognize DTMF/speech) |
+| `CallRecording` | Start/stop/pause recording |
+| `CallAutomationEventParser` | Parse webhook events from ACS |
+
+## Create Outbound Call
+
+```java
+import com.azure.communication.callautomation.models.*;
+import com.azure.communication.common.CommunicationUserIdentifier;
+import com.azure.communication.common.PhoneNumberIdentifier;
+
+// Call to PSTN number
+PhoneNumberIdentifier target = new PhoneNumberIdentifier("+14255551234");
+PhoneNumberIdentifier caller = new PhoneNumberIdentifier("+14255550100");
+
+CreateCallOptions options = new CreateCallOptions(
+    new CommunicationUserIdentifier("<user-id>"),  // Source
+    List.of(target))                                // Targets
+    .setSourceCallerId(caller)
+    .setCallbackUrl("https://your-app.com/api/callbacks");
+
+CreateCallResult result = client.createCall(options);
+String callConnectionId = result.getCallConnectionProperties().getCallConnectionId();
+```
+
+## Answer Incoming Call
+
+```java
+// From Event Grid webhook - IncomingCall event
+String incomingCallContext = "<incoming-call-context-from-event>";
+
+AnswerCallOptions options = new AnswerCallOptions(
+    incomingCallContext,
+    "https://your-app.com/api/callbacks");
+
+AnswerCallResult result = client.answerCall(options);
+CallConnection callConnection = result.getCallConnection();
+```
+
+## Play Audio (Text-to-Speech)
+
+```java
+CallConnection callConnection = client.getCallConnection(callConnectionId);
+CallMedia callMedia = callConnection.getCallMedia();
+
+// Play text-to-speech
+TextSource textSource = new TextSource()
+    .setText("Welcome to Contoso. Press 1 for sales, 2 for support.")
+    .setVoiceName("en-US-JennyNeural");
+
+PlayOptions playOptions = new PlayOptions(
+    List.of(textSource),
+    List.of(new CommunicationUserIdentifier("<target-user>")));
+
+callMedia.play(playOptions);
+
+// Play audio file
+FileSource fileSource = new FileSource()
+    .setUrl("https://storage.blob.core.windows.net/audio/greeting.wav");
+
+callMedia.play(new PlayOptions(List.of(fileSource), List.of(target)));
+```
+
+## Recognize DTMF Input
+
+```java
+// Recognize DTMF tones
+DtmfTone stopTones = DtmfTone.POUND;
+
+CallMediaRecognizeDtmfOptions recognizeOptions = new CallMediaRecognizeDtmfOptions(
+    new CommunicationUserIdentifier("<target-user>"),
+    5)  // Max tones to collect
+    .setInterToneTimeout(Duration.ofSeconds(5))
+    .setStopTones(List.of(stopTones))
+    .setInitialSilenceTimeout(Duration.ofSeconds(15))
+    .setPlayPrompt(new TextSource().setText("Enter your account number followed by pound."));
+
+callMedia.startRecognizing(recognizeOptions);
+```
+
+## Recognize Speech
+
+```java
+// Speech recognition with AI
+CallMediaRecognizeSpeechOptions speechOptions = new CallMediaRecognizeSpeechOptions(
+    new CommunicationUserIdentifier("<target-user>"))
+    .setEndSilenceTimeout(Duration.ofSeconds(2))
+    .setSpeechLanguage("en-US")
+    .setPlayPrompt(new TextSource().setText("How can I help you today?"));
+
+callMedia.startRecognizing(speechOptions);
+```
+
+## Call Recording
+
+```java
+CallRecording callRecording = client.getCallRecording();
+
+// Start recording
+StartRecordingOptions recordingOptions = new StartRecordingOptions(
+    new ServerCallLocator("<server-call-id>"))
+    .setRecordingChannel(RecordingChannel.MIXED)
+    .setRecordingContent(RecordingContent.AUDIO_VIDEO)
+    .setRecordingFormat(RecordingFormat.MP4);
+
+RecordingStateResult recordingResult = callRecording.start(recordingOptions);
+String recordingId = recordingResult.getRecordingId();
+
+// Pause/resume/stop
+callRecording.pause(recordingId);
+callRecording.resume(recordingId);
+callRecording.stop(recordingId);
+
+// Download recording (after RecordingFileStatusUpdated event)
+callRecording.downloadTo(recordingUrl, Paths.get("recording.mp4"));
+```
+
+## Add Participant to Call
+
+```java
+CallConnection callConnection = client.getCallConnection(callConnectionId);
+
+CommunicationUserIdentifier participant = new CommunicationUserIdentifier("<user-id>");
+AddParticipantOptions addOptions = new AddParticipantOptions(participant)
+    .setInvitationTimeout(Duration.ofSeconds(30));
+
+AddParticipantResult result = callConnection.addParticipant(addOptions);
+```
+
+## Transfer Call
+
+```java
+// Blind transfer
+PhoneNumberIdentifier transferTarget = new PhoneNumberIdentifier("+14255559999");
+TransferCallToParticipantResult result = callConnection.transferCallToParticipant(transferTarget);
+```
+
+## Handle Events (Webhook)
+
+```java
+import com.azure.communication.callautomation.CallAutomationEventParser;
+import com.azure.communication.callautomation.models.events.*;
+
+// In your webhook endpoint
+public void handleCallback(String requestBody) {
+    List<CallAutomationEventBase> events = CallAutomationEventParser.parseEvents(requestBody);
+    
+    for (CallAutomationEventBase event : events) {
+        if (event instanceof CallConnected) {
+            CallConnected connected = (CallConnected) event;
+            System.out.println("Call connected: " + connected.getCallConnectionId());
+        } else if (event instanceof RecognizeCompleted) {
+            RecognizeCompleted recognized = (RecognizeCompleted) event;
+            // Handle DTMF or speech recognition result
+            DtmfResult dtmfResult = (DtmfResult) recognized.getRecognizeResult();
+            String tones = dtmfResult.getTones().stream()
+                .map(DtmfTone::toString)
+                .collect(Collectors.joining());
+            System.out.println("DTMF received: " + tones);
+        } else if (event instanceof PlayCompleted) {
+            System.out.println("Audio playback completed");
+        } else if (event instanceof CallDisconnected) {
+            System.out.println("Call ended");
+        }
+    }
+}
+```
+
+## Hang Up Call
+
+```java
+// Hang up for all participants
+callConnection.hangUp(true);
+
+// Hang up only this leg
+callConnection.hangUp(false);
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    client.answerCall(options);
+} catch (HttpResponseException e) {
+    if (e.getResponse().getStatusCode() == 404) {
+        System.out.println("Call not found or already ended");
+    } else if (e.getResponse().getStatusCode() == 400) {
+        System.out.println("Invalid request: " + e.getMessage());
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
+AZURE_COMMUNICATION_CONNECTION_STRING=endpoint=https://...;accesskey=...
+CALLBACK_BASE_URL=https://your-app.com/api/callbacks
+```
+
+## Trigger Phrases
+
+- "call automation Java", "IVR Java", "interactive voice response"
+- "call recording Java", "DTMF recognition Java"
+- "text to speech call", "speech recognition call"
+- "answer incoming call", "transfer call Java"
+- "Azure Communication Services call automation"

--- a/skills/java/communication/callautomation/references/examples.md
+++ b/skills/java/communication/callautomation/references/examples.md
@@ -1,0 +1,567 @@
+# Azure Communication Call Automation SDK for Java - Examples
+
+Comprehensive code examples for the Azure Communication Call Automation SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Creating Outbound Calls](#creating-outbound-calls)
+- [Answering Inbound Calls](#answering-inbound-calls)
+- [Playing Audio/TTS](#playing-audiotts)
+- [Recognizing DTMF Tones](#recognizing-dtmf-tones)
+- [Recording Calls](#recording-calls)
+- [Transfer Calls](#transfer-calls)
+- [Add/Remove Participants](#addremove-participants)
+- [Handling Call Events](#handling-call-events)
+- [Async Client Patterns](#async-client-patterns)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-callautomation</artifactId>
+    <version>1.5.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### Sync Client
+
+```java
+import com.azure.communication.callautomation.CallAutomationClient;
+import com.azure.communication.callautomation.CallAutomationClientBuilder;
+
+CallAutomationClient callAutomationClient = new CallAutomationClientBuilder()
+    .connectionString("<Azure Communication Services connection string>")
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.communication.callautomation.CallAutomationAsyncClient;
+
+CallAutomationAsyncClient asyncClient = new CallAutomationClientBuilder()
+    .connectionString("<acsConnectionString>")
+    .buildAsyncClient();
+```
+
+## Creating Outbound Calls
+
+### Single PSTN Call
+
+```java
+import com.azure.communication.callautomation.models.*;
+import com.azure.communication.common.PhoneNumberIdentifier;
+import com.azure.core.util.Context;
+
+String callbackUri = "https://<myendpoint>/Events";
+PhoneNumberIdentifier callerIdNumber = new PhoneNumberIdentifier("+18001234567");
+PhoneNumberIdentifier target = new PhoneNumberIdentifier("+16471234567");
+
+CallInvite callInvite = new CallInvite(target, callerIdNumber);
+CreateCallOptions createCallOptions = new CreateCallOptions(callInvite, callbackUri);
+
+// Optional: Add AI capabilities
+CallIntelligenceOptions callIntelligenceOptions = new CallIntelligenceOptions()
+    .setCognitiveServicesEndpoint("https://your-cognitive-services.cognitiveservices.azure.com/");
+createCallOptions.setCallIntelligenceOptions(callIntelligenceOptions);
+
+Response<CreateCallResult> result = callAutomationClient.createCallWithResponse(
+    createCallOptions, 
+    Context.NONE
+);
+String callConnectionId = result.getValue().getCallConnectionProperties().getCallConnectionId();
+```
+
+### Group Call
+
+```java
+import com.azure.communication.common.CommunicationUserIdentifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+List<CommunicationIdentifier> targets = new ArrayList<>(Arrays.asList(
+    new PhoneNumberIdentifier("+16471234567"),
+    new CommunicationUserIdentifier("<user_id>")
+));
+
+CreateGroupCallOptions groupCallOptions = new CreateGroupCallOptions(targets, callbackUri);
+groupCallOptions.setSourceCallIdNumber(callerIdNumber);
+
+Response<CreateCallResult> response = callAutomationClient.createGroupCallWithResponse(
+    groupCallOptions, 
+    Context.NONE
+);
+```
+
+## Answering Inbound Calls
+
+### Basic Answer
+
+```java
+import com.azure.communication.callautomation.models.*;
+
+String incomingCallContext = "<IncomingCallContext_From_IncomingCall_Event>";
+String callbackUri = "https://<myendpoint>/Events";
+
+AnswerCallOptions answerCallOptions = new AnswerCallOptions(incomingCallContext, callbackUri);
+Response<AnswerCallResult> response = callAutomationClient.answerCallWithResponse(
+    answerCallOptions, 
+    Context.NONE
+);
+```
+
+### Answer with AI Capabilities
+
+```java
+CallIntelligenceOptions callIntelligenceOptions = new CallIntelligenceOptions()
+    .setCognitiveServicesEndpoint("https://cognitive-services.cognitiveservices.azure.com/");
+
+AnswerCallOptions answerCallOptions = new AnswerCallOptions(incomingCallContext, callbackUri)
+    .setCallIntelligenceOptions(callIntelligenceOptions);
+
+Response<AnswerCallResult> response = callAutomationClient.answerCallWithResponse(
+    answerCallOptions, 
+    Context.NONE
+);
+```
+
+### Answer with Transcription
+
+```java
+TranscriptionOptions transcriptionOptions = new TranscriptionOptions(
+    "wss://your-websocket-url",
+    TranscriptionTransport.WEBSOCKET,
+    "en-US",
+    false,
+    "your-endpoint-id"
+);
+
+AnswerCallOptions answerCallOptions = new AnswerCallOptions(incomingCallContext, callbackUri)
+    .setCallIntelligenceOptions(callIntelligenceOptions)
+    .setTranscriptionOptions(transcriptionOptions);
+```
+
+## Playing Audio/TTS
+
+### Play Text-to-Speech to All
+
+```java
+import com.azure.communication.callautomation.CallConnection;
+
+String textToPlay = "Welcome to Contoso. How can I help you today?";
+
+TextSource textSource = new TextSource()
+    .setText(textToPlay)
+    .setVoiceName("en-US-NancyNeural");
+
+CallConnection callConnection = callAutomationClient.getCallConnection(callConnectionId);
+callConnection.getCallMedia().playToAll(textSource);
+```
+
+### Play Audio File to Participant
+
+```java
+import java.util.Arrays;
+
+CommunicationIdentifier targetParticipant = new PhoneNumberIdentifier("+16471234567");
+
+FileSource playSource = new FileSource()
+    .setUrl("https://storage.blob.core.windows.net/audio/welcome.wav")
+    .setPlaySourceCacheId("<playSourceId>");  // Optional: cache for repeated playback
+
+var playTo = Arrays.asList(targetParticipant);
+PlayOptions playOptions = new PlayOptions(playSource, playTo);
+
+callAutomationClient.getCallConnection(callConnectionId)
+    .getCallMedia()
+    .playWithResponse(playOptions, Context.NONE);
+```
+
+### Play with SSML
+
+```java
+String ssmlText = "<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\">" +
+    "<voice name=\"en-US-JennyNeural\">Hello, welcome to our service!</voice></speak>";
+
+SsmlSource ssmlSource = new SsmlSource()
+    .setSsmlText(ssmlText);
+
+callConnection.getCallMedia().playToAll(ssmlSource);
+```
+
+## Recognizing DTMF Tones
+
+### DTMF Recognition
+
+```java
+import java.time.Duration;
+import java.util.Arrays;
+
+CommunicationIdentifier targetParticipant = new PhoneNumberIdentifier("+16471234567");
+int maxTonesToCollect = 3;
+
+TextSource playSource = new TextSource()
+    .setText("Please enter 3 digits.")
+    .setVoiceName("en-US-ElizabethNeural");
+
+CallMediaRecognizeDtmfOptions recognizeOptions = new CallMediaRecognizeDtmfOptions(
+    targetParticipant, 
+    maxTonesToCollect
+)
+    .setInitialSilenceTimeout(Duration.ofSeconds(30))
+    .setPlayPrompt(playSource)
+    .setInterToneTimeout(Duration.ofSeconds(5))
+    .setInterruptPrompt(true)
+    .setStopTones(Arrays.asList(DtmfTone.POUND));
+
+callAutomationClient.getCallConnection(callConnectionId)
+    .getCallMedia()
+    .startRecognizingWithResponse(recognizeOptions, Context.NONE);
+```
+
+### Speech or DTMF Recognition
+
+```java
+CallMediaRecognizeSpeechOrDtmfOptions recognizeOptions = 
+    new CallMediaRecognizeSpeechOrDtmfOptions(
+        targetParticipant, 
+        maxTonesToCollect, 
+        Duration.ofMillis(1000)
+    )
+    .setPlayPrompt(playSource)
+    .setInitialSilenceTimeout(Duration.ofSeconds(30))
+    .setInterruptPrompt(true)
+    .setOperationContext("OpenQuestionSpeechOrDtmf");
+
+callAutomationClient.getCallConnection(callConnectionId)
+    .getCallMedia()
+    .startRecognizingWithResponse(recognizeOptions, Context.NONE);
+```
+
+### Choice Recognition
+
+```java
+import java.util.List;
+
+List<RecognitionChoice> choices = Arrays.asList(
+    new RecognitionChoice()
+        .setLabel("Confirm")
+        .setPhrases(Arrays.asList("Confirm", "Yes", "One"))
+        .setTone(DtmfTone.ONE),
+    new RecognitionChoice()
+        .setLabel("Cancel")
+        .setPhrases(Arrays.asList("Cancel", "No", "Two"))
+        .setTone(DtmfTone.TWO)
+);
+
+TextSource playSource = new TextSource()
+    .setText("Say Confirm or press 1 to confirm, or say Cancel or press 2 to cancel.")
+    .setVoiceName("en-US-ElizabethNeural");
+
+CallMediaRecognizeChoiceOptions recognizeOptions = new CallMediaRecognizeChoiceOptions(
+    targetParticipant, 
+    choices
+)
+    .setInterruptPrompt(true)
+    .setInitialSilenceTimeout(Duration.ofSeconds(30))
+    .setPlayPrompt(playSource)
+    .setOperationContext("AppointmentReminderMenu");
+
+callAutomationClient.getCallConnection(callConnectionId)
+    .getCallMedia()
+    .startRecognizingWithResponse(recognizeOptions, Context.NONE);
+```
+
+### Send DTMF Tones
+
+```java
+List<DtmfTone> tones = Arrays.asList(
+    DtmfTone.ONE, 
+    DtmfTone.TWO, 
+    DtmfTone.THREE, 
+    DtmfTone.POUND
+);
+
+SendDtmfTonesOptions options = new SendDtmfTonesOptions(
+    tones, 
+    new PhoneNumberIdentifier(targetPhoneNumber)
+);
+options.setOperationContext("dtmfs-to-ivr");
+
+callAutomationClient.getCallConnection(callConnectionId)
+    .getCallMedia()
+    .sendDtmfTonesWithResponse(options, Context.NONE);
+```
+
+## Recording Calls
+
+### Start Recording
+
+```java
+import com.azure.communication.callautomation.CallRecording;
+
+CallRecording callRecording = callAutomationClient.getCallRecording();
+
+StartRecordingOptions startRecordingOptions = new StartRecordingOptions(
+    new ServerCallLocator(serverCallId)
+)
+    .setRecordingContent(RecordingContent.AUDIO_VIDEO)
+    .setRecordingChannel(RecordingChannel.MIXED)
+    .setRecordingFormat(RecordingFormat.MP4);
+
+Response<RecordingStateResult> response = callRecording.startWithResponse(
+    startRecordingOptions, 
+    Context.NONE
+);
+
+String recordingId = response.getValue().getRecordingId();
+```
+
+### Pause/Resume Recording
+
+```java
+// Pause
+callRecording.pause(recordingId);
+
+// Resume
+callRecording.resume(recordingId);
+```
+
+### Stop Recording
+
+```java
+callRecording.stop(recordingId);
+```
+
+### Download Recording
+
+```java
+callRecording.downloadToWithResponse(
+    recordingUrl,
+    Paths.get("recording.mp4"),
+    null,  // HttpRange (optional)
+    Context.NONE
+);
+```
+
+## Transfer Calls
+
+### Blind Transfer
+
+```java
+CommunicationIdentifier transferDestination = new PhoneNumberIdentifier("+16471234567");
+
+TransferCallToParticipantOptions transferOptions = new TransferCallToParticipantOptions(
+    transferDestination
+);
+
+Response<TransferCallResult> response = callAutomationClient
+    .getCallConnection(callConnectionId)
+    .transferCallToParticipantWithResponse(transferOptions, Context.NONE);
+```
+
+### Transfer with Announcement
+
+```java
+TextSource transferee Prompt = new TextSource()
+    .setText("Please hold while we transfer your call.")
+    .setVoiceName("en-US-NancyNeural");
+
+TransferCallToParticipantOptions transferOptions = new TransferCallToParticipantOptions(
+    transferDestination
+)
+    .setSourceCallerIdNumber(new PhoneNumberIdentifier("+18001234567"))
+    .setTransfereeGreeting(transfereePrompt);
+
+callAutomationClient.getCallConnection(callConnectionId)
+    .transferCallToParticipantWithResponse(transferOptions, Context.NONE);
+```
+
+## Add/Remove Participants
+
+### Add Participant
+
+```java
+CommunicationIdentifier participant = new PhoneNumberIdentifier("+16471234567");
+PhoneNumberIdentifier callerId = new PhoneNumberIdentifier("+18001234567");
+
+AddParticipantOptions addOptions = new AddParticipantOptions(
+    new CallInvite(participant, callerId)
+);
+
+Response<AddParticipantResult> response = callAutomationClient
+    .getCallConnection(callConnectionId)
+    .addParticipantWithResponse(addOptions, Context.NONE);
+```
+
+### Remove Participant
+
+```java
+CommunicationIdentifier participant = new PhoneNumberIdentifier("+16471234567");
+
+callAutomationClient.getCallConnection(callConnectionId)
+    .removeParticipant(participant);
+```
+
+### List Participants
+
+```java
+ListParticipantsResult participants = callAutomationClient
+    .getCallConnection(callConnectionId)
+    .listParticipants();
+
+participants.getValues().forEach(p -> 
+    System.out.println("Participant: " + p.getIdentifier().getRawId()));
+```
+
+## Handling Call Events
+
+### Event Grid Webhook Handler (Spring Boot)
+
+```java
+import com.azure.communication.callautomation.CallAutomationEventParser;
+import com.azure.communication.callautomation.models.events.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class CallbackController {
+
+    @PostMapping("/Events")
+    public ResponseEntity<String> handleCallEvents(@RequestBody String requestBody) {
+        List<CallAutomationEventBase> events = CallAutomationEventParser.parseEvents(requestBody);
+        
+        for (CallAutomationEventBase event : events) {
+            String callConnectionId = event.getCallConnectionId();
+            
+            if (event instanceof CallConnected) {
+                handleCallConnected((CallConnected) event);
+            } else if (event instanceof RecognizeCompleted) {
+                handleRecognizeCompleted((RecognizeCompleted) event);
+            } else if (event instanceof RecognizeFailed) {
+                handleRecognizeFailed((RecognizeFailed) event);
+            } else if (event instanceof PlayCompleted) {
+                handlePlayCompleted((PlayCompleted) event);
+            } else if (event instanceof CallDisconnected) {
+                handleCallDisconnected((CallDisconnected) event);
+            }
+        }
+        
+        return ResponseEntity.ok("");
+    }
+    
+    private void handleCallConnected(CallConnected event) {
+        System.out.println("Call connected: " + event.getCallConnectionId());
+    }
+    
+    private void handleRecognizeCompleted(RecognizeCompleted event) {
+        CollectTonesResult result = (CollectTonesResult) event.getRecognizeResult();
+        String tones = result.getTones().stream()
+            .map(DtmfTone::toString)
+            .collect(Collectors.joining());
+        System.out.println("DTMF tones received: " + tones);
+    }
+    
+    private void handleRecognizeFailed(RecognizeFailed event) {
+        System.out.println("Recognition failed: " + event.getResultInformation().getMessage());
+    }
+    
+    private void handlePlayCompleted(PlayCompleted event) {
+        System.out.println("Play completed: " + event.getOperationContext());
+    }
+    
+    private void handleCallDisconnected(CallDisconnected event) {
+        System.out.println("Call disconnected: " + event.getCallConnectionId());
+    }
+}
+```
+
+## Async Client Patterns
+
+### Create Call Async
+
+```java
+asyncClient.createCall(callInvite, callbackUri)
+    .subscribe(
+        result -> System.out.println("Call ID: " + 
+            result.getCallConnectionProperties().getCallConnectionId()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### Play Audio Async
+
+```java
+asyncClient.getCallConnectionAsync(callConnectionId)
+    .getCallMediaAsync()
+    .playToAll(textSource)
+    .subscribe(
+        unused -> System.out.println("Play started"),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### Recognize Async
+
+```java
+asyncClient.getCallConnectionAsync(callConnectionId)
+    .getCallMediaAsync()
+    .startRecognizingWithResponse(recognizeOptions)
+    .subscribe(
+        response -> System.out.println("Recognition started"),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+## Error Handling
+
+### Sync Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    Response<CreateCallResult> result = callAutomationClient.createCallWithResponse(
+        createCallOptions, 
+        Context.NONE
+    );
+} catch (HttpResponseException e) {
+    System.err.println("HTTP Status: " + e.getResponse().getStatusCode());
+    System.err.println("Error: " + e.getMessage());
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+### Async Error Handling
+
+```java
+asyncClient.createCall(callInvite, callbackUri)
+    .subscribe(
+        result -> System.out.println("Success"),
+        error -> {
+            if (error instanceof HttpResponseException) {
+                HttpResponseException httpError = (HttpResponseException) error;
+                System.err.println("HTTP error: " + httpError.getResponse().getStatusCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        }
+    );
+```
+
+### Common Error Codes
+
+| Code | Meaning |
+|------|---------|
+| 400 | Invalid request |
+| 401 | Authentication failed |
+| 403 | Not authorized |
+| 404 | Call/resource not found |
+| 429 | Rate limited |
+| 500 | Server error |

--- a/skills/java/communication/callingserver/SKILL.md
+++ b/skills/java/communication/callingserver/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: azure-communication-callingserver-java
+description: Azure Communication Services CallingServer (legacy) Java SDK. Note - This SDK is deprecated. Use azure-communication-callautomation instead for new projects. Only use this skill when maintaining legacy code.
+---
+
+# Azure Communication CallingServer (Java) - DEPRECATED
+
+> **⚠️ DEPRECATED**: This SDK has been renamed to **Call Automation**. For new projects, use `azure-communication-callautomation` instead. This skill is for maintaining legacy code only.
+
+## Migration to Call Automation
+
+```xml
+<!-- OLD (deprecated) -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-callingserver</artifactId>
+    <version>1.0.0-beta.5</version>
+</dependency>
+
+<!-- NEW (use this instead) -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-callautomation</artifactId>
+    <version>1.6.0</version>
+</dependency>
+```
+
+## Class Name Changes
+
+| CallingServer (Old) | Call Automation (New) |
+|---------------------|----------------------|
+| `CallingServerClient` | `CallAutomationClient` |
+| `CallingServerClientBuilder` | `CallAutomationClientBuilder` |
+| `CallConnection` | `CallConnection` (same) |
+| `ServerCall` | Removed - use `CallConnection` |
+
+## Legacy Client Creation
+
+```java
+// OLD WAY (deprecated)
+import com.azure.communication.callingserver.CallingServerClient;
+import com.azure.communication.callingserver.CallingServerClientBuilder;
+
+CallingServerClient client = new CallingServerClientBuilder()
+    .connectionString("<connection-string>")
+    .buildClient();
+
+// NEW WAY
+import com.azure.communication.callautomation.CallAutomationClient;
+import com.azure.communication.callautomation.CallAutomationClientBuilder;
+
+CallAutomationClient client = new CallAutomationClientBuilder()
+    .connectionString("<connection-string>")
+    .buildClient();
+```
+
+## Legacy Recording
+
+```java
+// OLD WAY
+StartRecordingOptions options = new StartRecordingOptions(serverCallId)
+    .setRecordingStateCallbackUri(callbackUri);
+
+StartCallRecordingResult result = client.startRecording(options);
+String recordingId = result.getRecordingId();
+
+client.pauseRecording(recordingId);
+client.resumeRecording(recordingId);
+client.stopRecording(recordingId);
+
+// NEW WAY - see azure-communication-callautomation skill
+```
+
+## For New Development
+
+**Do not use this SDK for new projects.** 
+
+See the `azure-communication-callautomation-java` skill for:
+- Making outbound calls
+- Answering incoming calls
+- Call recording
+- DTMF recognition
+- Text-to-speech / speech-to-text
+- Adding/removing participants
+- Call transfer
+
+## Trigger Phrases
+
+- "callingserver legacy", "deprecated calling SDK"
+- "migrate callingserver to callautomation"

--- a/skills/java/communication/callingserver/references/examples.md
+++ b/skills/java/communication/callingserver/references/examples.md
@@ -1,0 +1,93 @@
+# Azure Communication CallingServer Java SDK - Migration Guide
+
+> **⚠️ DEPRECATED**: This SDK has been renamed to **Call Automation**. For new projects, use `azure-communication-callautomation` instead.
+
+## Migration Summary
+
+The `azure-communication-callingserver` package is deprecated. All new development should use `azure-communication-callautomation`.
+
+## Dependency Change
+
+```xml
+<!-- OLD (deprecated) -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-callingserver</artifactId>
+    <version>1.0.0-beta.5</version>
+</dependency>
+
+<!-- NEW (use this instead) -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-callautomation</artifactId>
+    <version>1.6.0</version>
+</dependency>
+```
+
+## Class Name Changes
+
+| CallingServer (Old) | Call Automation (New) |
+|---------------------|----------------------|
+| `CallingServerClient` | `CallAutomationClient` |
+| `CallingServerClientBuilder` | `CallAutomationClientBuilder` |
+| `CallConnection` | `CallConnection` (same) |
+| `ServerCall` | Removed - use `CallConnection` |
+
+## Client Creation Migration
+
+### Old Way (Deprecated)
+
+```java
+import com.azure.communication.callingserver.CallingServerClient;
+import com.azure.communication.callingserver.CallingServerClientBuilder;
+
+CallingServerClient client = new CallingServerClientBuilder()
+    .connectionString("<connection-string>")
+    .buildClient();
+```
+
+### New Way (Recommended)
+
+```java
+import com.azure.communication.callautomation.CallAutomationClient;
+import com.azure.communication.callautomation.CallAutomationClientBuilder;
+
+CallAutomationClient client = new CallAutomationClientBuilder()
+    .connectionString("<connection-string>")
+    .buildClient();
+```
+
+## Recording Migration
+
+### Old Way
+
+```java
+StartRecordingOptions options = new StartRecordingOptions(serverCallId)
+    .setRecordingStateCallbackUri(callbackUri);
+
+StartCallRecordingResult result = client.startRecording(options);
+String recordingId = result.getRecordingId();
+
+client.pauseRecording(recordingId);
+client.resumeRecording(recordingId);
+client.stopRecording(recordingId);
+```
+
+### New Way
+
+See the `azure-communication-callautomation` skill for the new recording API.
+
+## For New Development
+
+Use the **azure-communication-callautomation** skill for:
+- Making outbound calls
+- Answering incoming calls
+- Call recording
+- DTMF recognition
+- Text-to-speech / speech-to-text
+- Adding/removing participants
+- Call transfer
+
+## Reference
+
+See the [Call Automation skill](../callautomation/SKILL.md) for complete documentation.

--- a/skills/java/communication/chat/SKILL.md
+++ b/skills/java/communication/chat/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: azure-communication-chat-java
+description: Build real-time chat applications with Azure Communication Services Chat Java SDK. Use when implementing chat threads, messaging, participants, read receipts, typing notifications, or real-time chat features.
+---
+
+# Azure Communication Chat (Java)
+
+Build real-time chat applications with thread management, messaging, participants, and read receipts.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-chat</artifactId>
+    <version>1.6.0</version>
+</dependency>
+```
+
+## Client Creation
+
+```java
+import com.azure.communication.chat.ChatClient;
+import com.azure.communication.chat.ChatClientBuilder;
+import com.azure.communication.chat.ChatThreadClient;
+import com.azure.communication.common.CommunicationTokenCredential;
+
+// ChatClient requires a CommunicationTokenCredential (user access token)
+String endpoint = "https://<resource>.communication.azure.com";
+String userAccessToken = "<user-access-token>";
+
+CommunicationTokenCredential credential = new CommunicationTokenCredential(userAccessToken);
+
+ChatClient chatClient = new ChatClientBuilder()
+    .endpoint(endpoint)
+    .credential(credential)
+    .buildClient();
+
+// Async client
+ChatAsyncClient chatAsyncClient = new ChatClientBuilder()
+    .endpoint(endpoint)
+    .credential(credential)
+    .buildAsyncClient();
+```
+
+## Key Concepts
+
+| Class | Purpose |
+|-------|---------|
+| `ChatClient` | Create/delete chat threads, get thread clients |
+| `ChatThreadClient` | Operations within a thread (messages, participants, receipts) |
+| `ChatParticipant` | User in a chat thread with display name |
+| `ChatMessage` | Message content, type, sender info, timestamps |
+| `ChatMessageReadReceipt` | Read receipt tracking per participant |
+
+## Create Chat Thread
+
+```java
+import com.azure.communication.chat.models.*;
+import com.azure.communication.common.CommunicationUserIdentifier;
+import java.util.ArrayList;
+import java.util.List;
+
+// Define participants
+List<ChatParticipant> participants = new ArrayList<>();
+
+ChatParticipant participant1 = new ChatParticipant()
+    .setCommunicationIdentifier(new CommunicationUserIdentifier("<user-id-1>"))
+    .setDisplayName("Alice");
+
+ChatParticipant participant2 = new ChatParticipant()
+    .setCommunicationIdentifier(new CommunicationUserIdentifier("<user-id-2>"))
+    .setDisplayName("Bob");
+
+participants.add(participant1);
+participants.add(participant2);
+
+// Create thread
+CreateChatThreadOptions options = new CreateChatThreadOptions("Project Discussion")
+    .setParticipants(participants);
+
+CreateChatThreadResult result = chatClient.createChatThread(options);
+String threadId = result.getChatThread().getId();
+
+// Get thread client for operations
+ChatThreadClient threadClient = chatClient.getChatThreadClient(threadId);
+```
+
+## Send Messages
+
+```java
+// Send text message
+SendChatMessageOptions messageOptions = new SendChatMessageOptions()
+    .setContent("Hello, team!")
+    .setSenderDisplayName("Alice")
+    .setType(ChatMessageType.TEXT);
+
+SendChatMessageResult sendResult = threadClient.sendMessage(messageOptions);
+String messageId = sendResult.getId();
+
+// Send HTML message
+SendChatMessageOptions htmlOptions = new SendChatMessageOptions()
+    .setContent("<strong>Important:</strong> Meeting at 3pm")
+    .setType(ChatMessageType.HTML);
+
+threadClient.sendMessage(htmlOptions);
+```
+
+## Get Messages
+
+```java
+import com.azure.core.util.paging.PagedIterable;
+
+// List all messages
+PagedIterable<ChatMessage> messages = threadClient.listMessages();
+
+for (ChatMessage message : messages) {
+    System.out.println("ID: " + message.getId());
+    System.out.println("Type: " + message.getType());
+    System.out.println("Content: " + message.getContent().getMessage());
+    System.out.println("Sender: " + message.getSenderDisplayName());
+    System.out.println("Created: " + message.getCreatedOn());
+    
+    // Check if edited or deleted
+    if (message.getEditedOn() != null) {
+        System.out.println("Edited: " + message.getEditedOn());
+    }
+    if (message.getDeletedOn() != null) {
+        System.out.println("Deleted: " + message.getDeletedOn());
+    }
+}
+
+// Get specific message
+ChatMessage message = threadClient.getMessage(messageId);
+```
+
+## Update and Delete Messages
+
+```java
+// Update message
+UpdateChatMessageOptions updateOptions = new UpdateChatMessageOptions()
+    .setContent("Updated message content");
+
+threadClient.updateMessage(messageId, updateOptions);
+
+// Delete message
+threadClient.deleteMessage(messageId);
+```
+
+## Manage Participants
+
+```java
+// List participants
+PagedIterable<ChatParticipant> participants = threadClient.listParticipants();
+
+for (ChatParticipant participant : participants) {
+    CommunicationUserIdentifier user = 
+        (CommunicationUserIdentifier) participant.getCommunicationIdentifier();
+    System.out.println("User: " + user.getId());
+    System.out.println("Display Name: " + participant.getDisplayName());
+}
+
+// Add participants
+List<ChatParticipant> newParticipants = new ArrayList<>();
+newParticipants.add(new ChatParticipant()
+    .setCommunicationIdentifier(new CommunicationUserIdentifier("<new-user-id>"))
+    .setDisplayName("Charlie")
+    .setShareHistoryTime(OffsetDateTime.now().minusDays(7))); // Share last 7 days
+
+threadClient.addParticipants(newParticipants);
+
+// Remove participant
+CommunicationUserIdentifier userToRemove = new CommunicationUserIdentifier("<user-id>");
+threadClient.removeParticipant(userToRemove);
+```
+
+## Read Receipts
+
+```java
+// Send read receipt
+threadClient.sendReadReceipt(messageId);
+
+// Get read receipts
+PagedIterable<ChatMessageReadReceipt> receipts = threadClient.listReadReceipts();
+
+for (ChatMessageReadReceipt receipt : receipts) {
+    System.out.println("Message ID: " + receipt.getChatMessageId());
+    System.out.println("Read by: " + receipt.getSenderCommunicationIdentifier());
+    System.out.println("Read at: " + receipt.getReadOn());
+}
+```
+
+## Typing Notifications
+
+```java
+import com.azure.communication.chat.models.TypingNotificationOptions;
+
+// Send typing notification
+TypingNotificationOptions typingOptions = new TypingNotificationOptions()
+    .setSenderDisplayName("Alice");
+
+threadClient.sendTypingNotificationWithResponse(typingOptions, Context.NONE);
+
+// Simple typing notification
+threadClient.sendTypingNotification();
+```
+
+## Thread Operations
+
+```java
+// Get thread properties
+ChatThreadProperties properties = threadClient.getProperties();
+System.out.println("Topic: " + properties.getTopic());
+System.out.println("Created: " + properties.getCreatedOn());
+
+// Update topic
+threadClient.updateTopic("New Project Discussion Topic");
+
+// Delete thread
+chatClient.deleteChatThread(threadId);
+```
+
+## List Threads
+
+```java
+// List all chat threads for the user
+PagedIterable<ChatThreadItem> threads = chatClient.listChatThreads();
+
+for (ChatThreadItem thread : threads) {
+    System.out.println("Thread ID: " + thread.getId());
+    System.out.println("Topic: " + thread.getTopic());
+    System.out.println("Last message: " + thread.getLastMessageReceivedOn());
+}
+```
+
+## Pagination
+
+```java
+import com.azure.core.http.rest.PagedResponse;
+
+// Paginate through messages
+int maxPageSize = 10;
+ListChatMessagesOptions listOptions = new ListChatMessagesOptions()
+    .setMaxPageSize(maxPageSize);
+
+PagedIterable<ChatMessage> pagedMessages = threadClient.listMessages(listOptions);
+
+pagedMessages.iterableByPage().forEach(page -> {
+    System.out.println("Page status code: " + page.getStatusCode());
+    page.getElements().forEach(msg -> 
+        System.out.println("Message: " + msg.getContent().getMessage()));
+});
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    threadClient.sendMessage(messageOptions);
+} catch (HttpResponseException e) {
+    switch (e.getResponse().getStatusCode()) {
+        case 401:
+            System.out.println("Unauthorized - check token");
+            break;
+        case 403:
+            System.out.println("Forbidden - user not in thread");
+            break;
+        case 404:
+            System.out.println("Thread not found");
+            break;
+        default:
+            System.out.println("Error: " + e.getMessage());
+    }
+}
+```
+
+## Message Types
+
+| Type | Description |
+|------|-------------|
+| `TEXT` | Regular chat message |
+| `HTML` | HTML-formatted message |
+| `TOPIC_UPDATED` | System message - topic changed |
+| `PARTICIPANT_ADDED` | System message - participant joined |
+| `PARTICIPANT_REMOVED` | System message - participant left |
+
+## Environment Variables
+
+```bash
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
+AZURE_COMMUNICATION_USER_TOKEN=<user-access-token>
+```
+
+## Best Practices
+
+1. **Token Management** - User tokens expire; implement refresh logic with `CommunicationTokenRefreshOptions`
+2. **Pagination** - Use `listMessages(options)` with `maxPageSize` for large threads
+3. **Share History** - Set `shareHistoryTime` when adding participants to control message visibility
+4. **Message Types** - Filter system messages (`PARTICIPANT_ADDED`, etc.) from user messages
+5. **Read Receipts** - Send receipts only when messages are actually viewed by user
+
+## Trigger Phrases
+
+- "chat application Java", "real-time messaging Java"
+- "chat thread", "chat participants", "chat messages"
+- "read receipts", "typing notifications"
+- "Azure Communication Services chat"

--- a/skills/java/communication/chat/references/examples.md
+++ b/skills/java/communication/chat/references/examples.md
@@ -1,0 +1,435 @@
+# Azure Communication Chat SDK for Java - Examples
+
+Comprehensive code examples for the Azure Communication Chat SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Creating Chat Threads](#creating-chat-threads)
+- [Sending Messages](#sending-messages)
+- [Listing Messages](#listing-messages)
+- [Adding and Removing Participants](#adding-and-removing-participants)
+- [Updating Thread Topic](#updating-thread-topic)
+- [Typing Notifications](#typing-notifications)
+- [Read Receipts](#read-receipts)
+- [Async Client Patterns](#async-client-patterns)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-chat</artifactId>
+    <version>1.6.4</version>
+</dependency>
+
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-common</artifactId>
+    <version>1.3.8</version>
+</dependency>
+```
+
+Using Azure SDK BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-communication-chat</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## Client Creation
+
+### Synchronous ChatClient
+
+```java
+import com.azure.communication.chat.ChatClient;
+import com.azure.communication.chat.ChatClientBuilder;
+import com.azure.communication.common.CommunicationTokenCredential;
+
+String endpoint = "https://<RESOURCE_NAME>.communication.azure.com";
+String userAccessToken = "<USER_ACCESS_TOKEN>";
+
+CommunicationTokenCredential credential = new CommunicationTokenCredential(userAccessToken);
+
+ChatClient chatClient = new ChatClientBuilder()
+    .endpoint(endpoint)
+    .credential(credential)
+    .buildClient();
+```
+
+### Asynchronous ChatAsyncClient
+
+```java
+import com.azure.communication.chat.ChatAsyncClient;
+import com.azure.communication.chat.ChatClientBuilder;
+
+ChatAsyncClient chatAsyncClient = new ChatClientBuilder()
+    .endpoint(endpoint)
+    .credential(credential)
+    .buildAsyncClient();
+```
+
+### Get ChatThreadClient
+
+```java
+import com.azure.communication.chat.ChatThreadClient;
+
+String chatThreadId = "19:abc123...@thread.v2";
+ChatThreadClient chatThreadClient = chatClient.getChatThreadClient(chatThreadId);
+```
+
+## Creating Chat Threads
+
+```java
+import com.azure.communication.chat.models.ChatParticipant;
+import com.azure.communication.chat.models.CreateChatThreadOptions;
+import com.azure.communication.chat.models.CreateChatThreadResult;
+import com.azure.communication.common.CommunicationUserIdentifier;
+
+String userId1 = "<USER_Id1>";
+ChatParticipant firstParticipant = new ChatParticipant()
+    .setCommunicationIdentifier(new CommunicationUserIdentifier(userId1))
+    .setDisplayName("Display Name 1");
+
+String userId2 = "<USER_Id2>";
+ChatParticipant secondParticipant = new ChatParticipant()
+    .setCommunicationIdentifier(new CommunicationUserIdentifier(userId2))
+    .setDisplayName("Display Name 2");
+
+CreateChatThreadOptions createOptions = new CreateChatThreadOptions("Topic")
+    .addParticipant(firstParticipant)
+    .addParticipant(secondParticipant);
+
+CreateChatThreadResult result = chatClient.createChatThread(createOptions);
+String chatThreadId = result.getChatThread().getId();
+
+// Get thread client
+ChatThreadClient chatThreadClient = chatClient.getChatThreadClient(chatThreadId);
+```
+
+### Using setParticipants
+
+```java
+import java.util.ArrayList;
+import java.util.List;
+
+List<ChatParticipant> participants = new ArrayList<>();
+participants.add(firstParticipant);
+participants.add(secondParticipant);
+
+CreateChatThreadOptions createOptions = new CreateChatThreadOptions("Topic")
+    .setParticipants(participants);
+
+CreateChatThreadResult result = chatClient.createChatThread(createOptions);
+```
+
+## Sending Messages
+
+### Send Text Message
+
+```java
+import com.azure.communication.chat.models.ChatMessageType;
+import com.azure.communication.chat.models.SendChatMessageOptions;
+import com.azure.communication.chat.models.SendChatMessageResult;
+
+SendChatMessageOptions sendOptions = new SendChatMessageOptions()
+    .setContent("Message content")
+    .setType(ChatMessageType.TEXT)
+    .setSenderDisplayName("Sender Display Name");
+
+SendChatMessageResult sendResult = chatThreadClient.sendMessage(sendOptions);
+String chatMessageId = sendResult.getId();
+```
+
+### Send Message with Metadata
+
+```java
+import java.util.HashMap;
+import java.util.Map;
+
+Map<String, String> metadata = new HashMap<>();
+metadata.put("hasAttachment", "true");
+metadata.put("attachmentUrl", "https://contoso.com/files/attachment.docx");
+
+SendChatMessageOptions sendOptions = new SendChatMessageOptions()
+    .setType(ChatMessageType.TEXT)
+    .setContent("Please take a look at the attachment")
+    .setSenderDisplayName("Sender")
+    .setMetadata(metadata);
+
+SendChatMessageResult sendResult = chatThreadClient.sendMessage(sendOptions);
+```
+
+## Listing Messages
+
+### List All Messages
+
+```java
+import com.azure.communication.chat.models.ChatMessage;
+
+chatThreadClient.listMessages().forEach(message -> {
+    System.out.printf("Message id: %s%n", message.getId());
+    System.out.printf("Content: %s%n", message.getContent().getMessage());
+});
+```
+
+### List with Pagination
+
+```java
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<ChatMessage> messages = chatThreadClient.listMessages();
+messages.iterableByPage().forEach(page -> {
+    System.out.printf("Status: %d%n", page.getStatusCode());
+    page.getElements().forEach(message ->
+        System.out.printf("Message: %s%n", message.getId()));
+});
+```
+
+### Get Specific Message
+
+```java
+ChatMessage message = chatThreadClient.getMessage(chatMessageId);
+System.out.printf("Content: %s%n", message.getContent().getMessage());
+```
+
+### Update Message
+
+```java
+import com.azure.communication.chat.models.UpdateChatMessageOptions;
+
+UpdateChatMessageOptions updateOptions = new UpdateChatMessageOptions()
+    .setContent("Updated message content");
+
+chatThreadClient.updateMessage(chatMessageId, updateOptions);
+```
+
+### Delete Message
+
+```java
+chatThreadClient.deleteMessage(chatMessageId);
+```
+
+### Check Message Status
+
+```java
+chatThreadClient.listMessages().forEach(message -> {
+    // Check if deleted
+    if (message.getDeletedOn() != null) {
+        System.out.println("Deleted at: " + message.getDeletedOn());
+    }
+    
+    // Check if edited
+    if (message.getEditedOn() != null) {
+        System.out.println("Edited at: " + message.getEditedOn());
+    }
+    
+    // Message type
+    System.out.println("Type: " + message.getType());
+});
+```
+
+## Adding and Removing Participants
+
+### Add Participants
+
+```java
+import java.util.ArrayList;
+import java.util.List;
+
+List<ChatParticipant> participants = new ArrayList<>();
+
+ChatParticipant newParticipant = new ChatParticipant()
+    .setCommunicationIdentifier(new CommunicationUserIdentifier("<USER_Id3>"))
+    .setDisplayName("Display Name 3");
+
+participants.add(newParticipant);
+
+chatThreadClient.addParticipants(participants);
+```
+
+### Add Participant with History Sharing
+
+```java
+import java.time.OffsetDateTime;
+
+ChatParticipant newParticipant = new ChatParticipant()
+    .setCommunicationIdentifier(new CommunicationUserIdentifier("<USER_ID>"))
+    .setDisplayName("New Participant")
+    .setShareHistoryTime(OffsetDateTime.MIN);  // Share from beginning
+
+List<ChatParticipant> participants = new ArrayList<>();
+participants.add(newParticipant);
+chatThreadClient.addParticipants(participants);
+```
+
+### Remove Participant
+
+```java
+CommunicationUserIdentifier user = new CommunicationUserIdentifier("<USER_ID>");
+chatThreadClient.removeParticipant(user);
+```
+
+### List Participants
+
+```java
+import com.azure.communication.chat.models.ChatParticipant;
+
+chatThreadClient.listParticipants().forEach(participant -> {
+    System.out.println("Participant: " + participant.getDisplayName());
+});
+```
+
+## Updating Thread Topic
+
+```java
+chatThreadClient.updateTopic("New Topic");
+```
+
+## Typing Notifications
+
+### Send Typing Notification
+
+```java
+chatThreadClient.sendTypingNotification();
+```
+
+### Send with Options
+
+```java
+import com.azure.communication.chat.models.TypingNotificationOptions;
+
+TypingNotificationOptions options = new TypingNotificationOptions()
+    .setSenderDisplayName("Sender Name");
+
+chatThreadClient.sendTypingNotificationWithResponse(options, null);
+```
+
+## Read Receipts
+
+### Send Read Receipt
+
+```java
+chatThreadClient.sendReadReceipt(chatMessageId);
+```
+
+### List Read Receipts
+
+```java
+import com.azure.communication.chat.models.ChatMessageReadReceipt;
+
+chatThreadClient.listReadReceipts().forEach(receipt -> {
+    System.out.printf("Message ID: %s, Read by: %s at %s%n",
+        receipt.getChatMessageId(),
+        receipt.getSenderCommunicationIdentifier().getRawId(),
+        receipt.getReadOn());
+});
+```
+
+## Async Client Patterns
+
+### Create Thread Async
+
+```java
+chatAsyncClient.createChatThread(createOptions)
+    .subscribe(
+        result -> System.out.println("Thread ID: " + result.getChatThread().getId()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### Send Message Async
+
+```java
+ChatThreadAsyncClient asyncThreadClient = chatAsyncClient.getChatThreadClient(chatThreadId);
+
+asyncThreadClient.sendMessage(sendOptions)
+    .subscribe(
+        result -> System.out.println("Message ID: " + result.getId()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### List Messages Async
+
+```java
+asyncThreadClient.listMessages()
+    .subscribe(
+        message -> System.out.println("Message: " + message.getId()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### Chain Operations Async
+
+```java
+chatAsyncClient.createChatThread(createOptions)
+    .flatMap(result -> {
+        String threadId = result.getChatThread().getId();
+        return chatAsyncClient.getChatThreadClient(threadId).sendMessage(sendOptions);
+    })
+    .subscribe(
+        sendResult -> System.out.println("Message sent: " + sendResult.getId()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+## Error Handling
+
+### Sync Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    chatThreadClient.sendMessage(sendOptions);
+} catch (HttpResponseException e) {
+    System.err.println("HTTP Status: " + e.getResponse().getStatusCode());
+    System.err.println("Error: " + e.getMessage());
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+### Async Error Handling
+
+```java
+asyncThreadClient.sendMessage(sendOptions)
+    .subscribe(
+        result -> System.out.println("Success"),
+        error -> {
+            if (error instanceof HttpResponseException) {
+                HttpResponseException httpError = (HttpResponseException) error;
+                System.err.println("HTTP error: " + httpError.getResponse().getStatusCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        }
+    );
+```
+
+### Common Error Scenarios
+
+| Status Code | Cause |
+|-------------|-------|
+| 401 | Invalid or expired token |
+| 403 | User not in thread |
+| 404 | Thread or message not found |
+| 429 | Rate limited |

--- a/skills/java/communication/common/SKILL.md
+++ b/skills/java/communication/common/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: azure-communication-common-java
+description: Azure Communication Services common utilities for Java. Use when working with CommunicationTokenCredential, user identifiers, token refresh, or shared authentication across ACS services.
+---
+
+# Azure Communication Common (Java)
+
+Shared authentication utilities and data structures for Azure Communication Services.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-common</artifactId>
+    <version>1.4.0</version>
+</dependency>
+```
+
+## Key Concepts
+
+| Class | Purpose |
+|-------|---------|
+| `CommunicationTokenCredential` | Authenticate users with ACS services |
+| `CommunicationTokenRefreshOptions` | Configure automatic token refresh |
+| `CommunicationUserIdentifier` | Identify ACS users |
+| `PhoneNumberIdentifier` | Identify PSTN phone numbers |
+| `MicrosoftTeamsUserIdentifier` | Identify Teams users |
+| `UnknownIdentifier` | Generic identifier for unknown types |
+
+## CommunicationTokenCredential
+
+### Static Token (Short-lived Clients)
+
+```java
+import com.azure.communication.common.CommunicationTokenCredential;
+
+// Simple static token - no refresh
+String userToken = "<user-access-token>";
+CommunicationTokenCredential credential = new CommunicationTokenCredential(userToken);
+
+// Use with Chat, Calling, etc.
+ChatClient chatClient = new ChatClientBuilder()
+    .endpoint("https://<resource>.communication.azure.com")
+    .credential(credential)
+    .buildClient();
+```
+
+### Proactive Token Refresh (Long-lived Clients)
+
+```java
+import com.azure.communication.common.CommunicationTokenRefreshOptions;
+import java.util.concurrent.Callable;
+
+// Token refresher callback - called when token is about to expire
+Callable<String> tokenRefresher = () -> {
+    // Call your server to get a fresh token
+    return fetchNewTokenFromServer();
+};
+
+// With proactive refresh
+CommunicationTokenRefreshOptions refreshOptions = new CommunicationTokenRefreshOptions(tokenRefresher)
+    .setRefreshProactively(true)      // Refresh before expiry
+    .setInitialToken(currentToken);    // Optional initial token
+
+CommunicationTokenCredential credential = new CommunicationTokenCredential(refreshOptions);
+```
+
+### Async Token Refresh
+
+```java
+import java.util.concurrent.CompletableFuture;
+
+// Async token fetcher
+Callable<String> asyncRefresher = () -> {
+    CompletableFuture<String> future = fetchTokenAsync();
+    return future.get();  // Block until token is available
+};
+
+CommunicationTokenRefreshOptions options = new CommunicationTokenRefreshOptions(asyncRefresher)
+    .setRefreshProactively(true);
+
+CommunicationTokenCredential credential = new CommunicationTokenCredential(options);
+```
+
+## Entra ID (Azure AD) Authentication
+
+```java
+import com.azure.identity.InteractiveBrowserCredentialBuilder;
+import com.azure.communication.common.EntraCommunicationTokenCredentialOptions;
+import java.util.Arrays;
+import java.util.List;
+
+// For Teams Phone Extensibility
+InteractiveBrowserCredential entraCredential = new InteractiveBrowserCredentialBuilder()
+    .clientId("<your-client-id>")
+    .tenantId("<your-tenant-id>")
+    .redirectUrl("<your-redirect-uri>")
+    .build();
+
+String resourceEndpoint = "https://<resource>.communication.azure.com";
+List<String> scopes = Arrays.asList(
+    "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls"
+);
+
+EntraCommunicationTokenCredentialOptions entraOptions = 
+    new EntraCommunicationTokenCredentialOptions(entraCredential, resourceEndpoint)
+        .setScopes(scopes);
+
+CommunicationTokenCredential credential = new CommunicationTokenCredential(entraOptions);
+```
+
+## Communication Identifiers
+
+### CommunicationUserIdentifier
+
+```java
+import com.azure.communication.common.CommunicationUserIdentifier;
+
+// Create identifier for ACS user
+CommunicationUserIdentifier user = new CommunicationUserIdentifier("8:acs:resource-id_user-id");
+
+// Get raw ID
+String rawId = user.getId();
+```
+
+### PhoneNumberIdentifier
+
+```java
+import com.azure.communication.common.PhoneNumberIdentifier;
+
+// E.164 format phone number
+PhoneNumberIdentifier phone = new PhoneNumberIdentifier("+14255551234");
+
+String phoneNumber = phone.getPhoneNumber();  // "+14255551234"
+String rawId = phone.getRawId();              // "4:+14255551234"
+```
+
+### MicrosoftTeamsUserIdentifier
+
+```java
+import com.azure.communication.common.MicrosoftTeamsUserIdentifier;
+
+// Teams user identifier
+MicrosoftTeamsUserIdentifier teamsUser = new MicrosoftTeamsUserIdentifier("<teams-user-id>")
+    .setCloudEnvironment(CommunicationCloudEnvironment.PUBLIC);
+
+// For anonymous Teams users
+MicrosoftTeamsUserIdentifier anonymousTeamsUser = new MicrosoftTeamsUserIdentifier("<teams-user-id>")
+    .setAnonymous(true);
+```
+
+### UnknownIdentifier
+
+```java
+import com.azure.communication.common.UnknownIdentifier;
+
+// For identifiers of unknown type
+UnknownIdentifier unknown = new UnknownIdentifier("some-raw-id");
+```
+
+## Identifier Parsing
+
+```java
+import com.azure.communication.common.CommunicationIdentifier;
+import com.azure.communication.common.CommunicationIdentifierModel;
+
+// Parse raw ID to appropriate type
+public CommunicationIdentifier parseIdentifier(String rawId) {
+    if (rawId.startsWith("8:acs:")) {
+        return new CommunicationUserIdentifier(rawId);
+    } else if (rawId.startsWith("4:")) {
+        String phone = rawId.substring(2);
+        return new PhoneNumberIdentifier(phone);
+    } else if (rawId.startsWith("8:orgid:")) {
+        String teamsId = rawId.substring(8);
+        return new MicrosoftTeamsUserIdentifier(teamsId);
+    } else {
+        return new UnknownIdentifier(rawId);
+    }
+}
+```
+
+## Type Checking Identifiers
+
+```java
+import com.azure.communication.common.CommunicationIdentifier;
+
+public void processIdentifier(CommunicationIdentifier identifier) {
+    if (identifier instanceof CommunicationUserIdentifier) {
+        CommunicationUserIdentifier user = (CommunicationUserIdentifier) identifier;
+        System.out.println("ACS User: " + user.getId());
+        
+    } else if (identifier instanceof PhoneNumberIdentifier) {
+        PhoneNumberIdentifier phone = (PhoneNumberIdentifier) identifier;
+        System.out.println("Phone: " + phone.getPhoneNumber());
+        
+    } else if (identifier instanceof MicrosoftTeamsUserIdentifier) {
+        MicrosoftTeamsUserIdentifier teams = (MicrosoftTeamsUserIdentifier) identifier;
+        System.out.println("Teams User: " + teams.getUserId());
+        System.out.println("Anonymous: " + teams.isAnonymous());
+        
+    } else if (identifier instanceof UnknownIdentifier) {
+        UnknownIdentifier unknown = (UnknownIdentifier) identifier;
+        System.out.println("Unknown: " + unknown.getId());
+    }
+}
+```
+
+## Token Access
+
+```java
+import com.azure.core.credential.AccessToken;
+
+// Get current token (for debugging/logging - don't expose!)
+CommunicationTokenCredential credential = new CommunicationTokenCredential(token);
+
+// Sync access
+AccessToken accessToken = credential.getToken();
+System.out.println("Token expires: " + accessToken.getExpiresAt());
+
+// Async access
+credential.getTokenAsync()
+    .subscribe(token -> {
+        System.out.println("Token: " + token.getToken().substring(0, 20) + "...");
+        System.out.println("Expires: " + token.getExpiresAt());
+    });
+```
+
+## Dispose Credential
+
+```java
+// Clean up when done
+credential.close();
+
+// Or use try-with-resources
+try (CommunicationTokenCredential cred = new CommunicationTokenCredential(options)) {
+    // Use credential
+    chatClient.doSomething();
+}
+```
+
+## Cloud Environments
+
+```java
+import com.azure.communication.common.CommunicationCloudEnvironment;
+
+// Available environments
+CommunicationCloudEnvironment publicCloud = CommunicationCloudEnvironment.PUBLIC;
+CommunicationCloudEnvironment govCloud = CommunicationCloudEnvironment.GCCH;
+CommunicationCloudEnvironment dodCloud = CommunicationCloudEnvironment.DOD;
+
+// Set on Teams identifier
+MicrosoftTeamsUserIdentifier teamsUser = new MicrosoftTeamsUserIdentifier("<user-id>")
+    .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
+```
+
+## Environment Variables
+
+```bash
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
+AZURE_COMMUNICATION_USER_TOKEN=<user-access-token>
+```
+
+## Best Practices
+
+1. **Proactive Refresh** - Always use `setRefreshProactively(true)` for long-lived clients
+2. **Token Security** - Never log or expose full tokens
+3. **Close Credentials** - Dispose of credentials when no longer needed
+4. **Error Handling** - Handle token refresh failures gracefully
+5. **Identifier Types** - Use specific identifier types, not raw strings
+
+## Common Usage Patterns
+
+```java
+// Pattern: Create credential for Chat/Calling client
+public ChatClient createChatClient(String token, String endpoint) {
+    CommunicationTokenRefreshOptions refreshOptions = 
+        new CommunicationTokenRefreshOptions(this::refreshToken)
+            .setRefreshProactively(true)
+            .setInitialToken(token);
+    
+    CommunicationTokenCredential credential = 
+        new CommunicationTokenCredential(refreshOptions);
+    
+    return new ChatClientBuilder()
+        .endpoint(endpoint)
+        .credential(credential)
+        .buildClient();
+}
+
+private String refreshToken() {
+    // Call your token endpoint
+    return tokenService.getNewToken();
+}
+```
+
+## Trigger Phrases
+
+- "ACS authentication", "communication token credential"
+- "user access token", "token refresh"
+- "CommunicationUserIdentifier", "PhoneNumberIdentifier"
+- "Azure Communication Services authentication"

--- a/skills/java/communication/common/references/examples.md
+++ b/skills/java/communication/common/references/examples.md
@@ -1,0 +1,431 @@
+# Azure Communication Common Java SDK - Examples
+
+Comprehensive code examples for the Azure Communication Services Common SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Communication Token Credential](#communication-token-credential)
+- [Communication Identifiers](#communication-identifiers)
+- [Token Refresh Patterns](#token-refresh-patterns)
+- [Entra ID Authentication](#entra-id-authentication)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-common</artifactId>
+    <version>1.4.0</version>
+</dependency>
+```
+
+## Communication Token Credential
+
+### Static Token (Short-lived Clients)
+
+```java
+import com.azure.communication.common.CommunicationTokenCredential;
+
+String userToken = "<user-access-token>";
+CommunicationTokenCredential credential = new CommunicationTokenCredential(userToken);
+```
+
+### Proactive Token Refresh (Long-lived Clients)
+
+```java
+import com.azure.communication.common.CommunicationTokenRefreshOptions;
+import java.util.concurrent.Callable;
+
+Callable<String> tokenRefresher = () -> {
+    // Call your server to get a fresh token
+    return fetchNewTokenFromServer();
+};
+
+CommunicationTokenRefreshOptions refreshOptions = new CommunicationTokenRefreshOptions(tokenRefresher)
+    .setRefreshProactively(true)
+    .setInitialToken(currentToken);
+
+CommunicationTokenCredential credential = new CommunicationTokenCredential(refreshOptions);
+```
+
+### Token Refresh with HTTP Client
+
+```java
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.URI;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TokenService {
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String tokenEndpoint;
+    private final String userId;
+    
+    public TokenService(String tokenEndpoint, String userId) {
+        this.tokenEndpoint = tokenEndpoint;
+        this.userId = userId;
+    }
+    
+    public String fetchToken() throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(tokenEndpoint + "/api/token?userId=" + userId))
+            .GET()
+            .build();
+        
+        HttpResponse<String> response = httpClient.send(request, 
+            HttpResponse.BodyHandlers.ofString());
+        
+        if (response.statusCode() == 200) {
+            JsonNode json = objectMapper.readTree(response.body());
+            return json.get("token").asText();
+        }
+        throw new RuntimeException("Failed to fetch token: " + response.statusCode());
+    }
+    
+    public CommunicationTokenCredential createCredential(String initialToken) {
+        CommunicationTokenRefreshOptions options = new CommunicationTokenRefreshOptions(this::fetchToken)
+            .setRefreshProactively(true)
+            .setInitialToken(initialToken);
+        
+        return new CommunicationTokenCredential(options);
+    }
+}
+```
+
+## Communication Identifiers
+
+### CommunicationUserIdentifier
+
+```java
+import com.azure.communication.common.CommunicationUserIdentifier;
+
+// Create identifier for ACS user
+CommunicationUserIdentifier user = new CommunicationUserIdentifier("8:acs:resource-id_user-id");
+String rawId = user.getId();
+```
+
+### PhoneNumberIdentifier
+
+```java
+import com.azure.communication.common.PhoneNumberIdentifier;
+
+// E.164 format
+PhoneNumberIdentifier phone = new PhoneNumberIdentifier("+14255551234");
+String phoneNumber = phone.getPhoneNumber();  // "+14255551234"
+String rawId = phone.getRawId();              // "4:+14255551234"
+```
+
+### MicrosoftTeamsUserIdentifier
+
+```java
+import com.azure.communication.common.MicrosoftTeamsUserIdentifier;
+import com.azure.communication.common.CommunicationCloudEnvironment;
+
+// Teams user
+MicrosoftTeamsUserIdentifier teamsUser = new MicrosoftTeamsUserIdentifier("<teams-user-id>")
+    .setCloudEnvironment(CommunicationCloudEnvironment.PUBLIC);
+
+// Anonymous Teams user
+MicrosoftTeamsUserIdentifier anonymousTeamsUser = new MicrosoftTeamsUserIdentifier("<teams-user-id>")
+    .setAnonymous(true);
+```
+
+### Identifier Parsing
+
+```java
+import com.azure.communication.common.*;
+
+public class IdentifierParser {
+    
+    public CommunicationIdentifier parseIdentifier(String rawId) {
+        if (rawId.startsWith("8:acs:")) {
+            return new CommunicationUserIdentifier(rawId);
+        } else if (rawId.startsWith("4:")) {
+            String phone = rawId.substring(2);
+            return new PhoneNumberIdentifier(phone);
+        } else if (rawId.startsWith("8:orgid:")) {
+            String teamsId = rawId.substring(8);
+            return new MicrosoftTeamsUserIdentifier(teamsId);
+        } else {
+            return new UnknownIdentifier(rawId);
+        }
+    }
+    
+    public void processIdentifier(CommunicationIdentifier identifier) {
+        if (identifier instanceof CommunicationUserIdentifier) {
+            CommunicationUserIdentifier user = (CommunicationUserIdentifier) identifier;
+            System.out.println("ACS User: " + user.getId());
+            
+        } else if (identifier instanceof PhoneNumberIdentifier) {
+            PhoneNumberIdentifier phone = (PhoneNumberIdentifier) identifier;
+            System.out.println("Phone: " + phone.getPhoneNumber());
+            
+        } else if (identifier instanceof MicrosoftTeamsUserIdentifier) {
+            MicrosoftTeamsUserIdentifier teams = (MicrosoftTeamsUserIdentifier) identifier;
+            System.out.println("Teams User: " + teams.getUserId());
+            System.out.println("Anonymous: " + teams.isAnonymous());
+            
+        } else if (identifier instanceof UnknownIdentifier) {
+            UnknownIdentifier unknown = (UnknownIdentifier) identifier;
+            System.out.println("Unknown: " + unknown.getId());
+        }
+    }
+}
+```
+
+## Token Refresh Patterns
+
+### Async Token Refresh
+
+```java
+import java.util.concurrent.CompletableFuture;
+
+public class AsyncTokenService {
+    
+    public CompletableFuture<String> fetchTokenAsync() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                // Simulate async HTTP call
+                Thread.sleep(100);
+                return "new-token-value";
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        });
+    }
+    
+    public CommunicationTokenCredential createCredential() {
+        Callable<String> asyncRefresher = () -> {
+            CompletableFuture<String> future = fetchTokenAsync();
+            return future.get();
+        };
+        
+        CommunicationTokenRefreshOptions options = new CommunicationTokenRefreshOptions(asyncRefresher)
+            .setRefreshProactively(true);
+        
+        return new CommunicationTokenCredential(options);
+    }
+}
+```
+
+### Token Refresh with Retry
+
+```java
+import java.util.concurrent.Callable;
+
+public class ResilientTokenService {
+    private final String tokenEndpoint;
+    private final int maxRetries;
+    
+    public ResilientTokenService(String tokenEndpoint, int maxRetries) {
+        this.tokenEndpoint = tokenEndpoint;
+        this.maxRetries = maxRetries;
+    }
+    
+    public String fetchTokenWithRetry() throws Exception {
+        Exception lastException = null;
+        
+        for (int attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                return fetchToken();
+            } catch (Exception e) {
+                lastException = e;
+                if (attempt < maxRetries - 1) {
+                    long delay = (long) Math.pow(2, attempt) * 1000;
+                    Thread.sleep(delay);
+                }
+            }
+        }
+        
+        throw new RuntimeException("Failed to fetch token after " + maxRetries + " attempts", lastException);
+    }
+    
+    private String fetchToken() throws Exception {
+        // HTTP call to token endpoint
+        return "token-value";
+    }
+    
+    public CommunicationTokenCredential createCredential(String initialToken) {
+        CommunicationTokenRefreshOptions options = new CommunicationTokenRefreshOptions(this::fetchTokenWithRetry)
+            .setRefreshProactively(true)
+            .setInitialToken(initialToken);
+        
+        return new CommunicationTokenCredential(options);
+    }
+}
+```
+
+## Entra ID Authentication
+
+### Teams Phone Extensibility
+
+```java
+import com.azure.identity.InteractiveBrowserCredentialBuilder;
+import com.azure.identity.InteractiveBrowserCredential;
+import com.azure.communication.common.EntraCommunicationTokenCredentialOptions;
+import java.util.Arrays;
+import java.util.List;
+
+InteractiveBrowserCredential entraCredential = new InteractiveBrowserCredentialBuilder()
+    .clientId("<your-client-id>")
+    .tenantId("<your-tenant-id>")
+    .redirectUrl("<your-redirect-uri>")
+    .build();
+
+String resourceEndpoint = "https://<resource>.communication.azure.com";
+List<String> scopes = Arrays.asList(
+    "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls"
+);
+
+EntraCommunicationTokenCredentialOptions entraOptions = 
+    new EntraCommunicationTokenCredentialOptions(entraCredential, resourceEndpoint)
+        .setScopes(scopes);
+
+CommunicationTokenCredential credential = new CommunicationTokenCredential(entraOptions);
+```
+
+## Complete Application Example
+
+### Chat Client Factory with Token Management
+
+```java
+import com.azure.communication.chat.ChatClient;
+import com.azure.communication.chat.ChatClientBuilder;
+import com.azure.communication.common.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+
+public class ChatClientFactory {
+    private final String endpoint;
+    private final TokenService tokenService;
+    private final Map<String, CommunicationTokenCredential> credentialCache = new ConcurrentHashMap<>();
+    
+    public ChatClientFactory(String endpoint, TokenService tokenService) {
+        this.endpoint = endpoint;
+        this.tokenService = tokenService;
+    }
+    
+    public ChatClient createChatClient(String userId, String initialToken) {
+        CommunicationTokenCredential credential = getOrCreateCredential(userId, initialToken);
+        
+        return new ChatClientBuilder()
+            .endpoint(endpoint)
+            .credential(credential)
+            .buildClient();
+    }
+    
+    private CommunicationTokenCredential getOrCreateCredential(String userId, String initialToken) {
+        return credentialCache.computeIfAbsent(userId, id -> {
+            Callable<String> refresher = () -> tokenService.fetchTokenForUser(id);
+            
+            CommunicationTokenRefreshOptions options = new CommunicationTokenRefreshOptions(refresher)
+                .setRefreshProactively(true)
+                .setInitialToken(initialToken);
+            
+            return new CommunicationTokenCredential(options);
+        });
+    }
+    
+    public void removeCredential(String userId) {
+        CommunicationTokenCredential credential = credentialCache.remove(userId);
+        if (credential != null) {
+            credential.close();
+        }
+    }
+    
+    public void close() {
+        credentialCache.values().forEach(CommunicationTokenCredential::close);
+        credentialCache.clear();
+    }
+}
+
+class TokenService {
+    public String fetchTokenForUser(String userId) {
+        // Fetch token from your server
+        return "token-for-" + userId;
+    }
+}
+```
+
+### Multi-Tenant Communication Service
+
+```java
+import com.azure.communication.common.*;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MultiTenantCommunicationService {
+    private final Map<String, TenantContext> tenantContexts = new ConcurrentHashMap<>();
+    
+    public void registerTenant(String tenantId, String endpoint, String connectionString) {
+        TenantContext context = new TenantContext(tenantId, endpoint, connectionString);
+        tenantContexts.put(tenantId, context);
+    }
+    
+    public CommunicationTokenCredential getCredentialForUser(String tenantId, String userId, String token) {
+        TenantContext context = tenantContexts.get(tenantId);
+        if (context == null) {
+            throw new IllegalArgumentException("Unknown tenant: " + tenantId);
+        }
+        
+        return context.getOrCreateCredential(userId, token);
+    }
+    
+    public CommunicationUserIdentifier createUserIdentifier(String tenantId, String userId) {
+        // Format: 8:acs:resourceId_userId
+        TenantContext context = tenantContexts.get(tenantId);
+        String rawId = "8:acs:" + context.getResourceId() + "_" + userId;
+        return new CommunicationUserIdentifier(rawId);
+    }
+    
+    private static class TenantContext {
+        private final String tenantId;
+        private final String endpoint;
+        private final String resourceId;
+        private final Map<String, CommunicationTokenCredential> userCredentials = new ConcurrentHashMap<>();
+        
+        TenantContext(String tenantId, String endpoint, String connectionString) {
+            this.tenantId = tenantId;
+            this.endpoint = endpoint;
+            this.resourceId = extractResourceId(endpoint);
+        }
+        
+        String getResourceId() {
+            return resourceId;
+        }
+        
+        CommunicationTokenCredential getOrCreateCredential(String userId, String token) {
+            return userCredentials.computeIfAbsent(userId, id -> 
+                new CommunicationTokenCredential(token));
+        }
+        
+        private String extractResourceId(String endpoint) {
+            // Extract resource ID from endpoint URL
+            return endpoint.replace("https://", "").replace(".communication.azure.com", "");
+        }
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
+AZURE_COMMUNICATION_USER_TOKEN=<user-access-token>
+```
+
+## Best Practices
+
+1. **Proactive Refresh** - Always use `setRefreshProactively(true)` for long-lived clients
+2. **Token Security** - Never log or expose full tokens
+3. **Close Credentials** - Dispose of credentials when no longer needed
+4. **Error Handling** - Handle token refresh failures gracefully
+5. **Identifier Types** - Use specific identifier types, not raw strings
+6. **Connection Reuse** - Reuse credentials across requests to the same user
+7. **Caching** - Cache credentials per user to avoid unnecessary token refreshes

--- a/skills/java/communication/sms/SKILL.md
+++ b/skills/java/communication/sms/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: azure-communication-sms-java
+description: Send SMS messages with Azure Communication Services SMS Java SDK. Use when implementing SMS notifications, alerts, OTP delivery, bulk messaging, or delivery reports.
+---
+
+# Azure Communication SMS (Java)
+
+Send SMS messages to single or multiple recipients with delivery reporting.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-sms</artifactId>
+    <version>1.2.0</version>
+</dependency>
+```
+
+## Client Creation
+
+```java
+import com.azure.communication.sms.SmsClient;
+import com.azure.communication.sms.SmsClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// With DefaultAzureCredential (recommended)
+SmsClient smsClient = new SmsClientBuilder()
+    .endpoint("https://<resource>.communication.azure.com")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+// With connection string
+SmsClient smsClient = new SmsClientBuilder()
+    .connectionString("<connection-string>")
+    .buildClient();
+
+// With AzureKeyCredential
+import com.azure.core.credential.AzureKeyCredential;
+
+SmsClient smsClient = new SmsClientBuilder()
+    .endpoint("https://<resource>.communication.azure.com")
+    .credential(new AzureKeyCredential("<access-key>"))
+    .buildClient();
+
+// Async client
+SmsAsyncClient smsAsyncClient = new SmsClientBuilder()
+    .connectionString("<connection-string>")
+    .buildAsyncClient();
+```
+
+## Send SMS to Single Recipient
+
+```java
+import com.azure.communication.sms.models.SmsSendResult;
+
+// Simple send
+SmsSendResult result = smsClient.send(
+    "+14255550100",      // From (your ACS phone number)
+    "+14255551234",      // To
+    "Your verification code is 123456");
+
+System.out.println("Message ID: " + result.getMessageId());
+System.out.println("To: " + result.getTo());
+System.out.println("Success: " + result.isSuccessful());
+
+if (!result.isSuccessful()) {
+    System.out.println("Error: " + result.getErrorMessage());
+    System.out.println("Status: " + result.getHttpStatusCode());
+}
+```
+
+## Send SMS to Multiple Recipients
+
+```java
+import com.azure.communication.sms.models.SmsSendOptions;
+import java.util.Arrays;
+import java.util.List;
+
+List<String> recipients = Arrays.asList(
+    "+14255551111",
+    "+14255552222",
+    "+14255553333"
+);
+
+// With options
+SmsSendOptions options = new SmsSendOptions()
+    .setDeliveryReportEnabled(true)
+    .setTag("marketing-campaign-001");
+
+Iterable<SmsSendResult> results = smsClient.sendWithResponse(
+    "+14255550100",      // From
+    recipients,          // To list
+    "Flash sale! 50% off today only.",
+    options,
+    Context.NONE
+).getValue();
+
+for (SmsSendResult result : results) {
+    if (result.isSuccessful()) {
+        System.out.println("Sent to " + result.getTo() + ": " + result.getMessageId());
+    } else {
+        System.out.println("Failed to " + result.getTo() + ": " + result.getErrorMessage());
+    }
+}
+```
+
+## Send Options
+
+```java
+SmsSendOptions options = new SmsSendOptions();
+
+// Enable delivery reports (sent via Event Grid)
+options.setDeliveryReportEnabled(true);
+
+// Add custom tag for tracking
+options.setTag("order-confirmation-12345");
+```
+
+## Response Handling
+
+```java
+import com.azure.core.http.rest.Response;
+
+Response<Iterable<SmsSendResult>> response = smsClient.sendWithResponse(
+    "+14255550100",
+    Arrays.asList("+14255551234"),
+    "Hello!",
+    new SmsSendOptions().setDeliveryReportEnabled(true),
+    Context.NONE
+);
+
+// Check HTTP response
+System.out.println("Status code: " + response.getStatusCode());
+System.out.println("Headers: " + response.getHeaders());
+
+// Process results
+for (SmsSendResult result : response.getValue()) {
+    System.out.println("Message ID: " + result.getMessageId());
+    System.out.println("Successful: " + result.isSuccessful());
+    
+    if (!result.isSuccessful()) {
+        System.out.println("HTTP Status: " + result.getHttpStatusCode());
+        System.out.println("Error: " + result.getErrorMessage());
+    }
+}
+```
+
+## Async Operations
+
+```java
+import reactor.core.publisher.Mono;
+
+SmsAsyncClient asyncClient = new SmsClientBuilder()
+    .connectionString("<connection-string>")
+    .buildAsyncClient();
+
+// Send single message
+asyncClient.send("+14255550100", "+14255551234", "Async message!")
+    .subscribe(
+        result -> System.out.println("Sent: " + result.getMessageId()),
+        error -> System.out.println("Error: " + error.getMessage())
+    );
+
+// Send to multiple with options
+SmsSendOptions options = new SmsSendOptions()
+    .setDeliveryReportEnabled(true);
+
+asyncClient.sendWithResponse(
+    "+14255550100",
+    Arrays.asList("+14255551111", "+14255552222"),
+    "Bulk async message",
+    options)
+    .subscribe(response -> {
+        for (SmsSendResult result : response.getValue()) {
+            System.out.println("Result: " + result.getTo() + " - " + result.isSuccessful());
+        }
+    });
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    SmsSendResult result = smsClient.send(
+        "+14255550100",
+        "+14255551234",
+        "Test message"
+    );
+    
+    // Individual message errors don't throw exceptions
+    if (!result.isSuccessful()) {
+        handleMessageError(result);
+    }
+    
+} catch (HttpResponseException e) {
+    // Request-level failures (auth, network, etc.)
+    System.out.println("Request failed: " + e.getMessage());
+    System.out.println("Status: " + e.getResponse().getStatusCode());
+} catch (RuntimeException e) {
+    System.out.println("Unexpected error: " + e.getMessage());
+}
+
+private void handleMessageError(SmsSendResult result) {
+    int status = result.getHttpStatusCode();
+    String error = result.getErrorMessage();
+    
+    if (status == 400) {
+        System.out.println("Invalid phone number: " + result.getTo());
+    } else if (status == 429) {
+        System.out.println("Rate limited - retry later");
+    } else {
+        System.out.println("Error " + status + ": " + error);
+    }
+}
+```
+
+## Delivery Reports
+
+Delivery reports are sent via Azure Event Grid. Configure an Event Grid subscription for your ACS resource.
+
+```java
+// Event Grid webhook handler (in your endpoint)
+public void handleDeliveryReport(String eventJson) {
+    // Parse Event Grid event
+    // Event type: Microsoft.Communication.SMSDeliveryReportReceived
+    
+    // Event data contains:
+    // - messageId: correlates to SmsSendResult.getMessageId()
+    // - from: sender number
+    // - to: recipient number
+    // - deliveryStatus: "Delivered", "Failed", etc.
+    // - deliveryStatusDetails: detailed status
+    // - receivedTimestamp: when status was received
+    // - tag: your custom tag from SmsSendOptions
+}
+```
+
+## SmsSendResult Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `getMessageId()` | String | Unique message identifier |
+| `getTo()` | String | Recipient phone number |
+| `isSuccessful()` | boolean | Whether send succeeded |
+| `getHttpStatusCode()` | int | HTTP status for this recipient |
+| `getErrorMessage()` | String | Error details if failed |
+| `getRepeatabilityResult()` | RepeatabilityResult | Idempotency result |
+
+## Environment Variables
+
+```bash
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
+AZURE_COMMUNICATION_CONNECTION_STRING=endpoint=https://...;accesskey=...
+SMS_FROM_NUMBER=+14255550100
+```
+
+## Best Practices
+
+1. **Phone Number Format** - Use E.164 format: `+[country code][number]`
+2. **Delivery Reports** - Enable for critical messages (OTP, alerts)
+3. **Tagging** - Use tags to correlate messages with business context
+4. **Error Handling** - Check `isSuccessful()` for each recipient individually
+5. **Rate Limiting** - Implement retry with backoff for 429 responses
+6. **Bulk Sending** - Use batch send for multiple recipients (more efficient)
+
+## Trigger Phrases
+
+- "send SMS Java", "text message Java"
+- "SMS notification", "OTP SMS", "bulk SMS"
+- "delivery report SMS", "Azure Communication Services SMS"

--- a/skills/java/communication/sms/references/examples.md
+++ b/skills/java/communication/sms/references/examples.md
@@ -1,0 +1,492 @@
+# Azure Communication SMS Java SDK - Examples
+
+Comprehensive code examples for the Azure Communication Services SMS SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Send Single SMS](#send-single-sms)
+- [Send Bulk SMS](#send-bulk-sms)
+- [Delivery Reports](#delivery-reports)
+- [Async Operations](#async-operations)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-communication-sms</artifactId>
+    <version>1.2.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### With DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.communication.sms.SmsClient;
+import com.azure.communication.sms.SmsClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+SmsClient smsClient = new SmsClientBuilder()
+    .endpoint("https://<resource>.communication.azure.com")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### With Connection String
+
+```java
+SmsClient smsClient = new SmsClientBuilder()
+    .connectionString(System.getenv("AZURE_COMMUNICATION_CONNECTION_STRING"))
+    .buildClient();
+```
+
+### With AzureKeyCredential
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+
+SmsClient smsClient = new SmsClientBuilder()
+    .endpoint("https://<resource>.communication.azure.com")
+    .credential(new AzureKeyCredential("<access-key>"))
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.communication.sms.SmsAsyncClient;
+
+SmsAsyncClient asyncClient = new SmsClientBuilder()
+    .connectionString(connectionString)
+    .buildAsyncClient();
+```
+
+## Send Single SMS
+
+### Simple Send
+
+```java
+import com.azure.communication.sms.models.SmsSendResult;
+
+SmsSendResult result = smsClient.send(
+    "+14255550100",      // From (your ACS phone number)
+    "+14255551234",      // To
+    "Your verification code is 123456"
+);
+
+System.out.println("Message ID: " + result.getMessageId());
+System.out.println("Success: " + result.isSuccessful());
+```
+
+### Send with Options
+
+```java
+import com.azure.communication.sms.models.SmsSendOptions;
+import com.azure.core.util.Context;
+import java.util.Collections;
+
+SmsSendOptions options = new SmsSendOptions()
+    .setDeliveryReportEnabled(true)
+    .setTag("verification-code");
+
+SmsSendResult result = smsClient.sendWithResponse(
+    "+14255550100",
+    Collections.singletonList("+14255551234"),
+    "Your verification code is 123456",
+    options,
+    Context.NONE
+).getValue().iterator().next();
+```
+
+## Send Bulk SMS
+
+### Send to Multiple Recipients
+
+```java
+import java.util.Arrays;
+import java.util.List;
+
+List<String> recipients = Arrays.asList(
+    "+14255551111",
+    "+14255552222",
+    "+14255553333"
+);
+
+SmsSendOptions options = new SmsSendOptions()
+    .setDeliveryReportEnabled(true)
+    .setTag("marketing-campaign-001");
+
+Iterable<SmsSendResult> results = smsClient.sendWithResponse(
+    "+14255550100",
+    recipients,
+    "Flash sale! 50% off today only.",
+    options,
+    Context.NONE
+).getValue();
+
+// Process results for each recipient
+for (SmsSendResult result : results) {
+    if (result.isSuccessful()) {
+        System.out.printf("✓ Sent to %s: %s%n", result.getTo(), result.getMessageId());
+    } else {
+        System.out.printf("✗ Failed to %s: %s (HTTP %d)%n", 
+            result.getTo(), 
+            result.getErrorMessage(),
+            result.getHttpStatusCode());
+    }
+}
+```
+
+### Batch SMS with Retry Logic
+
+```java
+import java.util.ArrayList;
+import java.util.List;
+
+public class SmsBatchSender {
+    private final SmsClient smsClient;
+    private final String fromNumber;
+    
+    public SmsBatchSender(SmsClient smsClient, String fromNumber) {
+        this.smsClient = smsClient;
+        this.fromNumber = fromNumber;
+    }
+    
+    public List<SmsSendResult> sendBatch(List<String> recipients, String message) {
+        List<SmsSendResult> allResults = new ArrayList<>();
+        List<String> failedRecipients = new ArrayList<>();
+        
+        SmsSendOptions options = new SmsSendOptions()
+            .setDeliveryReportEnabled(true);
+        
+        // First attempt
+        Iterable<SmsSendResult> results = smsClient.sendWithResponse(
+            fromNumber, recipients, message, options, Context.NONE
+        ).getValue();
+        
+        for (SmsSendResult result : results) {
+            allResults.add(result);
+            if (!result.isSuccessful() && result.getHttpStatusCode() == 429) {
+                failedRecipients.add(result.getTo());
+            }
+        }
+        
+        // Retry rate-limited messages after delay
+        if (!failedRecipients.isEmpty()) {
+            try {
+                Thread.sleep(2000); // Wait 2 seconds
+                Iterable<SmsSendResult> retryResults = smsClient.sendWithResponse(
+                    fromNumber, failedRecipients, message, options, Context.NONE
+                ).getValue();
+                
+                for (SmsSendResult result : retryResults) {
+                    allResults.add(result);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        
+        return allResults;
+    }
+}
+```
+
+## Delivery Reports
+
+Delivery reports are sent via Azure Event Grid. Configure an Event Grid subscription for your ACS resource.
+
+### Event Grid Webhook Handler
+
+```java
+import com.azure.messaging.eventgrid.EventGridEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SmsDeliveryReportHandler {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    
+    public void handleDeliveryReport(String eventJson) throws Exception {
+        List<EventGridEvent> events = EventGridEvent.fromString(eventJson);
+        
+        for (EventGridEvent event : events) {
+            if ("Microsoft.Communication.SMSDeliveryReportReceived".equals(event.getEventType())) {
+                JsonNode data = objectMapper.readTree(event.getData().toString());
+                
+                String messageId = data.get("messageId").asText();
+                String from = data.get("from").asText();
+                String to = data.get("to").asText();
+                String deliveryStatus = data.get("deliveryStatus").asText();
+                String deliveryStatusDetails = data.get("deliveryStatusDetails").asText();
+                String tag = data.has("tag") ? data.get("tag").asText() : null;
+                
+                System.out.printf("Delivery Report - MessageId: %s, To: %s, Status: %s%n",
+                    messageId, to, deliveryStatus);
+                
+                // Update your database or trigger actions based on status
+                switch (deliveryStatus) {
+                    case "Delivered":
+                        onMessageDelivered(messageId, to, tag);
+                        break;
+                    case "Failed":
+                        onMessageFailed(messageId, to, deliveryStatusDetails, tag);
+                        break;
+                }
+            }
+        }
+    }
+    
+    private void onMessageDelivered(String messageId, String to, String tag) {
+        System.out.printf("Message %s delivered to %s (tag: %s)%n", messageId, to, tag);
+    }
+    
+    private void onMessageFailed(String messageId, String to, String reason, String tag) {
+        System.out.printf("Message %s failed to %s: %s (tag: %s)%n", 
+            messageId, to, reason, tag);
+    }
+}
+```
+
+## Async Operations
+
+### Async Send Single Message
+
+```java
+import reactor.core.publisher.Mono;
+
+SmsAsyncClient asyncClient = new SmsClientBuilder()
+    .connectionString(connectionString)
+    .buildAsyncClient();
+
+asyncClient.send("+14255550100", "+14255551234", "Async message!")
+    .subscribe(
+        result -> {
+            System.out.println("Sent: " + result.getMessageId());
+            System.out.println("Success: " + result.isSuccessful());
+        },
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### Async Bulk Send with Reactive Streams
+
+```java
+import reactor.core.publisher.Flux;
+
+SmsSendOptions options = new SmsSendOptions()
+    .setDeliveryReportEnabled(true);
+
+asyncClient.sendWithResponse(
+    "+14255550100",
+    Arrays.asList("+14255551111", "+14255552222"),
+    "Bulk async message",
+    options)
+    .flatMapMany(response -> Flux.fromIterable(response.getValue()))
+    .subscribe(
+        result -> {
+            if (result.isSuccessful()) {
+                System.out.printf("✓ %s: %s%n", result.getTo(), result.getMessageId());
+            } else {
+                System.out.printf("✗ %s: %s%n", result.getTo(), result.getErrorMessage());
+            }
+        },
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("All messages processed")
+    );
+```
+
+## Error Handling
+
+### Comprehensive Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+public class SmsService {
+    private final SmsClient smsClient;
+    private final String fromNumber;
+    
+    public SmsService(SmsClient smsClient, String fromNumber) {
+        this.smsClient = smsClient;
+        this.fromNumber = fromNumber;
+    }
+    
+    public SmsSendResult sendSms(String to, String message) {
+        try {
+            SmsSendResult result = smsClient.send(fromNumber, to, message);
+            
+            if (!result.isSuccessful()) {
+                handleMessageError(result);
+            }
+            
+            return result;
+            
+        } catch (HttpResponseException e) {
+            // Request-level failures (auth, network, etc.)
+            System.err.printf("HTTP Error %d: %s%n", 
+                e.getResponse().getStatusCode(), e.getMessage());
+            throw new RuntimeException("Failed to send SMS", e);
+        } catch (RuntimeException e) {
+            System.err.println("Unexpected error: " + e.getMessage());
+            throw e;
+        }
+    }
+    
+    private void handleMessageError(SmsSendResult result) {
+        int status = result.getHttpStatusCode();
+        String to = result.getTo();
+        String error = result.getErrorMessage();
+        
+        switch (status) {
+            case 400:
+                System.err.printf("Invalid phone number: %s%n", to);
+                break;
+            case 401:
+                System.err.println("Authentication failed - check credentials");
+                break;
+            case 403:
+                System.err.printf("Not authorized to send to: %s%n", to);
+                break;
+            case 429:
+                System.err.println("Rate limited - implement backoff retry");
+                break;
+            default:
+                System.err.printf("Error %d sending to %s: %s%n", status, to, error);
+        }
+    }
+}
+```
+
+## Complete Application Example
+
+### OTP SMS Service
+
+```java
+import com.azure.communication.sms.SmsClient;
+import com.azure.communication.sms.SmsClientBuilder;
+import com.azure.communication.sms.models.SmsSendOptions;
+import com.azure.communication.sms.models.SmsSendResult;
+import com.azure.core.util.Context;
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class OtpSmsService {
+    private final SmsClient smsClient;
+    private final String fromNumber;
+    private final Map<String, OtpEntry> otpStore = new ConcurrentHashMap<>();
+    private final SecureRandom random = new SecureRandom();
+    
+    public OtpSmsService(String connectionString, String fromNumber) {
+        this.smsClient = new SmsClientBuilder()
+            .connectionString(connectionString)
+            .buildClient();
+        this.fromNumber = fromNumber;
+    }
+    
+    public String sendOtp(String phoneNumber) {
+        // Generate 6-digit OTP
+        String otp = String.format("%06d", random.nextInt(1000000));
+        
+        // Store OTP with expiry
+        otpStore.put(phoneNumber, new OtpEntry(otp, System.currentTimeMillis() + 300000));
+        
+        // Send SMS
+        String message = String.format("Your verification code is %s. Valid for 5 minutes.", otp);
+        
+        SmsSendOptions options = new SmsSendOptions()
+            .setDeliveryReportEnabled(true)
+            .setTag("otp-" + phoneNumber);
+        
+        SmsSendResult result = smsClient.sendWithResponse(
+            fromNumber,
+            Collections.singletonList(phoneNumber),
+            message,
+            options,
+            Context.NONE
+        ).getValue().iterator().next();
+        
+        if (result.isSuccessful()) {
+            System.out.printf("OTP sent to %s: %s%n", phoneNumber, result.getMessageId());
+            return result.getMessageId();
+        } else {
+            throw new RuntimeException("Failed to send OTP: " + result.getErrorMessage());
+        }
+    }
+    
+    public boolean verifyOtp(String phoneNumber, String otp) {
+        OtpEntry entry = otpStore.get(phoneNumber);
+        
+        if (entry == null) {
+            return false;
+        }
+        
+        if (System.currentTimeMillis() > entry.expiryTime) {
+            otpStore.remove(phoneNumber);
+            return false;
+        }
+        
+        if (entry.otp.equals(otp)) {
+            otpStore.remove(phoneNumber);
+            return true;
+        }
+        
+        return false;
+    }
+    
+    private static class OtpEntry {
+        final String otp;
+        final long expiryTime;
+        
+        OtpEntry(String otp, long expiryTime) {
+            this.otp = otp;
+            this.expiryTime = expiryTime;
+        }
+    }
+}
+```
+
+### Usage
+
+```java
+public class Main {
+    public static void main(String[] args) {
+        String connectionString = System.getenv("AZURE_COMMUNICATION_CONNECTION_STRING");
+        String fromNumber = System.getenv("SMS_FROM_NUMBER");
+        
+        OtpSmsService otpService = new OtpSmsService(connectionString, fromNumber);
+        
+        // Send OTP
+        String messageId = otpService.sendOtp("+14255551234");
+        System.out.println("OTP sent with message ID: " + messageId);
+        
+        // Verify OTP (user enters code)
+        boolean verified = otpService.verifyOtp("+14255551234", "123456");
+        System.out.println("OTP verified: " + verified);
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
+AZURE_COMMUNICATION_CONNECTION_STRING=endpoint=https://...;accesskey=...
+SMS_FROM_NUMBER=+14255550100
+```
+
+## Best Practices
+
+1. **Phone Number Format** - Use E.164 format: `+[country code][number]`
+2. **Delivery Reports** - Enable for critical messages (OTP, alerts)
+3. **Tagging** - Use tags to correlate messages with business context
+4. **Error Handling** - Check `isSuccessful()` for each recipient individually
+5. **Rate Limiting** - Implement retry with exponential backoff for 429 responses
+6. **Bulk Sending** - Use batch send for multiple recipients (more efficient)
+7. **Connection Reuse** - Reuse `SmsClient` instances across requests

--- a/skills/java/compute/batch/SKILL.md
+++ b/skills/java/compute/batch/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: azure-compute-batch-java
+description: |
+  Azure Batch SDK for Java. Run large-scale parallel and HPC batch jobs with pools, jobs, tasks, and compute nodes.
+  Triggers: "BatchClient java", "azure batch java", "batch pool java", "batch job java", "HPC java", "parallel computing java".
+---
+
+# Azure Batch SDK for Java
+
+Client library for running large-scale parallel and high-performance computing (HPC) batch jobs in Azure.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-compute-batch</artifactId>
+    <version>1.0.0-beta.5</version>
+</dependency>
+```
+
+## Prerequisites
+
+- Azure Batch account
+- Pool configured with compute nodes
+- Azure subscription
+
+## Environment Variables
+
+```bash
+AZURE_BATCH_ENDPOINT=https://<account>.<region>.batch.azure.com
+AZURE_BATCH_ACCOUNT=<account-name>
+AZURE_BATCH_ACCESS_KEY=<account-key>
+```
+
+## Client Creation
+
+### With Microsoft Entra ID (Recommended)
+
+```java
+import com.azure.compute.batch.BatchClient;
+import com.azure.compute.batch.BatchClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+BatchClient batchClient = new BatchClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(System.getenv("AZURE_BATCH_ENDPOINT"))
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.compute.batch.BatchAsyncClient;
+
+BatchAsyncClient batchAsyncClient = new BatchClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(System.getenv("AZURE_BATCH_ENDPOINT"))
+    .buildAsyncClient();
+```
+
+### With Shared Key Credentials
+
+```java
+import com.azure.core.credential.AzureNamedKeyCredential;
+
+String accountName = System.getenv("AZURE_BATCH_ACCOUNT");
+String accountKey = System.getenv("AZURE_BATCH_ACCESS_KEY");
+AzureNamedKeyCredential sharedKeyCreds = new AzureNamedKeyCredential(accountName, accountKey);
+
+BatchClient batchClient = new BatchClientBuilder()
+    .credential(sharedKeyCreds)
+    .endpoint(System.getenv("AZURE_BATCH_ENDPOINT"))
+    .buildClient();
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Pool | Collection of compute nodes that run tasks |
+| Job | Logical grouping of tasks |
+| Task | Unit of computation (command/script) |
+| Node | VM that executes tasks |
+| Job Schedule | Recurring job creation |
+
+## Pool Operations
+
+### Create Pool
+
+```java
+import com.azure.compute.batch.models.*;
+
+batchClient.createPool(new BatchPoolCreateParameters("myPoolId", "STANDARD_DC2s_V2")
+    .setVirtualMachineConfiguration(
+        new VirtualMachineConfiguration(
+            new BatchVmImageReference()
+                .setPublisher("Canonical")
+                .setOffer("UbuntuServer")
+                .setSku("22_04-lts")
+                .setVersion("latest"),
+            "batch.node.ubuntu 22.04"))
+    .setTargetDedicatedNodes(2)
+    .setTargetLowPriorityNodes(0), null);
+```
+
+### Get Pool
+
+```java
+BatchPool pool = batchClient.getPool("myPoolId");
+System.out.println("Pool state: " + pool.getState());
+System.out.println("Current dedicated nodes: " + pool.getCurrentDedicatedNodes());
+```
+
+### List Pools
+
+```java
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<BatchPool> pools = batchClient.listPools();
+for (BatchPool pool : pools) {
+    System.out.println("Pool: " + pool.getId() + ", State: " + pool.getState());
+}
+```
+
+### Resize Pool
+
+```java
+import com.azure.core.util.polling.SyncPoller;
+
+BatchPoolResizeParameters resizeParams = new BatchPoolResizeParameters()
+    .setTargetDedicatedNodes(4)
+    .setTargetLowPriorityNodes(2);
+
+SyncPoller<BatchPool, BatchPool> poller = batchClient.beginResizePool("myPoolId", resizeParams);
+poller.waitForCompletion();
+BatchPool resizedPool = poller.getFinalResult();
+```
+
+### Enable AutoScale
+
+```java
+BatchPoolEnableAutoScaleParameters autoScaleParams = new BatchPoolEnableAutoScaleParameters()
+    .setAutoScaleEvaluationInterval(Duration.ofMinutes(5))
+    .setAutoScaleFormula("$TargetDedicatedNodes = min(10, $PendingTasks.GetSample(TimeInterval_Minute * 5));");
+
+batchClient.enablePoolAutoScale("myPoolId", autoScaleParams);
+```
+
+### Delete Pool
+
+```java
+SyncPoller<BatchPool, Void> deletePoller = batchClient.beginDeletePool("myPoolId");
+deletePoller.waitForCompletion();
+```
+
+## Job Operations
+
+### Create Job
+
+```java
+batchClient.createJob(
+    new BatchJobCreateParameters("myJobId", new BatchPoolInfo().setPoolId("myPoolId"))
+        .setPriority(100)
+        .setConstraints(new BatchJobConstraints()
+            .setMaxWallClockTime(Duration.ofHours(24))
+            .setMaxTaskRetryCount(3)),
+    null);
+```
+
+### Get Job
+
+```java
+BatchJob job = batchClient.getJob("myJobId", null, null);
+System.out.println("Job state: " + job.getState());
+```
+
+### List Jobs
+
+```java
+PagedIterable<BatchJob> jobs = batchClient.listJobs(new BatchJobsListOptions());
+for (BatchJob job : jobs) {
+    System.out.println("Job: " + job.getId() + ", State: " + job.getState());
+}
+```
+
+### Get Task Counts
+
+```java
+BatchTaskCountsResult counts = batchClient.getJobTaskCounts("myJobId");
+System.out.println("Active: " + counts.getTaskCounts().getActive());
+System.out.println("Running: " + counts.getTaskCounts().getRunning());
+System.out.println("Completed: " + counts.getTaskCounts().getCompleted());
+```
+
+### Terminate Job
+
+```java
+BatchJobTerminateParameters terminateParams = new BatchJobTerminateParameters()
+    .setTerminationReason("Manual termination");
+BatchJobTerminateOptions options = new BatchJobTerminateOptions().setParameters(terminateParams);
+
+SyncPoller<BatchJob, BatchJob> poller = batchClient.beginTerminateJob("myJobId", options, null);
+poller.waitForCompletion();
+```
+
+### Delete Job
+
+```java
+SyncPoller<BatchJob, Void> deletePoller = batchClient.beginDeleteJob("myJobId");
+deletePoller.waitForCompletion();
+```
+
+## Task Operations
+
+### Create Single Task
+
+```java
+BatchTaskCreateParameters task = new BatchTaskCreateParameters("task1", "echo 'Hello World'");
+batchClient.createTask("myJobId", task);
+```
+
+### Create Task with Exit Conditions
+
+```java
+batchClient.createTask("myJobId", new BatchTaskCreateParameters("task2", "cmd /c exit 3")
+    .setExitConditions(new ExitConditions()
+        .setExitCodeRanges(Arrays.asList(
+            new ExitCodeRangeMapping(2, 4, 
+                new ExitOptions().setJobAction(BatchJobActionKind.TERMINATE)))))
+    .setUserIdentity(new UserIdentity()
+        .setAutoUser(new AutoUserSpecification()
+            .setScope(AutoUserScope.TASK)
+            .setElevationLevel(ElevationLevel.NON_ADMIN))),
+    null);
+```
+
+### Create Task Collection (up to 100)
+
+```java
+List<BatchTaskCreateParameters> taskList = Arrays.asList(
+    new BatchTaskCreateParameters("task1", "echo Task 1"),
+    new BatchTaskCreateParameters("task2", "echo Task 2"),
+    new BatchTaskCreateParameters("task3", "echo Task 3")
+);
+BatchTaskGroup taskGroup = new BatchTaskGroup(taskList);
+BatchCreateTaskCollectionResult result = batchClient.createTaskCollection("myJobId", taskGroup);
+```
+
+### Create Many Tasks (no limit)
+
+```java
+List<BatchTaskCreateParameters> tasks = new ArrayList<>();
+for (int i = 0; i < 1000; i++) {
+    tasks.add(new BatchTaskCreateParameters("task" + i, "echo Task " + i));
+}
+batchClient.createTasks("myJobId", tasks);
+```
+
+### Get Task
+
+```java
+BatchTask task = batchClient.getTask("myJobId", "task1");
+System.out.println("Task state: " + task.getState());
+System.out.println("Exit code: " + task.getExecutionInfo().getExitCode());
+```
+
+### List Tasks
+
+```java
+PagedIterable<BatchTask> tasks = batchClient.listTasks("myJobId");
+for (BatchTask task : tasks) {
+    System.out.println("Task: " + task.getId() + ", State: " + task.getState());
+}
+```
+
+### Get Task Output
+
+```java
+import com.azure.core.util.BinaryData;
+import java.nio.charset.StandardCharsets;
+
+BinaryData stdout = batchClient.getTaskFile("myJobId", "task1", "stdout.txt");
+System.out.println(new String(stdout.toBytes(), StandardCharsets.UTF_8));
+```
+
+### Terminate Task
+
+```java
+batchClient.terminateTask("myJobId", "task1", null, null);
+```
+
+## Node Operations
+
+### List Nodes
+
+```java
+PagedIterable<BatchNode> nodes = batchClient.listNodes("myPoolId", new BatchNodesListOptions());
+for (BatchNode node : nodes) {
+    System.out.println("Node: " + node.getId() + ", State: " + node.getState());
+}
+```
+
+### Reboot Node
+
+```java
+SyncPoller<BatchNode, BatchNode> rebootPoller = batchClient.beginRebootNode("myPoolId", "nodeId");
+rebootPoller.waitForCompletion();
+```
+
+### Get Remote Login Settings
+
+```java
+BatchNodeRemoteLoginSettings settings = batchClient.getNodeRemoteLoginSettings("myPoolId", "nodeId");
+System.out.println("IP: " + settings.getRemoteLoginIpAddress());
+System.out.println("Port: " + settings.getRemoteLoginPort());
+```
+
+## Job Schedule Operations
+
+### Create Job Schedule
+
+```java
+batchClient.createJobSchedule(new BatchJobScheduleCreateParameters("myScheduleId",
+    new BatchJobScheduleConfiguration()
+        .setRecurrenceInterval(Duration.ofHours(6))
+        .setDoNotRunUntil(OffsetDateTime.now().plusDays(1)),
+    new BatchJobSpecification(new BatchPoolInfo().setPoolId("myPoolId"))
+        .setPriority(50)),
+    null);
+```
+
+### Get Job Schedule
+
+```java
+BatchJobSchedule schedule = batchClient.getJobSchedule("myScheduleId");
+System.out.println("Schedule state: " + schedule.getState());
+```
+
+## Error Handling
+
+```java
+import com.azure.compute.batch.models.BatchErrorException;
+import com.azure.compute.batch.models.BatchError;
+
+try {
+    batchClient.getPool("nonexistent-pool");
+} catch (BatchErrorException e) {
+    BatchError error = e.getValue();
+    System.err.println("Error code: " + error.getCode());
+    System.err.println("Message: " + error.getMessage().getValue());
+    
+    if ("PoolNotFound".equals(error.getCode())) {
+        System.err.println("The specified pool does not exist.");
+    }
+}
+```
+
+## Best Practices
+
+1. **Use Entra ID** — Preferred over shared key for authentication
+2. **Use management SDK for pools** — `azure-resourcemanager-batch` supports managed identities
+3. **Batch task creation** — Use `createTaskCollection` or `createTasks` for multiple tasks
+4. **Handle LRO properly** — Pool resize, delete operations are long-running
+5. **Monitor task counts** — Use `getJobTaskCounts` to track progress
+6. **Set constraints** — Configure `maxWallClockTime` and `maxTaskRetryCount`
+7. **Use low-priority nodes** — Cost savings for fault-tolerant workloads
+8. **Enable autoscale** — Dynamically adjust pool size based on workload
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Maven Package | https://central.sonatype.com/artifact/com.azure/azure-compute-batch |
+| GitHub | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/batch/azure-compute-batch |
+| API Documentation | https://learn.microsoft.com/java/api/com.azure.compute.batch |
+| Product Docs | https://learn.microsoft.com/azure/batch/ |
+| REST API | https://learn.microsoft.com/rest/api/batchservice/ |
+| Samples | https://github.com/azure/azure-batch-samples |

--- a/skills/java/compute/batch/references/examples.md
+++ b/skills/java/compute/batch/references/examples.md
@@ -1,0 +1,921 @@
+# Azure Batch Java SDK - Examples
+
+Comprehensive code examples for the Azure Batch SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Pool Operations](#pool-operations)
+- [Job Operations](#job-operations)
+- [Task Operations](#task-operations)
+- [Node Operations](#node-operations)
+- [Job Schedule Operations](#job-schedule-operations)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-compute-batch</artifactId>
+    <version>1.0.0-beta.5</version>
+</dependency>
+
+<!-- For DefaultAzureCredential -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### With Microsoft Entra ID (Recommended)
+
+```java
+import com.azure.compute.batch.BatchClient;
+import com.azure.compute.batch.BatchClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+String endpoint = System.getenv("AZURE_BATCH_ENDPOINT");
+
+BatchClient batchClient = new BatchClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.compute.batch.BatchAsyncClient;
+
+BatchAsyncClient batchAsyncClient = new BatchClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildAsyncClient();
+```
+
+### With Shared Key Credentials
+
+```java
+import com.azure.core.credential.AzureNamedKeyCredential;
+
+String accountName = System.getenv("AZURE_BATCH_ACCOUNT");
+String accountKey = System.getenv("AZURE_BATCH_ACCESS_KEY");
+
+AzureNamedKeyCredential sharedKeyCreds = new AzureNamedKeyCredential(accountName, accountKey);
+
+BatchClient batchClient = new BatchClientBuilder()
+    .credential(sharedKeyCreds)
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+## Pool Operations
+
+### Create Pool
+
+```java
+import com.azure.compute.batch.models.*;
+
+batchClient.createPool(new BatchPoolCreateParameters("myPoolId", "STANDARD_DC2s_v2")
+    .setVirtualMachineConfiguration(
+        new VirtualMachineConfiguration(
+            new BatchVmImageReference()
+                .setPublisher("Canonical")
+                .setOffer("UbuntuServer")
+                .setSku("22_04-lts")
+                .setVersion("latest"),
+            "batch.node.ubuntu 22.04"))
+    .setTargetDedicatedNodes(2)
+    .setTargetLowPriorityNodes(0)
+    .setTaskSlotsPerNode(4)
+    .setTaskSchedulingPolicy(new TaskSchedulingPolicy(ComputeNodeFillType.SPREAD)), null);
+
+System.out.println("Pool created: myPoolId");
+```
+
+### Create Pool with Start Task
+
+```java
+batchClient.createPool(new BatchPoolCreateParameters("myPoolWithStartTask", "STANDARD_D2s_v3")
+    .setVirtualMachineConfiguration(
+        new VirtualMachineConfiguration(
+            new BatchVmImageReference()
+                .setPublisher("Canonical")
+                .setOffer("0001-com-ubuntu-server-jammy")
+                .setSku("22_04-lts")
+                .setVersion("latest"),
+            "batch.node.ubuntu 22.04"))
+    .setTargetDedicatedNodes(2)
+    .setStartTask(new StartTask("apt-get update && apt-get install -y python3")
+        .setUserIdentity(new UserIdentity()
+            .setAutoUser(new AutoUserSpecification()
+                .setScope(AutoUserScope.POOL)
+                .setElevationLevel(ElevationLevel.ADMIN)))
+        .setMaxTaskRetryCount(2)
+        .setWaitForSuccess(true)), null);
+```
+
+### Create Pool with Application Packages
+
+```java
+import java.util.Arrays;
+
+batchClient.createPool(new BatchPoolCreateParameters("appPackagePool", "STANDARD_D2s_v3")
+    .setVirtualMachineConfiguration(
+        new VirtualMachineConfiguration(
+            new BatchVmImageReference()
+                .setPublisher("MicrosoftWindowsServer")
+                .setOffer("WindowsServer")
+                .setSku("2022-datacenter")
+                .setVersion("latest"),
+            "batch.node.windows amd64"))
+    .setTargetDedicatedNodes(2)
+    .setApplicationPackageReferences(Arrays.asList(
+        new ApplicationPackageReference("myApp").setVersion("1.0"),
+        new ApplicationPackageReference("myDependency").setVersion("2.0"))), null);
+```
+
+### Get Pool
+
+```java
+BatchPool pool = batchClient.getPool("myPoolId");
+
+System.out.println("=== Pool Details ===");
+System.out.println("Pool ID: " + pool.getId());
+System.out.println("State: " + pool.getState());
+System.out.println("Allocation State: " + pool.getAllocationState());
+System.out.println("VM Size: " + pool.getVmSize());
+System.out.println("Current Dedicated Nodes: " + pool.getCurrentDedicatedNodes());
+System.out.println("Current Low Priority Nodes: " + pool.getCurrentLowPriorityNodes());
+System.out.println("Target Dedicated Nodes: " + pool.getTargetDedicatedNodes());
+```
+
+### List Pools
+
+```java
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<BatchPool> pools = batchClient.listPools();
+
+System.out.println("=== Available Pools ===");
+for (BatchPool p : pools) {
+    System.out.printf("Pool: %s, State: %s, Nodes: %d/%d%n",
+        p.getId(),
+        p.getState(),
+        p.getCurrentDedicatedNodes(),
+        p.getTargetDedicatedNodes());
+}
+```
+
+### Resize Pool
+
+```java
+import com.azure.core.util.polling.SyncPoller;
+import java.time.Duration;
+
+BatchPoolResizeParameters resizeParams = new BatchPoolResizeParameters()
+    .setTargetDedicatedNodes(4)
+    .setTargetLowPriorityNodes(2)
+    .setResizeTimeout(Duration.ofMinutes(15))
+    .setNodeDeallocationOption(BatchNodeDeallocationOption.TASK_COMPLETION);
+
+SyncPoller<BatchPool, BatchPool> poller = batchClient.beginResizePool("myPoolId", resizeParams);
+poller.waitForCompletion();
+
+BatchPool resizedPool = poller.getFinalResult();
+System.out.println("Pool resized. New target: " + resizedPool.getTargetDedicatedNodes());
+```
+
+### Enable AutoScale
+
+```java
+String autoScaleFormula = """
+    // Target 1 dedicated node per 5 pending tasks
+    pendingTasks = $PendingTasks.GetSample(TimeInterval_Minute * 5);
+    $TargetDedicatedNodes = min(10, max(1, pendingTasks / 5));
+    $TargetLowPriorityNodes = 0;
+    """;
+
+BatchPoolEnableAutoScaleParameters autoScaleParams = new BatchPoolEnableAutoScaleParameters()
+    .setAutoScaleEvaluationInterval(Duration.ofMinutes(5))
+    .setAutoScaleFormula(autoScaleFormula);
+
+batchClient.enablePoolAutoScale("myPoolId", autoScaleParams);
+System.out.println("AutoScale enabled");
+```
+
+### Disable AutoScale
+
+```java
+batchClient.disablePoolAutoScale("myPoolId");
+System.out.println("AutoScale disabled");
+```
+
+### Delete Pool
+
+```java
+SyncPoller<BatchPool, Void> deletePoller = batchClient.beginDeletePool("myPoolId");
+deletePoller.waitForCompletion();
+System.out.println("Pool deleted");
+```
+
+## Job Operations
+
+### Create Job
+
+```java
+batchClient.createJob(
+    new BatchJobCreateParameters("myJobId", new BatchPoolInfo().setPoolId("myPoolId"))
+        .setDisplayName("My Batch Job")
+        .setPriority(100)
+        .setConstraints(new BatchJobConstraints()
+            .setMaxWallClockTime(Duration.ofHours(24))
+            .setMaxTaskRetryCount(3))
+        .setOnAllTasksComplete(OnAllBatchTasksComplete.TERMINATE_JOB)
+        .setOnTaskFailure(OnBatchTaskFailure.NO_ACTION),
+    null);
+
+System.out.println("Job created: myJobId");
+```
+
+### Create Job with Job Manager Task
+
+```java
+batchClient.createJob(
+    new BatchJobCreateParameters("managedJobId", new BatchPoolInfo().setPoolId("myPoolId"))
+        .setJobManagerTask(new BatchJobManagerTask("manager", "python3 manage_tasks.py")
+            .setDisplayName("Job Manager")
+            .setKillJobOnCompletion(true)
+            .setRunExclusive(true)),
+    null);
+```
+
+### Get Job
+
+```java
+BatchJob job = batchClient.getJob("myJobId", null, null);
+
+System.out.println("=== Job Details ===");
+System.out.println("Job ID: " + job.getId());
+System.out.println("State: " + job.getState());
+System.out.println("Priority: " + job.getPriority());
+System.out.println("Pool: " + job.getPoolInfo().getPoolId());
+System.out.println("Created: " + job.getCreationTime());
+```
+
+### List Jobs
+
+```java
+PagedIterable<BatchJob> jobs = batchClient.listJobs(new BatchJobsListOptions());
+
+System.out.println("=== Active Jobs ===");
+for (BatchJob j : jobs) {
+    System.out.printf("Job: %s, State: %s, Pool: %s%n",
+        j.getId(),
+        j.getState(),
+        j.getPoolInfo().getPoolId());
+}
+```
+
+### Get Task Counts
+
+```java
+BatchTaskCountsResult counts = batchClient.getJobTaskCounts("myJobId");
+
+System.out.println("=== Task Counts ===");
+System.out.println("Active: " + counts.getTaskCounts().getActive());
+System.out.println("Running: " + counts.getTaskCounts().getRunning());
+System.out.println("Completed: " + counts.getTaskCounts().getCompleted());
+System.out.println("Succeeded: " + counts.getTaskCounts().getSucceeded());
+System.out.println("Failed: " + counts.getTaskCounts().getFailed());
+```
+
+### Update Job
+
+```java
+BatchJobUpdateParameters updateParams = new BatchJobUpdateParameters()
+    .setPriority(200)
+    .setConstraints(new BatchJobConstraints()
+        .setMaxWallClockTime(Duration.ofHours(48)));
+
+batchClient.updateJob("myJobId", updateParams);
+System.out.println("Job updated");
+```
+
+### Terminate Job
+
+```java
+BatchJobTerminateParameters terminateParams = new BatchJobTerminateParameters()
+    .setTerminationReason("Manual termination - job complete");
+BatchJobTerminateOptions options = new BatchJobTerminateOptions().setParameters(terminateParams);
+
+SyncPoller<BatchJob, BatchJob> poller = batchClient.beginTerminateJob("myJobId", options, null);
+poller.waitForCompletion();
+System.out.println("Job terminated");
+```
+
+### Delete Job
+
+```java
+SyncPoller<BatchJob, Void> deletePoller = batchClient.beginDeleteJob("myJobId");
+deletePoller.waitForCompletion();
+System.out.println("Job deleted");
+```
+
+## Task Operations
+
+### Create Single Task
+
+```java
+BatchTaskCreateParameters task = new BatchTaskCreateParameters("task1", "echo 'Hello World'");
+batchClient.createTask("myJobId", task);
+System.out.println("Task created: task1");
+```
+
+### Create Task with Resource Files
+
+```java
+import java.util.Arrays;
+
+BatchTaskCreateParameters task = new BatchTaskCreateParameters("processDataTask", 
+    "python3 process.py input.csv output.csv")
+    .setResourceFiles(Arrays.asList(
+        new ResourceFile()
+            .setHttpUrl("https://storage.blob.core.windows.net/container/process.py?sasToken")
+            .setFilePath("process.py"),
+        new ResourceFile()
+            .setHttpUrl("https://storage.blob.core.windows.net/container/input.csv?sasToken")
+            .setFilePath("input.csv")))
+    .setOutputFiles(Arrays.asList(
+        new OutputFile("output.csv")
+            .setDestination(new OutputFileDestination()
+                .setContainer(new OutputFileBlobContainerDestination(
+                    "https://storage.blob.core.windows.net/results?sasToken")
+                    .setPath("results/output.csv")))
+            .setUploadOptions(new OutputFileUploadOptions()
+                .setUploadCondition(OutputFileUploadCondition.TASK_SUCCESS))));
+
+batchClient.createTask("myJobId", task);
+```
+
+### Create Task with Exit Conditions
+
+```java
+BatchTaskCreateParameters task = new BatchTaskCreateParameters("conditionalTask", "cmd /c exit 3")
+    .setExitConditions(new ExitConditions()
+        .setExitCodeRanges(Arrays.asList(
+            new ExitCodeRangeMapping(0, 0,
+                new ExitOptions().setJobAction(BatchJobActionKind.NONE)),
+            new ExitCodeRangeMapping(1, 5,
+                new ExitOptions().setJobAction(BatchJobActionKind.TERMINATE)),
+            new ExitCodeRangeMapping(6, 10,
+                new ExitOptions().setDependencyAction(DependencyActionKind.BLOCK))))
+        .setDefault(new ExitOptions()
+            .setJobAction(BatchJobActionKind.NONE)));
+
+batchClient.createTask("myJobId", task);
+```
+
+### Create Task with User Identity
+
+```java
+BatchTaskCreateParameters task = new BatchTaskCreateParameters("adminTask", "sudo apt-get update")
+    .setUserIdentity(new UserIdentity()
+        .setAutoUser(new AutoUserSpecification()
+            .setScope(AutoUserScope.TASK)
+            .setElevationLevel(ElevationLevel.ADMIN)));
+
+batchClient.createTask("myJobId", task);
+```
+
+### Create Task Collection (up to 100)
+
+```java
+List<BatchTaskCreateParameters> taskList = Arrays.asList(
+    new BatchTaskCreateParameters("task1", "echo Task 1"),
+    new BatchTaskCreateParameters("task2", "echo Task 2"),
+    new BatchTaskCreateParameters("task3", "echo Task 3"),
+    new BatchTaskCreateParameters("task4", "echo Task 4"),
+    new BatchTaskCreateParameters("task5", "echo Task 5")
+);
+
+BatchTaskGroup taskGroup = new BatchTaskGroup(taskList);
+BatchCreateTaskCollectionResult result = batchClient.createTaskCollection("myJobId", taskGroup);
+
+System.out.printf("Created %d tasks%n", result.getValue().size());
+```
+
+### Create Many Tasks (no limit)
+
+```java
+import java.util.ArrayList;
+
+List<BatchTaskCreateParameters> tasks = new ArrayList<>();
+for (int i = 0; i < 1000; i++) {
+    tasks.add(new BatchTaskCreateParameters("task" + i, 
+        String.format("python3 process.py --partition %d", i)));
+}
+
+batchClient.createTasks("myJobId", tasks);
+System.out.printf("Created %d tasks%n", tasks.size());
+```
+
+### Create Task with Dependencies
+
+```java
+// First, create prerequisite tasks
+batchClient.createTask("myJobId", new BatchTaskCreateParameters("setup", "setup.sh"));
+batchClient.createTask("myJobId", new BatchTaskCreateParameters("download", "download.sh"));
+
+// Create dependent task
+BatchTaskCreateParameters dependentTask = new BatchTaskCreateParameters("process", "process.sh")
+    .setDependsOn(new BatchTaskDependencies()
+        .setTaskIds(Arrays.asList("setup", "download")));
+
+batchClient.createTask("myJobId", dependentTask);
+```
+
+### Get Task
+
+```java
+BatchTask task = batchClient.getTask("myJobId", "task1");
+
+System.out.println("=== Task Details ===");
+System.out.println("Task ID: " + task.getId());
+System.out.println("State: " + task.getState());
+System.out.println("Command: " + task.getCommandLine());
+
+if (task.getExecutionInfo() != null) {
+    System.out.println("Exit Code: " + task.getExecutionInfo().getExitCode());
+    System.out.println("Start Time: " + task.getExecutionInfo().getStartTime());
+    System.out.println("End Time: " + task.getExecutionInfo().getEndTime());
+    
+    if (task.getExecutionInfo().getFailureInfo() != null) {
+        System.out.println("Failure: " + task.getExecutionInfo().getFailureInfo().getMessage());
+    }
+}
+```
+
+### List Tasks
+
+```java
+PagedIterable<BatchTask> tasks = batchClient.listTasks("myJobId");
+
+System.out.println("=== Tasks ===");
+for (BatchTask t : tasks) {
+    System.out.printf("Task: %s, State: %s%n", t.getId(), t.getState());
+}
+```
+
+### Get Task Output
+
+```java
+import com.azure.core.util.BinaryData;
+import java.nio.charset.StandardCharsets;
+
+// Get stdout
+BinaryData stdout = batchClient.getTaskFile("myJobId", "task1", "stdout.txt");
+System.out.println("=== stdout ===");
+System.out.println(new String(stdout.toBytes(), StandardCharsets.UTF_8));
+
+// Get stderr
+BinaryData stderr = batchClient.getTaskFile("myJobId", "task1", "stderr.txt");
+System.out.println("=== stderr ===");
+System.out.println(new String(stderr.toBytes(), StandardCharsets.UTF_8));
+```
+
+### List Task Files
+
+```java
+PagedIterable<BatchNodeFile> files = batchClient.listTaskFiles("myJobId", "task1");
+
+System.out.println("=== Task Files ===");
+for (BatchNodeFile file : files) {
+    System.out.printf("File: %s, Size: %d bytes%n",
+        file.getName(),
+        file.getProperties().getContentLength());
+}
+```
+
+### Terminate Task
+
+```java
+batchClient.terminateTask("myJobId", "task1", null, null);
+System.out.println("Task terminated");
+```
+
+### Delete Task
+
+```java
+batchClient.deleteTask("myJobId", "task1");
+System.out.println("Task deleted");
+```
+
+## Node Operations
+
+### List Nodes
+
+```java
+PagedIterable<BatchNode> nodes = batchClient.listNodes("myPoolId", new BatchNodesListOptions());
+
+System.out.println("=== Compute Nodes ===");
+for (BatchNode node : nodes) {
+    System.out.printf("Node: %s, State: %s, IP: %s%n",
+        node.getId(),
+        node.getState(),
+        node.getIpAddress());
+}
+```
+
+### Get Node
+
+```java
+BatchNode node = batchClient.getNode("myPoolId", "nodeId");
+
+System.out.println("=== Node Details ===");
+System.out.println("Node ID: " + node.getId());
+System.out.println("State: " + node.getState());
+System.out.println("IP Address: " + node.getIpAddress());
+System.out.println("VM Size: " + node.getVmSize());
+System.out.println("Total Tasks Run: " + node.getTotalTasksRun());
+System.out.println("Running Tasks: " + node.getRunningTasksCount());
+```
+
+### Reboot Node
+
+```java
+BatchNodeRebootParameters rebootParams = new BatchNodeRebootParameters()
+    .setNodeRebootOption(BatchNodeRebootOption.TASK_COMPLETION);
+
+SyncPoller<BatchNode, BatchNode> rebootPoller = 
+    batchClient.beginRebootNode("myPoolId", "nodeId", rebootParams);
+rebootPoller.waitForCompletion();
+System.out.println("Node rebooted");
+```
+
+### Get Remote Login Settings
+
+```java
+BatchNodeRemoteLoginSettings settings = batchClient.getNodeRemoteLoginSettings("myPoolId", "nodeId");
+
+System.out.println("=== Remote Login Settings ===");
+System.out.println("IP Address: " + settings.getRemoteLoginIpAddress());
+System.out.println("Port: " + settings.getRemoteLoginPort());
+
+// SSH command
+System.out.printf("SSH: ssh -p %d user@%s%n",
+    settings.getRemoteLoginPort(),
+    settings.getRemoteLoginIpAddress());
+```
+
+### Remove Node from Pool
+
+```java
+BatchNodeRemoveParameters removeParams = new BatchNodeRemoveParameters(
+    Arrays.asList("nodeId1", "nodeId2"))
+    .setNodeDeallocationOption(BatchNodeDeallocationOption.TASK_COMPLETION)
+    .setResizeTimeout(Duration.ofMinutes(15));
+
+batchClient.removeNodes("myPoolId", removeParams);
+System.out.println("Nodes removal initiated");
+```
+
+## Job Schedule Operations
+
+### Create Job Schedule
+
+```java
+import java.time.OffsetDateTime;
+
+batchClient.createJobSchedule(new BatchJobScheduleCreateParameters("dailySchedule",
+    new BatchJobScheduleConfiguration()
+        .setRecurrenceInterval(Duration.ofHours(24))
+        .setDoNotRunUntil(OffsetDateTime.now().plusHours(1))
+        .setDoNotRunAfter(OffsetDateTime.now().plusDays(30)),
+    new BatchJobSpecification(new BatchPoolInfo().setPoolId("myPoolId"))
+        .setDisplayName("Daily Processing Job")
+        .setPriority(100)
+        .setConstraints(new BatchJobConstraints()
+            .setMaxTaskRetryCount(3))),
+    null);
+
+System.out.println("Job schedule created: dailySchedule");
+```
+
+### Get Job Schedule
+
+```java
+BatchJobSchedule schedule = batchClient.getJobSchedule("dailySchedule");
+
+System.out.println("=== Job Schedule Details ===");
+System.out.println("Schedule ID: " + schedule.getId());
+System.out.println("State: " + schedule.getState());
+System.out.println("Next Run: " + schedule.getExecutionInfo().getNextRunTime());
+System.out.println("Recent Jobs: " + schedule.getExecutionInfo().getRecentJob());
+```
+
+### List Job Schedules
+
+```java
+PagedIterable<BatchJobSchedule> schedules = batchClient.listJobSchedules();
+
+System.out.println("=== Job Schedules ===");
+for (BatchJobSchedule s : schedules) {
+    System.out.printf("Schedule: %s, State: %s%n", s.getId(), s.getState());
+}
+```
+
+### Disable Job Schedule
+
+```java
+batchClient.disableJobSchedule("dailySchedule");
+System.out.println("Job schedule disabled");
+```
+
+### Enable Job Schedule
+
+```java
+batchClient.enableJobSchedule("dailySchedule");
+System.out.println("Job schedule enabled");
+```
+
+### Terminate Job Schedule
+
+```java
+batchClient.terminateJobSchedule("dailySchedule");
+System.out.println("Job schedule terminated");
+```
+
+### Delete Job Schedule
+
+```java
+batchClient.deleteJobSchedule("dailySchedule");
+System.out.println("Job schedule deleted");
+```
+
+## Error Handling
+
+```java
+import com.azure.compute.batch.models.BatchErrorException;
+import com.azure.compute.batch.models.BatchError;
+
+try {
+    BatchPool pool = batchClient.getPool("nonexistent-pool");
+} catch (BatchErrorException e) {
+    BatchError error = e.getValue();
+    
+    System.err.println("=== Batch Error ===");
+    System.err.println("Error code: " + error.getCode());
+    System.err.println("Message: " + error.getMessage().getValue());
+    
+    // Handle specific errors
+    switch (error.getCode()) {
+        case "PoolNotFound":
+            System.err.println("The specified pool does not exist.");
+            break;
+        case "JobNotFound":
+            System.err.println("The specified job does not exist.");
+            break;
+        case "TaskNotFound":
+            System.err.println("The specified task does not exist.");
+            break;
+        case "PoolQuotaReached":
+            System.err.println("Pool quota exceeded. Delete unused pools or request quota increase.");
+            break;
+        case "ActiveJobAndScheduleQuotaReached":
+            System.err.println("Job quota exceeded.");
+            break;
+        default:
+            System.err.println("Unexpected error: " + error.getCode());
+    }
+    
+    // Show additional details if available
+    if (error.getValues() != null) {
+        for (var detail : error.getValues()) {
+            System.err.printf("  %s: %s%n", detail.getKey(), detail.getValue());
+        }
+    }
+}
+```
+
+## Complete Application Example
+
+```java
+import com.azure.compute.batch.BatchClient;
+import com.azure.compute.batch.BatchClientBuilder;
+import com.azure.compute.batch.models.*;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.util.BinaryData;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+
+public class BatchJobRunner {
+    
+    private final BatchClient client;
+    private final String poolId;
+    
+    public BatchJobRunner(String poolId) {
+        this.client = new BatchClientBuilder()
+            .endpoint(System.getenv("AZURE_BATCH_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+        this.poolId = poolId;
+    }
+    
+    public void ensurePoolExists() {
+        try {
+            BatchPool pool = client.getPool(poolId);
+            System.out.println("Pool exists: " + pool.getId());
+        } catch (BatchErrorException e) {
+            if ("PoolNotFound".equals(e.getValue().getCode())) {
+                createPool();
+            } else {
+                throw e;
+            }
+        }
+    }
+    
+    private void createPool() {
+        System.out.println("Creating pool: " + poolId);
+        
+        client.createPool(new BatchPoolCreateParameters(poolId, "STANDARD_D2s_v3")
+            .setVirtualMachineConfiguration(
+                new VirtualMachineConfiguration(
+                    new BatchVmImageReference()
+                        .setPublisher("Canonical")
+                        .setOffer("0001-com-ubuntu-server-jammy")
+                        .setSku("22_04-lts")
+                        .setVersion("latest"),
+                    "batch.node.ubuntu 22.04"))
+            .setTargetDedicatedNodes(2)
+            .setTaskSlotsPerNode(4), null);
+        
+        // Wait for pool to be ready
+        waitForPoolReady();
+    }
+    
+    private void waitForPoolReady() {
+        System.out.println("Waiting for pool to be ready...");
+        while (true) {
+            BatchPool pool = client.getPool(poolId);
+            if (pool.getAllocationState() == AllocationState.STEADY 
+                && pool.getCurrentDedicatedNodes() > 0) {
+                System.out.println("Pool is ready with " + pool.getCurrentDedicatedNodes() + " nodes");
+                break;
+            }
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+    }
+    
+    public String runJob(String jobId, List<String> commands) {
+        // Create job
+        client.createJob(
+            new BatchJobCreateParameters(jobId, new BatchPoolInfo().setPoolId(poolId))
+                .setOnAllTasksComplete(OnAllBatchTasksComplete.TERMINATE_JOB),
+            null);
+        
+        System.out.println("Job created: " + jobId);
+        
+        // Create tasks
+        List<BatchTaskCreateParameters> tasks = new ArrayList<>();
+        for (int i = 0; i < commands.size(); i++) {
+            tasks.add(new BatchTaskCreateParameters("task" + i, commands.get(i)));
+        }
+        
+        client.createTasks(jobId, tasks);
+        System.out.println("Created " + tasks.size() + " tasks");
+        
+        // Wait for completion
+        waitForJobComplete(jobId);
+        
+        return jobId;
+    }
+    
+    private void waitForJobComplete(String jobId) {
+        System.out.println("Waiting for job to complete...");
+        while (true) {
+            BatchJob job = client.getJob(jobId, null, null);
+            
+            if (job.getState() == BatchJobState.COMPLETED) {
+                System.out.println("Job completed");
+                break;
+            } else if (job.getState() == BatchJobState.DISABLED 
+                    || job.getState() == BatchJobState.TERMINATING) {
+                throw new RuntimeException("Job failed or was terminated");
+            }
+            
+            // Show progress
+            BatchTaskCountsResult counts = client.getJobTaskCounts(jobId);
+            System.out.printf("Progress: %d/%d tasks completed%n",
+                counts.getTaskCounts().getCompleted(),
+                counts.getTaskCounts().getActive() + counts.getTaskCounts().getRunning() 
+                    + counts.getTaskCounts().getCompleted());
+            
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+    }
+    
+    public Map<String, String> getTaskOutputs(String jobId) {
+        Map<String, String> outputs = new HashMap<>();
+        
+        PagedIterable<BatchTask> tasks = client.listTasks(jobId);
+        for (BatchTask task : tasks) {
+            try {
+                BinaryData stdout = client.getTaskFile(jobId, task.getId(), "stdout.txt");
+                outputs.put(task.getId(), new String(stdout.toBytes(), StandardCharsets.UTF_8));
+            } catch (Exception e) {
+                outputs.put(task.getId(), "Error: " + e.getMessage());
+            }
+        }
+        
+        return outputs;
+    }
+    
+    public void cleanup(String jobId) {
+        try {
+            client.beginDeleteJob(jobId).waitForCompletion();
+            System.out.println("Job deleted: " + jobId);
+        } catch (Exception e) {
+            System.err.println("Failed to delete job: " + e.getMessage());
+        }
+    }
+    
+    public static void main(String[] args) {
+        BatchJobRunner runner = new BatchJobRunner("my-batch-pool");
+        
+        try {
+            // Ensure pool exists
+            runner.ensurePoolExists();
+            
+            // Run job with tasks
+            List<String> commands = Arrays.asList(
+                "echo 'Processing partition 1' && sleep 5",
+                "echo 'Processing partition 2' && sleep 5",
+                "echo 'Processing partition 3' && sleep 5",
+                "echo 'Processing partition 4' && sleep 5"
+            );
+            
+            String jobId = "job-" + System.currentTimeMillis();
+            runner.runJob(jobId, commands);
+            
+            // Get outputs
+            Map<String, String> outputs = runner.getTaskOutputs(jobId);
+            
+            System.out.println("\n=== Task Outputs ===");
+            outputs.forEach((taskId, output) -> {
+                System.out.printf("%s: %s%n", taskId, output.trim());
+            });
+            
+            // Cleanup
+            runner.cleanup(jobId);
+            
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_BATCH_ENDPOINT=https://<account>.<region>.batch.azure.com
+AZURE_BATCH_ACCOUNT=<account-name>
+AZURE_BATCH_ACCESS_KEY=<account-key>
+
+# For DefaultAzureCredential
+AZURE_CLIENT_ID=<service-principal-client-id>
+AZURE_CLIENT_SECRET=<service-principal-secret>
+AZURE_TENANT_ID=<tenant-id>
+```
+
+## Best Practices
+
+1. **Use Entra ID** — Preferred over shared key for authentication
+2. **Use management SDK for pools** — `azure-resourcemanager-batch` supports managed identities
+3. **Batch task creation** — Use `createTaskCollection` or `createTasks` for multiple tasks
+4. **Handle LRO properly** — Pool resize, delete operations are long-running
+5. **Monitor task counts** — Use `getJobTaskCounts` to track progress
+6. **Set constraints** — Configure `maxWallClockTime` and `maxTaskRetryCount`
+7. **Use low-priority nodes** — Cost savings for fault-tolerant workloads
+8. **Enable autoscale** — Dynamically adjust pool size based on workload

--- a/skills/java/data/blob/SKILL.md
+++ b/skills/java/data/blob/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: azure-storage-blob-java
+description: Build blob storage applications with Azure Storage Blob SDK for Java. Use when uploading, downloading, or managing files in Azure Blob Storage, working with containers, or implementing streaming data operations.
+---
+
+# Azure Storage Blob SDK for Java
+
+Build blob storage applications using the Azure Storage Blob SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-storage-blob</artifactId>
+    <version>12.33.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### BlobServiceClient
+
+```java
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+
+// With SAS token
+BlobServiceClient serviceClient = new BlobServiceClientBuilder()
+    .endpoint("<storage-account-url>")
+    .sasToken("<sas-token>")
+    .buildClient();
+
+// With connection string
+BlobServiceClient serviceClient = new BlobServiceClientBuilder()
+    .connectionString("<connection-string>")
+    .buildClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+BlobServiceClient serviceClient = new BlobServiceClientBuilder()
+    .endpoint("<storage-account-url>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### BlobContainerClient
+
+```java
+import com.azure.storage.blob.BlobContainerClient;
+
+// From service client
+BlobContainerClient containerClient = serviceClient.getBlobContainerClient("mycontainer");
+
+// Direct construction
+BlobContainerClient containerClient = new BlobContainerClientBuilder()
+    .connectionString("<connection-string>")
+    .containerName("mycontainer")
+    .buildClient();
+```
+
+### BlobClient
+
+```java
+import com.azure.storage.blob.BlobClient;
+
+// From container client
+BlobClient blobClient = containerClient.getBlobClient("myblob.txt");
+
+// With directory structure
+BlobClient blobClient = containerClient.getBlobClient("folder/subfolder/myblob.txt");
+
+// Direct construction
+BlobClient blobClient = new BlobClientBuilder()
+    .connectionString("<connection-string>")
+    .containerName("mycontainer")
+    .blobName("myblob.txt")
+    .buildClient();
+```
+
+## Core Patterns
+
+### Create Container
+
+```java
+// Create container
+serviceClient.createBlobContainer("mycontainer");
+
+// Create if not exists
+BlobContainerClient container = serviceClient.createBlobContainerIfNotExists("mycontainer");
+
+// From container client
+containerClient.create();
+containerClient.createIfNotExists();
+```
+
+### Upload Data
+
+```java
+import com.azure.core.util.BinaryData;
+
+// Upload string
+String data = "Hello, Azure Blob Storage!";
+blobClient.upload(BinaryData.fromString(data));
+
+// Upload with overwrite
+blobClient.upload(BinaryData.fromString(data), true);
+```
+
+### Upload from File
+
+```java
+blobClient.uploadFromFile("local-file.txt");
+
+// With overwrite
+blobClient.uploadFromFile("local-file.txt", true);
+```
+
+### Upload from Stream
+
+```java
+import com.azure.storage.blob.specialized.BlockBlobClient;
+
+BlockBlobClient blockBlobClient = blobClient.getBlockBlobClient();
+
+try (ByteArrayInputStream dataStream = new ByteArrayInputStream(data.getBytes())) {
+    blockBlobClient.upload(dataStream, data.length());
+}
+```
+
+### Upload with Options
+
+```java
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+
+BlobHttpHeaders headers = new BlobHttpHeaders()
+    .setContentType("text/plain")
+    .setCacheControl("max-age=3600");
+
+Map<String, String> metadata = Map.of("author", "john", "version", "1.0");
+
+try (InputStream stream = new FileInputStream("large-file.bin")) {
+    BlobParallelUploadOptions options = new BlobParallelUploadOptions(stream)
+        .setHeaders(headers)
+        .setMetadata(metadata);
+    
+    blobClient.uploadWithResponse(options, null, Context.NONE);
+}
+```
+
+### Upload if Not Exists
+
+```java
+import com.azure.storage.blob.models.BlobRequestConditions;
+
+BlobParallelUploadOptions options = new BlobParallelUploadOptions(inputStream, length)
+    .setRequestConditions(new BlobRequestConditions().setIfNoneMatch("*"));
+
+blobClient.uploadWithResponse(options, null, Context.NONE);
+```
+
+### Download Data
+
+```java
+// Download to BinaryData
+BinaryData content = blobClient.downloadContent();
+String text = content.toString();
+
+// Download to file
+blobClient.downloadToFile("downloaded-file.txt");
+```
+
+### Download to Stream
+
+```java
+try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+    blobClient.downloadStream(outputStream);
+    byte[] data = outputStream.toByteArray();
+}
+```
+
+### Download with InputStream
+
+```java
+import com.azure.storage.blob.specialized.BlobInputStream;
+
+try (BlobInputStream blobIS = blobClient.openInputStream()) {
+    byte[] buffer = new byte[1024];
+    int bytesRead;
+    while ((bytesRead = blobIS.read(buffer)) != -1) {
+        // Process buffer
+    }
+}
+```
+
+### Upload via OutputStream
+
+```java
+import com.azure.storage.blob.specialized.BlobOutputStream;
+
+try (BlobOutputStream blobOS = blobClient.getBlockBlobClient().getBlobOutputStream()) {
+    blobOS.write("Data to upload".getBytes());
+}
+```
+
+### List Blobs
+
+```java
+import com.azure.storage.blob.models.BlobItem;
+
+// List all blobs
+for (BlobItem blobItem : containerClient.listBlobs()) {
+    System.out.println("Blob: " + blobItem.getName());
+}
+
+// List with prefix (virtual directory)
+import com.azure.storage.blob.models.ListBlobsOptions;
+
+ListBlobsOptions options = new ListBlobsOptions().setPrefix("folder/");
+for (BlobItem blobItem : containerClient.listBlobs(options, null)) {
+    System.out.println("Blob: " + blobItem.getName());
+}
+```
+
+### List Blobs by Hierarchy
+
+```java
+import com.azure.storage.blob.models.BlobListDetails;
+
+String delimiter = "/";
+ListBlobsOptions options = new ListBlobsOptions()
+    .setPrefix("data/")
+    .setDetails(new BlobListDetails().setRetrieveMetadata(true));
+
+for (BlobItem item : containerClient.listBlobsByHierarchy(delimiter, options, null)) {
+    if (item.isPrefix()) {
+        System.out.println("Directory: " + item.getName());
+    } else {
+        System.out.println("Blob: " + item.getName());
+    }
+}
+```
+
+### Delete Blob
+
+```java
+blobClient.delete();
+
+// Delete if exists
+blobClient.deleteIfExists();
+
+// Delete with snapshots
+import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
+blobClient.deleteWithResponse(DeleteSnapshotsOptionType.INCLUDE, null, null, Context.NONE);
+```
+
+### Copy Blob
+
+```java
+import com.azure.storage.blob.models.BlobCopyInfo;
+import com.azure.core.util.polling.SyncPoller;
+
+// Async copy (for large blobs or cross-account)
+SyncPoller<BlobCopyInfo, Void> poller = blobClient.beginCopy("<source-blob-url>", Duration.ofSeconds(1));
+poller.waitForCompletion();
+
+// Sync copy from URL (for same account)
+blobClient.copyFromUrl("<source-blob-url>");
+```
+
+### Generate SAS Token
+
+```java
+import com.azure.storage.blob.sas.*;
+import java.time.OffsetDateTime;
+
+// Blob-level SAS
+BlobSasPermission permissions = new BlobSasPermission().setReadPermission(true);
+OffsetDateTime expiry = OffsetDateTime.now().plusDays(1);
+
+BlobServiceSasSignatureValues sasValues = new BlobServiceSasSignatureValues(expiry, permissions);
+String sasToken = blobClient.generateSas(sasValues);
+
+// Container-level SAS
+BlobContainerSasPermission containerPermissions = new BlobContainerSasPermission()
+    .setReadPermission(true)
+    .setListPermission(true);
+    
+BlobServiceSasSignatureValues containerSasValues = new BlobServiceSasSignatureValues(expiry, containerPermissions);
+String containerSas = containerClient.generateSas(containerSasValues);
+```
+
+### Blob Properties and Metadata
+
+```java
+import com.azure.storage.blob.models.BlobProperties;
+
+// Get properties
+BlobProperties properties = blobClient.getProperties();
+System.out.println("Size: " + properties.getBlobSize());
+System.out.println("Content-Type: " + properties.getContentType());
+System.out.println("Last Modified: " + properties.getLastModified());
+
+// Set metadata
+Map<String, String> metadata = Map.of("key1", "value1", "key2", "value2");
+blobClient.setMetadata(metadata);
+
+// Set HTTP headers
+BlobHttpHeaders headers = new BlobHttpHeaders()
+    .setContentType("application/json")
+    .setCacheControl("max-age=86400");
+blobClient.setHttpHeaders(headers);
+```
+
+### Lease Blob
+
+```java
+import com.azure.storage.blob.specialized.BlobLeaseClient;
+import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
+
+BlobLeaseClient leaseClient = new BlobLeaseClientBuilder()
+    .blobClient(blobClient)
+    .buildClient();
+
+// Acquire lease (-1 for infinite)
+String leaseId = leaseClient.acquireLease(60);
+
+// Renew lease
+leaseClient.renewLease();
+
+// Release lease
+leaseClient.releaseLease();
+```
+
+## Error Handling
+
+```java
+import com.azure.storage.blob.models.BlobStorageException;
+
+try {
+    blobClient.download(outputStream);
+} catch (BlobStorageException e) {
+    System.out.println("Status: " + e.getStatusCode());
+    System.out.println("Error code: " + e.getErrorCode());
+    // 404 = Blob not found
+    // 409 = Conflict (lease, etc.)
+}
+```
+
+## Proxy Configuration
+
+```java
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import java.net.InetSocketAddress;
+
+ProxyOptions proxyOptions = new ProxyOptions(
+    ProxyOptions.Type.HTTP,
+    new InetSocketAddress("localhost", 8888));
+
+BlobServiceClient client = new BlobServiceClientBuilder()
+    .endpoint("<endpoint>")
+    .sasToken("<sas-token>")
+    .httpClient(new NettyAsyncHttpClientBuilder().proxy(proxyOptions).build())
+    .buildClient();
+```
+
+## Environment Variables
+
+```bash
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
+AZURE_STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net
+```
+
+## Trigger Phrases
+
+- "Azure Blob Storage Java"
+- "upload download blob"
+- "blob container SDK"
+- "storage streaming"
+- "SAS token generation"
+- "blob metadata properties"

--- a/skills/java/data/blob/references/examples.md
+++ b/skills/java/data/blob/references/examples.md
@@ -1,0 +1,410 @@
+# Azure Storage Blob Java SDK - Examples
+
+Comprehensive code examples for the Azure Storage Blob SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Container Operations](#container-operations)
+- [Upload Blobs](#upload-blobs)
+- [Download Blobs](#download-blobs)
+- [List Blobs](#list-blobs)
+- [SAS Token Generation](#sas-token-generation)
+- [Error Handling](#error-handling)
+
+---
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-storage-blob</artifactId>
+    <version>12.33.0</version>
+</dependency>
+```
+
+Or use the BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-storage-blob</artifactId>
+    </dependency>
+</dependencies>
+```
+
+---
+
+## Client Creation
+
+### Using Shared Key Credential
+
+```java
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+
+StorageSharedKeyCredential credential = new StorageSharedKeyCredential(accountName, accountKey);
+
+String endpoint = String.format("https://%s.blob.core.windows.net", accountName);
+BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+    .endpoint(endpoint)
+    .credential(credential)
+    .buildClient();
+```
+
+### Using SAS Token
+
+```java
+// Separate endpoint and SAS token
+BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+    .endpoint("<your-storage-account-url>")
+    .sasToken("<your-sasToken>")
+    .buildClient();
+
+// Combined URL with SAS token
+BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+    .endpoint("<your-storage-account-url>" + "?" + "<your-sasToken>")
+    .buildClient();
+```
+
+### Using DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+    .endpoint("<your-storage-account-url>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+---
+
+## Container Operations
+
+### Create BlobContainerClient
+
+```java
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+
+// From BlobServiceClient
+BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient("mycontainer");
+
+// From builder with SAS token
+BlobContainerClient containerClient = new BlobContainerClientBuilder()
+    .endpoint("<your-storage-account-url>")
+    .sasToken("<your-sasToken>")
+    .containerName("mycontainer")
+    .buildClient();
+```
+
+### Create Container
+
+```java
+import java.util.Collections;
+import java.util.Map;
+
+// Simple create
+containerClient.create();
+
+// Create with metadata
+Map<String, String> metadata = Collections.singletonMap("mykey", "myvalue");
+containerClient.createWithResponse(metadata, null, null, Context.NONE);
+
+// Create from service client
+blobServiceClient.createBlobContainer("mycontainer");
+```
+
+### List and Delete Containers
+
+```java
+// List all containers
+blobServiceClient.listBlobContainers().forEach(containerItem -> {
+    System.out.println("Container name: " + containerItem.getName());
+});
+
+// Delete container
+containerClient.delete();
+```
+
+---
+
+## Upload Blobs
+
+### Upload BinaryData
+
+```java
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
+
+BlobClient blobClient = containerClient.getBlobClient("myblob");
+String dataSample = "samples";
+blobClient.upload(BinaryData.fromString(dataSample));
+```
+
+### Upload from InputStream
+
+```java
+import com.azure.storage.blob.specialized.BlockBlobClient;
+import java.io.ByteArrayInputStream;
+
+BlockBlobClient blockBlobClient = containerClient.getBlobClient("myblockblob").getBlockBlobClient();
+String dataSample = "samples";
+try (ByteArrayInputStream dataStream = new ByteArrayInputStream(dataSample.getBytes())) {
+    blockBlobClient.upload(dataStream, dataSample.length());
+}
+```
+
+### Upload from File
+
+```java
+BlobClient blobClient = containerClient.getBlobClient("myblockblob");
+blobClient.uploadFromFile("local-file.jpg");
+```
+
+### Upload with Overwrite Control
+
+```java
+// Upload without overwrite (fails if blob exists)
+blobClient.upload(BinaryData.fromString("data"), false);
+
+// Upload with overwrite enabled
+blobClient.upload(BinaryData.fromString("data"), true);
+
+// Upload with access conditions (fail if blob exists)
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+
+BlobParallelUploadOptions options = new BlobParallelUploadOptions(dataStream, dataSample.length());
+options.setRequestConditions(new BlobRequestConditions().setIfNoneMatch("*"));
+blobClient.uploadWithResponse(options, null, Context.NONE);
+```
+
+### Upload with Metadata and Headers
+
+```java
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import java.security.MessageDigest;
+import java.nio.charset.StandardCharsets;
+
+Map<String, String> metadata = Collections.singletonMap("myblobmetadata", "sample");
+BlobHttpHeaders headers = new BlobHttpHeaders()
+    .setContentDisposition("attachment")
+    .setContentType("text/html; charset=utf-8");
+
+String data = "Hello world!";
+byte[] md5 = MessageDigest.getInstance("MD5").digest(data.getBytes(StandardCharsets.UTF_8));
+
+try (InputStream dataStream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))) {
+    blockBlobClient.uploadWithResponse(
+        dataStream, 
+        data.length(), 
+        headers, 
+        metadata, 
+        null,  // tier
+        md5,   // content MD5
+        null,  // request conditions
+        null,  // timeout
+        null   // context
+    );
+}
+```
+
+---
+
+## Download Blobs
+
+### Download to BinaryData
+
+```java
+BinaryData content = blobClient.downloadContent();
+String text = content.toString();
+```
+
+### Download to OutputStream
+
+```java
+import java.io.ByteArrayOutputStream;
+
+try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+    blobClient.downloadStream(outputStream);
+    byte[] data = outputStream.toByteArray();
+}
+```
+
+### Download to File
+
+```java
+blobClient.downloadToFile("downloaded-file.jpg");
+```
+
+### Download via InputStream
+
+```java
+import com.azure.storage.blob.specialized.BlobInputStream;
+
+try (BlobInputStream blobIS = blobClient.openInputStream()) {
+    int data = blobIS.read();
+    // Process data...
+}
+```
+
+---
+
+## List Blobs
+
+### Simple Listing
+
+```java
+import com.azure.storage.blob.models.BlobItem;
+
+for (BlobItem blobItem : containerClient.listBlobs()) {
+    System.out.println("Blob name: " + blobItem.getName());
+}
+```
+
+### List and Create Clients
+
+```java
+for (BlobItem blobItem : containerClient.listBlobs()) {
+    BlobClient blobClient;
+    if (blobItem.getSnapshot() != null) {
+        blobClient = containerClient.getBlobClient(blobItem.getName(), blobItem.getSnapshot());
+    } else {
+        blobClient = containerClient.getBlobClient(blobItem.getName());
+    }
+    System.out.println("Blob URI: " + blobClient.getBlobUrl());
+}
+```
+
+---
+
+## SAS Token Generation
+
+```java
+import com.azure.storage.blob.sas.*;
+import com.azure.storage.common.sas.*;
+import java.time.OffsetDateTime;
+
+// Generate Account SAS
+OffsetDateTime expiryTime = OffsetDateTime.now().plusDays(1);
+AccountSasPermission accountSasPermission = new AccountSasPermission().setReadPermission(true);
+AccountSasService services = new AccountSasService().setBlobAccess(true);
+AccountSasResourceType resourceTypes = new AccountSasResourceType().setObject(true);
+
+AccountSasSignatureValues accountSasValues = new AccountSasSignatureValues(
+    expiryTime, accountSasPermission, services, resourceTypes);
+String sasToken = blobServiceClient.generateAccountSas(accountSasValues);
+
+// Generate Container SAS
+BlobContainerSasPermission containerSasPermission = new BlobContainerSasPermission().setCreatePermission(true);
+BlobServiceSasSignatureValues serviceSasValues = new BlobServiceSasSignatureValues(expiryTime, containerSasPermission);
+String containerSas = containerClient.generateSas(serviceSasValues);
+
+// Generate Blob SAS
+BlobSasPermission blobSasPermission = new BlobSasPermission().setReadPermission(true);
+BlobServiceSasSignatureValues blobSasValues = new BlobServiceSasSignatureValues(expiryTime, blobSasPermission);
+String blobSas = blobClient.generateSas(blobSasValues);
+```
+
+---
+
+## Error Handling
+
+```java
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+
+try {
+    containerClient.create();
+} catch (BlobStorageException e) {
+    if (e.getErrorCode() == BlobErrorCode.CONTAINER_ALREADY_EXISTS) {
+        System.out.println("Container already exists: " + containerClient.getBlobContainerUrl());
+    } else if (e.getErrorCode() == BlobErrorCode.CONTAINER_BEING_DELETED) {
+        System.out.println("Container is being deleted: " + e.getServiceMessage());
+    } else if (e.getErrorCode() == BlobErrorCode.RESOURCE_NOT_FOUND) {
+        System.out.println("Resource not found, status: " + e.getStatusCode());
+    } else {
+        throw e;
+    }
+}
+```
+
+---
+
+## Complete Working Example
+
+```java
+import com.azure.storage.blob.*;
+import com.azure.storage.blob.specialized.BlockBlobClient;
+import com.azure.storage.common.StorageSharedKeyCredential;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+public class BasicExample {
+
+    public static void main(String[] args) throws IOException {
+        String accountName = System.getenv("AZURE_STORAGE_ACCOUNT_NAME");
+        String accountKey = System.getenv("AZURE_STORAGE_ACCOUNT_KEY");
+
+        StorageSharedKeyCredential credential = new StorageSharedKeyCredential(accountName, accountKey);
+        String endpoint = String.format(Locale.ROOT, "https://%s.blob.core.windows.net", accountName);
+
+        BlobServiceClient storageClient = new BlobServiceClientBuilder()
+            .endpoint(endpoint)
+            .credential(credential)
+            .buildClient();
+
+        // Create container (names must be lowercase)
+        BlobContainerClient containerClient = storageClient
+            .getBlobContainerClient("myjavacontainer" + System.currentTimeMillis());
+        containerClient.create();
+
+        // Create blob client
+        BlockBlobClient blobClient = containerClient
+            .getBlobClient("HelloWorld.txt")
+            .getBlockBlobClient();
+
+        // Upload data
+        String data = "Hello world!";
+        try (InputStream dataStream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))) {
+            blobClient.upload(dataStream, data.length());
+        }
+
+        // Download data
+        int dataSize = (int) blobClient.getProperties().getBlobSize();
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(dataSize)) {
+            blobClient.downloadStream(outputStream);
+            String downloaded = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            System.out.println("Downloaded: " + downloaded);
+        }
+
+        // List blobs
+        containerClient.listBlobs().forEach(blobItem -> 
+            System.out.println("Blob: " + blobItem.getName()));
+
+        // Cleanup
+        blobClient.delete();
+        containerClient.delete();
+    }
+}
+```

--- a/skills/java/data/cosmos/SKILL.md
+++ b/skills/java/data/cosmos/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: azure-cosmos-java
+description: |
+  Azure Cosmos DB SDK for Java. NoSQL database operations with global distribution, multi-model support, and reactive patterns.
+  Triggers: "CosmosClient java", "CosmosAsyncClient", "cosmos database java", "cosmosdb java", "document database java".
+---
+
+# Azure Cosmos DB SDK for Java
+
+Client library for Azure Cosmos DB NoSQL API with global distribution and reactive patterns.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-cosmos</artifactId>
+    <version>LATEST</version>
+</dependency>
+```
+
+Or use Azure SDK BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-cosmos</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## Environment Variables
+
+```bash
+COSMOS_ENDPOINT=https://<account>.documents.azure.com:443/
+COSMOS_KEY=<your-primary-key>
+```
+
+## Authentication
+
+### Key-based Authentication
+
+```java
+import com.azure.cosmos.CosmosClient;
+import com.azure.cosmos.CosmosClientBuilder;
+
+CosmosClient client = new CosmosClientBuilder()
+    .endpoint(System.getenv("COSMOS_ENDPOINT"))
+    .key(System.getenv("COSMOS_KEY"))
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.cosmos.CosmosAsyncClient;
+
+CosmosAsyncClient asyncClient = new CosmosClientBuilder()
+    .endpoint(serviceEndpoint)
+    .key(key)
+    .buildAsyncClient();
+```
+
+### With Customizations
+
+```java
+import com.azure.cosmos.ConsistencyLevel;
+import java.util.Arrays;
+
+CosmosClient client = new CosmosClientBuilder()
+    .endpoint(serviceEndpoint)
+    .key(key)
+    .directMode(directConnectionConfig, gatewayConnectionConfig)
+    .consistencyLevel(ConsistencyLevel.SESSION)
+    .connectionSharingAcrossClientsEnabled(true)
+    .contentResponseOnWriteEnabled(true)
+    .userAgentSuffix("my-application")
+    .preferredRegions(Arrays.asList("West US", "East US"))
+    .buildClient();
+```
+
+## Client Hierarchy
+
+| Class | Purpose |
+|-------|---------|
+| `CosmosClient` / `CosmosAsyncClient` | Account-level operations |
+| `CosmosDatabase` / `CosmosAsyncDatabase` | Database operations |
+| `CosmosContainer` / `CosmosAsyncContainer` | Container/item operations |
+
+## Core Workflow
+
+### Create Database
+
+```java
+// Sync
+client.createDatabaseIfNotExists("myDatabase")
+    .map(response -> client.getDatabase(response.getProperties().getId()));
+
+// Async with chaining
+asyncClient.createDatabaseIfNotExists("myDatabase")
+    .map(response -> asyncClient.getDatabase(response.getProperties().getId()))
+    .subscribe(database -> System.out.println("Created: " + database.getId()));
+```
+
+### Create Container
+
+```java
+asyncClient.createDatabaseIfNotExists("myDatabase")
+    .flatMap(dbResponse -> {
+        String databaseId = dbResponse.getProperties().getId();
+        return asyncClient.getDatabase(databaseId)
+            .createContainerIfNotExists("myContainer", "/partitionKey")
+            .map(containerResponse -> asyncClient.getDatabase(databaseId)
+                .getContainer(containerResponse.getProperties().getId()));
+    })
+    .subscribe(container -> System.out.println("Container: " + container.getId()));
+```
+
+### CRUD Operations
+
+```java
+import com.azure.cosmos.models.PartitionKey;
+
+CosmosAsyncContainer container = asyncClient
+    .getDatabase("myDatabase")
+    .getContainer("myContainer");
+
+// Create
+container.createItem(new User("1", "John Doe", "john@example.com"))
+    .flatMap(response -> {
+        System.out.println("Created: " + response.getItem());
+        // Read
+        return container.readItem(
+            response.getItem().getId(),
+            new PartitionKey(response.getItem().getId()),
+            User.class);
+    })
+    .flatMap(response -> {
+        System.out.println("Read: " + response.getItem());
+        // Update
+        User user = response.getItem();
+        user.setEmail("john.doe@example.com");
+        return container.replaceItem(
+            user,
+            user.getId(),
+            new PartitionKey(user.getId()));
+    })
+    .flatMap(response -> {
+        // Delete
+        return container.deleteItem(
+            response.getItem().getId(),
+            new PartitionKey(response.getItem().getId()));
+    })
+    .block();
+```
+
+### Query Documents
+
+```java
+import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.util.CosmosPagedIterable;
+
+CosmosContainer container = client.getDatabase("myDatabase").getContainer("myContainer");
+
+String query = "SELECT * FROM c WHERE c.status = @status";
+CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
+
+CosmosPagedIterable<User> results = container.queryItems(
+    query,
+    options,
+    User.class
+);
+
+results.forEach(user -> System.out.println("User: " + user.getName()));
+```
+
+## Key Concepts
+
+### Partition Keys
+
+Choose a partition key with:
+- High cardinality (many distinct values)
+- Even distribution of data and requests
+- Frequently used in queries
+
+### Consistency Levels
+
+| Level | Guarantee |
+|-------|-----------|
+| Strong | Linearizability |
+| Bounded Staleness | Consistent prefix with bounded lag |
+| Session | Consistent prefix within session |
+| Consistent Prefix | Reads never see out-of-order writes |
+| Eventual | No ordering guarantee |
+
+### Request Units (RUs)
+
+All operations consume RUs. Check response headers:
+
+```java
+CosmosItemResponse<User> response = container.createItem(user);
+System.out.println("RU charge: " + response.getRequestCharge());
+```
+
+## Best Practices
+
+1. **Reuse CosmosClient** — Create once, reuse throughout application
+2. **Use async client** for high-throughput scenarios
+3. **Choose partition key carefully** — Affects performance and scalability
+4. **Enable content response on write** for immediate access to created items
+5. **Configure preferred regions** for geo-distributed applications
+6. **Handle 429 errors** with retry policies (built-in by default)
+7. **Use direct mode** for lowest latency in production
+
+## Error Handling
+
+```java
+import com.azure.cosmos.CosmosException;
+
+try {
+    container.createItem(item);
+} catch (CosmosException e) {
+    System.err.println("Status: " + e.getStatusCode());
+    System.err.println("Message: " + e.getMessage());
+    System.err.println("Request charge: " + e.getRequestCharge());
+    
+    if (e.getStatusCode() == 409) {
+        System.err.println("Item already exists");
+    } else if (e.getStatusCode() == 429) {
+        System.err.println("Rate limited, retry after: " + e.getRetryAfterDuration());
+    }
+}
+```
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Maven Package | https://central.sonatype.com/artifact/com.azure/azure-cosmos |
+| API Documentation | https://azuresdkdocs.z19.web.core.windows.net/java/azure-cosmos/latest/index.html |
+| Product Docs | https://learn.microsoft.com/azure/cosmos-db/ |
+| Samples | https://github.com/Azure-Samples/azure-cosmos-java-sql-api-samples |
+| Performance Guide | https://learn.microsoft.com/azure/cosmos-db/performance-tips-java-sdk-v4-sql |
+| Troubleshooting | https://learn.microsoft.com/azure/cosmos-db/troubleshoot-java-sdk-v4-sql |

--- a/skills/java/data/cosmos/references/examples.md
+++ b/skills/java/data/cosmos/references/examples.md
@@ -1,0 +1,409 @@
+# Azure Cosmos DB Java SDK - Examples
+
+Comprehensive code examples for the Azure Cosmos DB SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Database Operations](#database-operations)
+- [Container Operations](#container-operations)
+- [CRUD Operations (Sync)](#crud-operations-sync)
+- [CRUD Operations (Async)](#crud-operations-async)
+- [SQL Queries](#sql-queries)
+
+---
+
+## Maven Dependency
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-cosmos</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-identity</artifactId>
+    </dependency>
+</dependencies>
+```
+
+---
+
+## Client Creation
+
+### Synchronous Client (CosmosClient)
+
+```java
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosClient;
+import com.azure.cosmos.CosmosClientBuilder;
+import java.util.Arrays;
+
+// Basic client with key authentication
+CosmosClient cosmosClient = new CosmosClientBuilder()
+    .endpoint("<YOUR ENDPOINT HERE>")
+    .key("<YOUR KEY HERE>")
+    .buildClient();
+
+// Client with full configuration
+CosmosClient cosmosClient = new CosmosClientBuilder()
+    .endpoint(serviceEndpoint)
+    .key(key)
+    .preferredRegions(Arrays.asList("West US", "East US"))
+    .consistencyLevel(ConsistencyLevel.SESSION)
+    .contentResponseOnWriteEnabled(true)
+    .connectionSharingAcrossClientsEnabled(true)
+    .userAgentSuffix("my-application-client")
+    .buildClient();
+```
+
+### Asynchronous Client (CosmosAsyncClient)
+
+```java
+import com.azure.cosmos.CosmosAsyncClient;
+import java.util.ArrayList;
+
+ArrayList<String> preferredRegions = new ArrayList<>();
+preferredRegions.add("West US");
+
+CosmosAsyncClient cosmosAsyncClient = new CosmosClientBuilder()
+    .endpoint(serviceEndpoint)
+    .key(masterKey)
+    .preferredRegions(preferredRegions)
+    .consistencyLevel(ConsistencyLevel.SESSION)
+    .contentResponseOnWriteEnabled(true)
+    .buildAsyncClient();
+```
+
+### Client with DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+CosmosClient cosmosClient = new CosmosClientBuilder()
+    .endpoint(serviceEndpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .preferredRegions(Arrays.asList("West US"))
+    .consistencyLevel(ConsistencyLevel.SESSION)
+    .contentResponseOnWriteEnabled(true)
+    .buildClient();
+```
+
+---
+
+## Database Operations
+
+```java
+import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.CosmosDatabaseResponse;
+import com.azure.cosmos.models.CosmosDatabaseRequestOptions;
+
+// Create database if not exists
+CosmosDatabaseResponse databaseResponse = cosmosClient.createDatabaseIfNotExists("AzureSampleFamilyDB");
+CosmosDatabase database = cosmosClient.getDatabase(databaseResponse.getProperties().getId());
+
+// Get existing database reference
+CosmosDatabase database = cosmosClient.getDatabase("AzureSampleFamilyDB");
+
+// Delete database
+CosmosDatabaseResponse deleteResponse = database.delete(new CosmosDatabaseRequestOptions());
+System.out.println("Status code for database delete: " + deleteResponse.getStatusCode());
+```
+
+---
+
+## Container Operations
+
+```java
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.models.CosmosContainerProperties;
+import com.azure.cosmos.models.CosmosContainerResponse;
+import com.azure.cosmos.models.ThroughputProperties;
+
+// Create container with partition key and throughput
+CosmosContainerProperties containerProperties = 
+    new CosmosContainerProperties("FamilyContainer", "/lastName");
+
+// Manual throughput (400 RU/s)
+ThroughputProperties throughputProperties = ThroughputProperties.createManualThroughput(400);
+
+CosmosContainerResponse containerResponse = database.createContainerIfNotExists(
+    containerProperties, 
+    throughputProperties
+);
+
+CosmosContainer container = database.getContainer(containerResponse.getProperties().getId());
+
+// Get existing container reference
+CosmosContainer container = database.getContainer("FamilyContainer");
+
+// Delete container
+container.delete();
+```
+
+---
+
+## CRUD Operations (Sync)
+
+```java
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.models.CosmosItemRequestOptions;
+import com.azure.cosmos.models.CosmosItemResponse;
+import com.azure.cosmos.models.PartitionKey;
+import java.time.Duration;
+
+// ============ CREATE ============
+Family family = new Family();
+family.setId("AndersenFamily");
+family.setLastName("Andersen");
+family.setRegistered(true);
+
+CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+CosmosItemResponse<Family> createResponse = container.createItem(
+    family, 
+    new PartitionKey(family.getLastName()), 
+    options
+);
+
+System.out.printf("Created item with request charge of %.2f within duration %s%n",
+    createResponse.getRequestCharge(), 
+    createResponse.getDuration());
+
+// ============ READ (Point Read) ============
+try {
+    CosmosItemResponse<Family> readResponse = container.readItem(
+        "AndersenFamily",                    // id
+        new PartitionKey("Andersen"),        // partition key
+        Family.class
+    );
+    
+    Family readFamily = readResponse.getItem();
+    double requestCharge = readResponse.getRequestCharge();
+    Duration requestLatency = readResponse.getDuration();
+    
+    System.out.printf("Read item id=%s with charge=%.2f, latency=%s%n",
+        readFamily.getId(), requestCharge, requestLatency);
+        
+} catch (CosmosException e) {
+    System.err.printf("Read failed with status code %d: %s%n", 
+        e.getStatusCode(), e.getMessage());
+}
+
+// ============ UPDATE (Replace) ============
+family.setDistrict("NewDistrict");
+CosmosItemResponse<Family> replaceResponse = container.replaceItem(
+    family,
+    family.getId(),
+    new PartitionKey(family.getLastName()),
+    new CosmosItemRequestOptions()
+);
+
+System.out.printf("Replaced item id=%s, district=%s, charge=%.2f%n",
+    replaceResponse.getItem().getId(),
+    replaceResponse.getItem().getDistrict(),
+    replaceResponse.getRequestCharge());
+
+// ============ UPSERT (Create or Replace) ============
+family.setRegistered(false);
+CosmosItemResponse<Family> upsertResponse = container.upsertItem(family);
+
+System.out.printf("Upserted item with charge=%.2f within duration %s%n",
+    upsertResponse.getRequestCharge(), 
+    upsertResponse.getDuration());
+
+// ============ DELETE ============
+container.deleteItem(
+    family.getId(),
+    new PartitionKey(family.getLastName()),
+    new CosmosItemRequestOptions()
+);
+```
+
+---
+
+## CRUD Operations (Async)
+
+```java
+import com.azure.cosmos.CosmosAsyncContainer;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
+
+// ============ CREATE (Async) ============
+Mono<CosmosItemResponse<Family>> createMono = cosmosAsyncContainer.createItem(family);
+
+createMono.subscribe(response -> {
+    System.out.printf("Created item with request charge of %.2f%n", 
+        response.getRequestCharge());
+});
+
+// ============ CHAINED CRUD OPERATIONS ============
+cosmosAsyncContainer.createItem(new Family("carla.davis@outlook.com", "Carla Davis"))
+    .flatMap(response -> {
+        System.out.println("Created item: " + response.getItem().getId());
+        // Read that item
+        return cosmosAsyncContainer.readItem(
+            response.getItem().getId(),
+            new PartitionKey(response.getItem().getLastName()), 
+            Family.class
+        );
+    })
+    .flatMap(response -> {
+        System.out.println("Read item: " + response.getItem().getId());
+        // Replace that item
+        Family p = response.getItem();
+        p.setDistrict("SFO");
+        return cosmosAsyncContainer.replaceItem(
+            p, 
+            response.getItem().getId(),
+            new PartitionKey(response.getItem().getLastName())
+        );
+    })
+    .flatMap(response -> {
+        // Delete that item
+        return cosmosAsyncContainer.deleteItem(
+            response.getItem().getId(),
+            new PartitionKey(response.getItem().getLastName())
+        );
+    })
+    .block(); // Block only for demo - avoid in production
+
+// ============ BATCH CREATE (Async) ============
+Flux<Family> familiesToCreate = Flux.just(family1, family2, family3, family4);
+
+double totalCharge = familiesToCreate
+    .flatMap(family -> cosmosAsyncContainer.createItem(family))
+    .flatMap(itemResponse -> {
+        System.out.printf("Created item ID: %s with charge %.2f%n",
+            itemResponse.getItem().getId(),
+            itemResponse.getRequestCharge());
+        return Mono.just(itemResponse.getRequestCharge());
+    })
+    .reduce(0.0, Double::sum)
+    .block();
+
+System.out.printf("Total request charge: %.2f%n", totalCharge);
+```
+
+---
+
+## SQL Queries
+
+### Basic Queries
+
+```java
+import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.util.CosmosPagedIterable;
+
+CosmosQueryRequestOptions queryOptions = new CosmosQueryRequestOptions();
+queryOptions.setQueryMetricsEnabled(true);
+
+// Query all documents
+CosmosPagedIterable<Family> families = container.queryItems(
+    "SELECT * FROM c", 
+    queryOptions, 
+    Family.class
+);
+
+for (Family family : families) {
+    System.out.println("Family: " + family.getId());
+}
+
+// Query with WHERE clause
+String query = "SELECT * FROM Family WHERE Family.lastName IN ('Andersen', 'Wakefield', 'Johnson')";
+CosmosPagedIterable<Family> filteredFamilies = container.queryItems(
+    query, 
+    queryOptions, 
+    Family.class
+);
+```
+
+### Parameterized Queries (Recommended)
+
+```java
+import com.azure.cosmos.models.SqlParameter;
+import com.azure.cosmos.models.SqlQuerySpec;
+import java.util.ArrayList;
+
+// Single parameter
+ArrayList<SqlParameter> paramList = new ArrayList<>();
+paramList.add(new SqlParameter("@id", "AndersenFamily"));
+
+SqlQuerySpec querySpec = new SqlQuerySpec(
+    "SELECT * FROM Families f WHERE (f.id = @id)",
+    paramList
+);
+
+CosmosPagedIterable<Family> families = container.queryItems(
+    querySpec, 
+    new CosmosQueryRequestOptions(), 
+    Family.class
+);
+
+// Multiple parameters
+paramList = new ArrayList<>();
+paramList.add(new SqlParameter("@id", "AndersenFamily"));
+paramList.add(new SqlParameter("@city", "Seattle"));
+
+querySpec = new SqlQuerySpec(
+    "SELECT * FROM Families f WHERE f.id = @id AND f.Address.City = @city",
+    paramList
+);
+
+CosmosPagedIterable<Family> result = container.queryItems(
+    querySpec, 
+    new CosmosQueryRequestOptions(), 
+    Family.class
+);
+```
+
+### Queries with Paging
+
+```java
+import com.azure.cosmos.models.FeedResponse;
+
+String query = "SELECT * FROM Families";
+int pageSize = 100;
+String continuationToken = null;
+double totalRequestCharge = 0.0;
+
+do {
+    CosmosQueryRequestOptions queryOptions = new CosmosQueryRequestOptions();
+    
+    Iterable<FeedResponse<Family>> feedResponseIterator = container
+        .queryItems(query, queryOptions, Family.class)
+        .iterableByPage(continuationToken, pageSize);
+
+    for (FeedResponse<Family> page : feedResponseIterator) {
+        System.out.printf("Page with %d items, charge: %.2f%n", 
+            page.getResults().size(),
+            page.getRequestCharge());
+        
+        totalRequestCharge += page.getRequestCharge();
+        
+        // Process items in this page
+        for (Family family : page.getResults()) {
+            System.out.println("  - " + family.getId());
+        }
+        
+        // Get continuation token for next page
+        continuationToken = page.getContinuationToken();
+    }
+} while (continuationToken != null);
+
+System.out.printf("Total request charge: %.2f%n", totalRequestCharge);
+```

--- a/skills/java/data/tables/SKILL.md
+++ b/skills/java/data/tables/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: azure-data-tables-java
+description: Build table storage applications with Azure Tables SDK for Java. Use when working with Azure Table Storage or Cosmos DB Table API for NoSQL key-value data, schemaless storage, or structured data at scale.
+---
+
+# Azure Tables SDK for Java
+
+Build table storage applications using the Azure Tables SDK for Java. Works with both Azure Table Storage and Cosmos DB Table API.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.azure</groupId>
+  <artifactId>azure-data-tables</artifactId>
+  <version>12.6.0-beta.1</version>
+</dependency>
+```
+
+## Client Creation
+
+### With Connection String
+
+```java
+import com.azure.data.tables.TableServiceClient;
+import com.azure.data.tables.TableServiceClientBuilder;
+import com.azure.data.tables.TableClient;
+
+TableServiceClient serviceClient = new TableServiceClientBuilder()
+    .connectionString("<your-connection-string>")
+    .buildClient();
+```
+
+### With Shared Key
+
+```java
+import com.azure.core.credential.AzureNamedKeyCredential;
+
+AzureNamedKeyCredential credential = new AzureNamedKeyCredential(
+    "<account-name>",
+    "<account-key>");
+
+TableServiceClient serviceClient = new TableServiceClientBuilder()
+    .endpoint("<your-table-account-url>")
+    .credential(credential)
+    .buildClient();
+```
+
+### With SAS Token
+
+```java
+TableServiceClient serviceClient = new TableServiceClientBuilder()
+    .endpoint("<your-table-account-url>")
+    .sasToken("<sas-token>")
+    .buildClient();
+```
+
+### With DefaultAzureCredential (Storage only)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+TableServiceClient serviceClient = new TableServiceClientBuilder()
+    .endpoint("<your-table-account-url>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Key Concepts
+
+- **TableServiceClient**: Manage tables (create, list, delete)
+- **TableClient**: Manage entities within a table (CRUD)
+- **Partition Key**: Groups entities for efficient queries
+- **Row Key**: Unique identifier within a partition
+- **Entity**: A row with up to 252 properties (1MB Storage, 2MB Cosmos)
+
+## Core Patterns
+
+### Create Table
+
+```java
+// Create table (throws if exists)
+TableClient tableClient = serviceClient.createTable("mytable");
+
+// Create if not exists (no exception)
+TableClient tableClient = serviceClient.createTableIfNotExists("mytable");
+```
+
+### Get Table Client
+
+```java
+// From service client
+TableClient tableClient = serviceClient.getTableClient("mytable");
+
+// Direct construction
+TableClient tableClient = new TableClientBuilder()
+    .connectionString("<connection-string>")
+    .tableName("mytable")
+    .buildClient();
+```
+
+### Create Entity
+
+```java
+import com.azure.data.tables.models.TableEntity;
+
+TableEntity entity = new TableEntity("partitionKey", "rowKey")
+    .addProperty("Name", "Product A")
+    .addProperty("Price", 29.99)
+    .addProperty("Quantity", 100)
+    .addProperty("IsAvailable", true);
+
+tableClient.createEntity(entity);
+```
+
+### Get Entity
+
+```java
+TableEntity entity = tableClient.getEntity("partitionKey", "rowKey");
+
+String name = (String) entity.getProperty("Name");
+Double price = (Double) entity.getProperty("Price");
+System.out.printf("Product: %s, Price: %.2f%n", name, price);
+```
+
+### Update Entity
+
+```java
+import com.azure.data.tables.models.TableEntityUpdateMode;
+
+// Merge (update only specified properties)
+TableEntity updateEntity = new TableEntity("partitionKey", "rowKey")
+    .addProperty("Price", 24.99);
+tableClient.updateEntity(updateEntity, TableEntityUpdateMode.MERGE);
+
+// Replace (replace entire entity)
+TableEntity replaceEntity = new TableEntity("partitionKey", "rowKey")
+    .addProperty("Name", "Product A Updated")
+    .addProperty("Price", 24.99)
+    .addProperty("Quantity", 150);
+tableClient.updateEntity(replaceEntity, TableEntityUpdateMode.REPLACE);
+```
+
+### Upsert Entity
+
+```java
+// Insert or update (merge mode)
+tableClient.upsertEntity(entity, TableEntityUpdateMode.MERGE);
+
+// Insert or replace
+tableClient.upsertEntity(entity, TableEntityUpdateMode.REPLACE);
+```
+
+### Delete Entity
+
+```java
+tableClient.deleteEntity("partitionKey", "rowKey");
+```
+
+### List Entities
+
+```java
+import com.azure.data.tables.models.ListEntitiesOptions;
+
+// List all entities
+for (TableEntity entity : tableClient.listEntities()) {
+    System.out.printf("%s - %s%n",
+        entity.getPartitionKey(),
+        entity.getRowKey());
+}
+
+// With filtering and selection
+ListEntitiesOptions options = new ListEntitiesOptions()
+    .setFilter("PartitionKey eq 'sales'")
+    .setSelect("Name", "Price");
+
+for (TableEntity entity : tableClient.listEntities(options, null, null)) {
+    System.out.printf("%s: %.2f%n",
+        entity.getProperty("Name"),
+        entity.getProperty("Price"));
+}
+```
+
+### Query with OData Filter
+
+```java
+// Filter by partition key
+ListEntitiesOptions options = new ListEntitiesOptions()
+    .setFilter("PartitionKey eq 'electronics'");
+
+// Filter with multiple conditions
+options.setFilter("PartitionKey eq 'electronics' and Price gt 100");
+
+// Filter with comparison operators
+options.setFilter("Quantity ge 10 and Quantity le 100");
+
+// Top N results
+options.setTop(10);
+
+for (TableEntity entity : tableClient.listEntities(options, null, null)) {
+    System.out.println(entity.getRowKey());
+}
+```
+
+### Batch Operations (Transactions)
+
+```java
+import com.azure.data.tables.models.TableTransactionAction;
+import com.azure.data.tables.models.TableTransactionActionType;
+import java.util.Arrays;
+
+// All entities must have same partition key
+List<TableTransactionAction> actions = Arrays.asList(
+    new TableTransactionAction(
+        TableTransactionActionType.CREATE,
+        new TableEntity("batch", "row1").addProperty("Name", "Item 1")),
+    new TableTransactionAction(
+        TableTransactionActionType.CREATE,
+        new TableEntity("batch", "row2").addProperty("Name", "Item 2")),
+    new TableTransactionAction(
+        TableTransactionActionType.UPSERT_MERGE,
+        new TableEntity("batch", "row3").addProperty("Name", "Item 3"))
+);
+
+tableClient.submitTransaction(actions);
+```
+
+### List Tables
+
+```java
+import com.azure.data.tables.models.TableItem;
+import com.azure.data.tables.models.ListTablesOptions;
+
+// List all tables
+for (TableItem table : serviceClient.listTables()) {
+    System.out.println(table.getName());
+}
+
+// Filter tables
+ListTablesOptions options = new ListTablesOptions()
+    .setFilter("TableName eq 'mytable'");
+
+for (TableItem table : serviceClient.listTables(options, null, null)) {
+    System.out.println(table.getName());
+}
+```
+
+### Delete Table
+
+```java
+serviceClient.deleteTable("mytable");
+```
+
+## Typed Entities
+
+```java
+public class Product implements TableEntity {
+    private String partitionKey;
+    private String rowKey;
+    private OffsetDateTime timestamp;
+    private String eTag;
+    private String name;
+    private double price;
+    
+    // Getters and setters for all fields
+    @Override
+    public String getPartitionKey() { return partitionKey; }
+    @Override
+    public void setPartitionKey(String partitionKey) { this.partitionKey = partitionKey; }
+    @Override
+    public String getRowKey() { return rowKey; }
+    @Override
+    public void setRowKey(String rowKey) { this.rowKey = rowKey; }
+    // ... other getters/setters
+    
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public double getPrice() { return price; }
+    public void setPrice(double price) { this.price = price; }
+}
+
+// Usage
+Product product = new Product();
+product.setPartitionKey("electronics");
+product.setRowKey("laptop-001");
+product.setName("Laptop");
+product.setPrice(999.99);
+
+tableClient.createEntity(product);
+```
+
+## Error Handling
+
+```java
+import com.azure.data.tables.models.TableServiceException;
+
+try {
+    tableClient.createEntity(entity);
+} catch (TableServiceException e) {
+    System.out.println("Status: " + e.getResponse().getStatusCode());
+    System.out.println("Error: " + e.getMessage());
+    // 409 = Conflict (entity exists)
+    // 404 = Not Found
+}
+```
+
+## Environment Variables
+
+```bash
+# Storage Account
+AZURE_TABLES_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
+AZURE_TABLES_ENDPOINT=https://<account>.table.core.windows.net
+
+# Cosmos DB Table API
+COSMOS_TABLE_ENDPOINT=https://<account>.table.cosmosdb.azure.com
+```
+
+## Best Practices
+
+1. **Partition Key Design**: Choose keys that distribute load evenly
+2. **Batch Operations**: Use transactions for atomic multi-entity updates
+3. **Query Optimization**: Always filter by PartitionKey when possible
+4. **Select Projection**: Only select needed properties for performance
+5. **Entity Size**: Keep entities under 1MB (Storage) or 2MB (Cosmos)
+
+## Trigger Phrases
+
+- "Azure Tables Java"
+- "table storage SDK"
+- "Cosmos DB Table API"
+- "NoSQL key-value storage"
+- "partition key row key"
+- "table entity CRUD"

--- a/skills/java/data/tables/references/examples.md
+++ b/skills/java/data/tables/references/examples.md
@@ -1,0 +1,561 @@
+# Azure Data Tables SDK for Java - Examples
+
+Comprehensive code examples for the Azure Data Tables SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Creating Tables](#creating-tables)
+- [CRUD Operations on Entities](#crud-operations-on-entities)
+- [Querying Entities](#querying-entities)
+- [Batch/Transactional Operations](#batchtransactional-operations)
+- [Async Client Patterns](#async-client-patterns)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-data-tables</artifactId>
+    <version>12.6.0-beta.1</version>
+</dependency>
+
+<!-- For DefaultAzureCredential authentication -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.18.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### TableServiceClient with DefaultAzureCredential
+
+```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.data.tables.TableServiceClient;
+import com.azure.data.tables.TableServiceClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+TokenCredential tokenCredential = new DefaultAzureCredentialBuilder().build();
+TableServiceClient tableServiceClient = new TableServiceClientBuilder()
+    .endpoint("<your-table-account-url>")
+    .credential(tokenCredential)
+    .buildClient();
+```
+
+### TableServiceClient with Connection String
+
+```java
+TableServiceClient tableServiceClient = new TableServiceClientBuilder()
+    .connectionString("<your-connection-string>")
+    .buildClient();
+```
+
+### TableServiceClient with Named Key Credential
+
+```java
+import com.azure.core.credential.AzureNamedKeyCredential;
+
+AzureNamedKeyCredential credential = new AzureNamedKeyCredential(
+    "<your-account-name>", 
+    "<account-access-key>"
+);
+TableServiceClient tableServiceClient = new TableServiceClientBuilder()
+    .endpoint("<your-table-account-url>")
+    .credential(credential)
+    .buildClient();
+```
+
+### TableServiceClient with SAS Token
+
+```java
+TableServiceClient tableServiceClient = new TableServiceClientBuilder()
+    .endpoint("<your-table-account-url>")
+    .sasToken("<sas-token-string>")
+    .buildClient();
+```
+
+### TableClient (Direct Table Access)
+
+```java
+import com.azure.data.tables.TableClient;
+import com.azure.data.tables.TableClientBuilder;
+
+// Using endpoint and credential
+TableClient tableClient = new TableClientBuilder()
+    .endpoint("https://myaccount.table.core.windows.net/")
+    .credential(new AzureNamedKeyCredential("name", "key"))
+    .tableName("myTable")
+    .buildClient();
+
+// Using connection string
+TableClient tableClient = new TableClientBuilder()
+    .connectionString("<your-connection-string>")
+    .tableName("myTable")
+    .buildClient();
+```
+
+### Get TableClient from TableServiceClient
+
+```java
+TableClient tableClient = tableServiceClient.getTableClient("myTable");
+System.out.printf("Table name: %s%n", tableClient.getTableName());
+```
+
+## Creating Tables
+
+### Create Table
+
+```java
+import com.azure.data.tables.TableClient;
+
+String tableName = "myTable";
+TableClient tableClient = tableServiceClient.createTable(tableName);
+System.out.printf("Created table: %s%n", tableClient.getTableName());
+```
+
+### Create Table If Not Exists (Idempotent)
+
+```java
+TableClient tableClient = tableServiceClient.createTableIfNotExists(tableName);
+```
+
+### Create with Response
+
+```java
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+import java.time.Duration;
+
+Response<TableClient> response = tableServiceClient.createTableWithResponse(
+    "myTable", 
+    Duration.ofSeconds(5), 
+    new Context("key1", "value1")
+);
+System.out.printf("Status: %d, Table: %s%n", 
+    response.getStatusCode(), 
+    response.getValue().getTableName());
+```
+
+### Delete Table
+
+```java
+tableServiceClient.deleteTable("myTable");
+```
+
+## CRUD Operations on Entities
+
+### Create Entity
+
+```java
+import com.azure.data.tables.models.TableEntity;
+
+String partitionKey = "OfficeSupplies";
+String rowKey = "s001";
+
+TableEntity entity = new TableEntity(partitionKey, rowKey)
+    .addProperty("Product", "Marker Set")
+    .addProperty("Price", 5.00)
+    .addProperty("Quantity", 21)
+    .addProperty("Type", "Pen");
+
+tableClient.createEntity(entity);
+System.out.printf("Created entity: %s/%s%n", partitionKey, rowKey);
+```
+
+### Create Entity with Response
+
+```java
+Response<Void> response = tableClient.createEntityWithResponse(
+    entity, 
+    Duration.ofSeconds(5), 
+    new Context("key1", "value1")
+);
+System.out.printf("Status: %d%n", response.getStatusCode());
+```
+
+### Get Entity
+
+```java
+TableEntity retrievedEntity = tableClient.getEntity(partitionKey, rowKey);
+System.out.printf("Retrieved: %s/%s%n", 
+    retrievedEntity.getPartitionKey(), 
+    retrievedEntity.getRowKey());
+
+// Access properties
+Object product = retrievedEntity.getProperty("Product");
+Object price = retrievedEntity.getProperty("Price");
+```
+
+### Get Entity with Select
+
+```java
+import java.util.Arrays;
+import java.util.List;
+
+List<String> propertiesToSelect = Arrays.asList("Product", "Price");
+
+Response<TableEntity> response = tableClient.getEntityWithResponse(
+    partitionKey, 
+    rowKey, 
+    propertiesToSelect, 
+    Duration.ofSeconds(5), 
+    new Context("key1", "value1")
+);
+
+TableEntity entity = response.getValue();
+entity.getProperties().forEach((key, value) ->
+    System.out.printf("%s: %s%n", key, value));
+```
+
+### Update Entity (Merge)
+
+```java
+import com.azure.data.tables.models.TableEntityUpdateMode;
+
+TableEntity entityForUpdate = new TableEntity(partitionKey, rowKey)
+    .addProperty("Type", "Pen")
+    .addProperty("Color", "Red");
+
+// MERGE mode: merges with existing entity (default)
+tableClient.updateEntity(entityForUpdate);
+
+// Explicit MERGE
+tableClient.updateEntity(entityForUpdate, TableEntityUpdateMode.MERGE);
+```
+
+### Update Entity (Replace)
+
+```java
+// REPLACE mode: replaces entire entity
+tableClient.updateEntity(entityForUpdate, TableEntityUpdateMode.REPLACE);
+```
+
+### Update with ETag (Optimistic Concurrency)
+
+```java
+Response<Void> response = tableClient.updateEntityWithResponse(
+    entityForUpdate, 
+    TableEntityUpdateMode.REPLACE, 
+    true,  // ifUnchanged - use ETag
+    Duration.ofSeconds(5), 
+    new Context("key1", "value1")
+);
+```
+
+### Upsert Entity (Insert or Update)
+
+```java
+TableEntity entityForUpsert = new TableEntity(partitionKey, "s002")
+    .addProperty("Type", "Marker")
+    .addProperty("Color", "Blue");
+
+// Insert if not exists, update if exists
+tableClient.upsertEntity(entityForUpsert);
+```
+
+### Delete Entity
+
+```java
+// By keys
+tableClient.deleteEntity(partitionKey, rowKey);
+
+// By entity object
+tableClient.deleteEntity(entity);
+
+// With response
+Response<Void> response = tableClient.deleteEntityWithResponse(
+    entity, 
+    true,  // ifUnchanged - use ETag
+    Duration.ofSeconds(5), 
+    new Context("key1", "value1")
+);
+```
+
+## Querying Entities
+
+### List All Entities
+
+```java
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<TableEntity> entities = tableClient.listEntities();
+
+entities.forEach(entity ->
+    System.out.printf("Entity: %s/%s%n", 
+        entity.getPartitionKey(), 
+        entity.getRowKey()));
+```
+
+### List with Filter and Select
+
+```java
+import com.azure.data.tables.models.ListEntitiesOptions;
+import java.util.Arrays;
+
+List<String> propertiesToSelect = Arrays.asList("Product", "Price");
+
+ListEntitiesOptions options = new ListEntitiesOptions()
+    .setFilter(String.format("PartitionKey eq '%s'", partitionKey))
+    .setSelect(propertiesToSelect);
+
+for (TableEntity entity : tableClient.listEntities(options, null, null)) {
+    System.out.printf("%s: %.2f%n", 
+        entity.getProperty("Product"), 
+        entity.getProperty("Price"));
+}
+```
+
+### Advanced Query with Top
+
+```java
+ListEntitiesOptions options = new ListEntitiesOptions()
+    .setTop(15)  // Limit results
+    .setFilter("PartitionKey eq 'MyPartitionKey' and RowKey eq 'MyRowKey'")
+    .setSelect(Arrays.asList("name", "lastname", "age"));
+
+PagedIterable<TableEntity> entities = tableClient.listEntities(
+    options,
+    Duration.ofSeconds(5), 
+    null
+);
+
+entities.forEach(entity -> {
+    System.out.printf("Entity: %s/%s%n", 
+        entity.getPartitionKey(), 
+        entity.getRowKey());
+    entity.getProperties().forEach((key, value) ->
+        System.out.printf("  %s: %s%n", key, value));
+});
+```
+
+### Filter Operators
+
+```java
+// Equals
+"PartitionKey eq 'Sales'"
+
+// Not equals
+"PartitionKey ne 'Sales'"
+
+// Greater than
+"Price gt 10.0"
+
+// Greater than or equal
+"Quantity ge 100"
+
+// Less than
+"Price lt 50.0"
+
+// Less than or equal
+"Quantity le 10"
+
+// And
+"PartitionKey eq 'Sales' and Price gt 10.0"
+
+// Or
+"Type eq 'Pen' or Type eq 'Marker'"
+```
+
+### List Tables
+
+```java
+import com.azure.data.tables.models.ListTablesOptions;
+import com.azure.data.tables.models.TableItem;
+
+// List all tables
+for (TableItem tableItem : tableServiceClient.listTables()) {
+    System.out.println(tableItem.getName());
+}
+
+// List with filter
+ListTablesOptions options = new ListTablesOptions()
+    .setFilter(String.format("TableName eq '%s'", tableName));
+
+for (TableItem tableItem : tableServiceClient.listTables(options, null, null)) {
+    System.out.println(tableItem.getName());
+}
+```
+
+## Batch/Transactional Operations
+
+All entities in a transaction must have the same partition key.
+
+```java
+import com.azure.data.tables.models.TableTransactionAction;
+import com.azure.data.tables.models.TableTransactionActionType;
+import com.azure.data.tables.models.TableTransactionResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+List<TableTransactionAction> transactionActions = new ArrayList<>();
+
+String partitionKey = "markers";  // All entities MUST have same partition key
+
+// CREATE action
+TableEntity firstEntity = new TableEntity(partitionKey, "m001")
+    .addProperty("Type", "Dry")
+    .addProperty("Color", "Red");
+transactionActions.add(new TableTransactionAction(
+    TableTransactionActionType.CREATE, 
+    firstEntity
+));
+
+// CREATE action
+TableEntity secondEntity = new TableEntity(partitionKey, "m002")
+    .addProperty("Type", "Wet")
+    .addProperty("Color", "Blue");
+transactionActions.add(new TableTransactionAction(
+    TableTransactionActionType.CREATE, 
+    secondEntity
+));
+
+// UPDATE_MERGE action
+TableEntity entityToUpdate = new TableEntity(partitionKey, "m003")
+    .addProperty("Brand", "Crayola")
+    .addProperty("Color", "Blue");
+transactionActions.add(new TableTransactionAction(
+    TableTransactionActionType.UPDATE_MERGE, 
+    entityToUpdate
+));
+
+// DELETE action
+TableEntity entityToDelete = new TableEntity(partitionKey, "m004");
+transactionActions.add(new TableTransactionAction(
+    TableTransactionActionType.DELETE, 
+    entityToDelete
+));
+
+// Submit transaction
+TableTransactionResult result = tableClient.submitTransaction(transactionActions);
+
+// Check results
+System.out.println("Transaction status codes:");
+result.getTransactionActionResponses().forEach(response ->
+    System.out.printf("  %d%n", response.getStatusCode()));
+```
+
+### Transaction Action Types
+
+```java
+TableTransactionActionType.CREATE          // Insert new entity
+TableTransactionActionType.UPDATE_MERGE    // Merge with existing entity
+TableTransactionActionType.UPDATE_REPLACE  // Replace entire entity
+TableTransactionActionType.UPSERT_MERGE    // Insert or merge
+TableTransactionActionType.UPSERT_REPLACE  // Insert or replace
+TableTransactionActionType.DELETE          // Delete entity
+```
+
+## Async Client Patterns
+
+### Create Async Clients
+
+```java
+import com.azure.data.tables.TableServiceAsyncClient;
+import com.azure.data.tables.TableAsyncClient;
+
+TableServiceAsyncClient asyncServiceClient = new TableServiceClientBuilder()
+    .connectionString("<connection-string>")
+    .buildAsyncClient();
+
+TableAsyncClient asyncTableClient = new TableClientBuilder()
+    .connectionString("<connection-string>")
+    .tableName("myTable")
+    .buildAsyncClient();
+```
+
+### Create Entity Async
+
+```java
+TableEntity entity = new TableEntity("partitionKey", "rowKey")
+    .addProperty("Name", "Async Entity");
+
+asyncTableClient.createEntity(entity)
+    .subscribe(
+        unused -> System.out.println("Entity created"),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Completed")
+    );
+```
+
+### Query Entities Async
+
+```java
+asyncTableClient.listEntities()
+    .subscribe(
+        entity -> System.out.printf("Entity: %s/%s%n", 
+            entity.getPartitionKey(), 
+            entity.getRowKey()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### Transaction Async
+
+```java
+asyncTableClient.submitTransaction(transactionActions)
+    .subscribe(
+        result -> {
+            System.out.println("Transaction completed");
+            result.getTransactionActionResponses().forEach(r ->
+                System.out.printf("Status: %d%n", r.getStatusCode()));
+        },
+        error -> System.err.println("Transaction failed: " + error.getMessage())
+    );
+```
+
+## Error Handling
+
+### Sync Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.data.tables.models.TableServiceException;
+
+try {
+    tableClient.createEntity(entity);
+} catch (TableServiceException e) {
+    System.err.println("Table service error: " + e.getMessage());
+    System.err.println("Status code: " + e.getResponse().getStatusCode());
+    System.err.println("Error code: " + e.getValue().getErrorCode());
+} catch (HttpResponseException e) {
+    System.err.println("HTTP error: " + e.getResponse().getStatusCode());
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+### Transaction Error Handling
+
+```java
+import com.azure.data.tables.models.TableTransactionFailedException;
+
+try {
+    tableClient.submitTransaction(transactionActions);
+} catch (TableTransactionFailedException e) {
+    System.err.println("Transaction failed");
+    System.err.println("Failed action index: " + e.getFailedTransactionActionIndex());
+    System.err.println("Status code: " + e.getResponse().getStatusCode());
+}
+```
+
+### Async Error Handling
+
+```java
+asyncTableClient.createEntity(entity)
+    .subscribe(
+        unused -> System.out.println("Success"),
+        error -> {
+            if (error instanceof TableServiceException) {
+                TableServiceException tse = (TableServiceException) error;
+                System.err.println("Error code: " + tse.getValue().getErrorCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        }
+    );
+```

--- a/skills/java/foundry/agents-persistent/SKILL.md
+++ b/skills/java/foundry/agents-persistent/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: azure-ai-agents-persistent-java
+description: |
+  Azure AI Agents Persistent SDK for Java. Low-level SDK for creating and managing AI agents with threads, messages, runs, and tools.
+  Triggers: "PersistentAgentsClient", "persistent agents java", "agent threads java", "agent runs java", "streaming agents java".
+---
+
+# Azure AI Agents Persistent SDK for Java
+
+Low-level SDK for creating and managing persistent AI agents with threads, messages, runs, and tools.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-agents-persistent</artifactId>
+    <version>1.0.0-beta.1</version>
+</dependency>
+```
+
+## Environment Variables
+
+```bash
+PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+MODEL_DEPLOYMENT_NAME=gpt-4o-mini
+```
+
+## Authentication
+
+```java
+import com.azure.ai.agents.persistent.PersistentAgentsClient;
+import com.azure.ai.agents.persistent.PersistentAgentsClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+String endpoint = System.getenv("PROJECT_ENDPOINT");
+PersistentAgentsClient client = new PersistentAgentsClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Key Concepts
+
+The Azure AI Agents Persistent SDK provides a low-level API for managing persistent agents that can be reused across sessions.
+
+### Client Hierarchy
+
+| Client | Purpose |
+|--------|---------|
+| `PersistentAgentsClient` | Sync client for agent operations |
+| `PersistentAgentsAsyncClient` | Async client for agent operations |
+
+## Core Workflow
+
+### 1. Create Agent
+
+```java
+// Create agent with tools
+PersistentAgent agent = client.createAgent(
+    modelDeploymentName,
+    "Math Tutor",
+    "You are a personal math tutor."
+);
+```
+
+### 2. Create Thread
+
+```java
+PersistentAgentThread thread = client.createThread();
+```
+
+### 3. Add Message
+
+```java
+client.createMessage(
+    thread.getId(),
+    MessageRole.USER,
+    "I need help with equations."
+);
+```
+
+### 4. Run Agent
+
+```java
+ThreadRun run = client.createRun(thread.getId(), agent.getId());
+
+// Poll for completion
+while (run.getStatus() == RunStatus.QUEUED || run.getStatus() == RunStatus.IN_PROGRESS) {
+    Thread.sleep(500);
+    run = client.getRun(thread.getId(), run.getId());
+}
+```
+
+### 5. Get Response
+
+```java
+PagedIterable<PersistentThreadMessage> messages = client.listMessages(thread.getId());
+for (PersistentThreadMessage message : messages) {
+    System.out.println(message.getRole() + ": " + message.getContent());
+}
+```
+
+### 6. Cleanup
+
+```java
+client.deleteThread(thread.getId());
+client.deleteAgent(agent.getId());
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** for production authentication
+2. **Poll with appropriate delays** — 500ms recommended between status checks
+3. **Clean up resources** — Delete threads and agents when done
+4. **Handle all run statuses** — Check for RequiresAction, Failed, Cancelled
+5. **Use async client** for better throughput in high-concurrency scenarios
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    PersistentAgent agent = client.createAgent(modelName, name, instructions);
+} catch (HttpResponseException e) {
+    System.err.println("Error: " + e.getResponse().getStatusCode() + " - " + e.getMessage());
+}
+```
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Maven Package | https://central.sonatype.com/artifact/com.azure/azure-ai-agents-persistent |
+| GitHub Source | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-agents-persistent |

--- a/skills/java/foundry/agents-persistent/references/examples.md
+++ b/skills/java/foundry/agents-persistent/references/examples.md
@@ -1,0 +1,778 @@
+# Azure AI Agents Persistent Java SDK - Examples
+
+Comprehensive code examples for the Azure AI Agents Persistent SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Agent Operations](#agent-operations)
+- [Thread Operations](#thread-operations)
+- [Message Operations](#message-operations)
+- [Run Operations](#run-operations)
+- [Streaming Responses](#streaming-responses)
+- [Tools Integration](#tools-integration)
+- [File Operations](#file-operations)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-agents-persistent</artifactId>
+    <version>1.0.0-beta.1</version>
+</dependency>
+
+<!-- For DefaultAzureCredential -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### With DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.ai.agents.persistent.PersistentAgentsClient;
+import com.azure.ai.agents.persistent.PersistentAgentsClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+String endpoint = System.getenv("PROJECT_ENDPOINT");
+
+PersistentAgentsClient client = new PersistentAgentsClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.ai.agents.persistent.PersistentAgentsAsyncClient;
+
+PersistentAgentsAsyncClient asyncClient = new PersistentAgentsClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+## Agent Operations
+
+### Create Agent
+
+```java
+import com.azure.ai.agents.persistent.models.*;
+
+String modelDeploymentName = System.getenv("MODEL_DEPLOYMENT_NAME");
+
+PersistentAgent agent = client.createAgent(
+    modelDeploymentName,
+    "Math Tutor",                                    // Name
+    "You are a personal math tutor. Help students understand mathematical concepts." // Instructions
+);
+
+System.out.println("Agent created:");
+System.out.println("  ID: " + agent.getId());
+System.out.println("  Name: " + agent.getName());
+System.out.println("  Model: " + agent.getModel());
+```
+
+### Create Agent with Configuration
+
+```java
+CreateAgentOptions options = new CreateAgentOptions(modelDeploymentName)
+    .setName("Customer Support Agent")
+    .setInstructions("You are a customer support agent. Help users with their questions politely.")
+    .setDescription("Handles customer inquiries")
+    .setTemperature(0.7)
+    .setTopP(0.9);
+
+PersistentAgent agent = client.createAgent(options);
+```
+
+### Create Agent with Tools
+
+```java
+import java.util.Arrays;
+import java.util.Map;
+
+// Code Interpreter tool
+ToolDefinition codeInterpreter = new CodeInterpreterToolDefinition();
+
+// Function tool
+FunctionDefinition functionDef = new FunctionDefinition("get_weather")
+    .setDescription("Get current weather for a location")
+    .setParameters(BinaryData.fromObject(Map.of(
+        "type", "object",
+        "properties", Map.of(
+            "location", Map.of(
+                "type", "string",
+                "description", "City name"
+            )
+        ),
+        "required", new String[]{"location"}
+    )));
+
+ToolDefinition functionTool = new FunctionToolDefinition(functionDef);
+
+CreateAgentOptions options = new CreateAgentOptions(modelDeploymentName)
+    .setName("Assistant with Tools")
+    .setInstructions("You can run code and check weather.")
+    .setTools(Arrays.asList(codeInterpreter, functionTool));
+
+PersistentAgent agent = client.createAgent(options);
+```
+
+### Get Agent
+
+```java
+PersistentAgent agent = client.getAgent(agentId);
+
+System.out.println("Agent: " + agent.getName());
+System.out.println("Instructions: " + agent.getInstructions());
+System.out.println("Tools: " + agent.getTools().size());
+```
+
+### List Agents
+
+```java
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<PersistentAgent> agents = client.listAgents();
+
+System.out.println("=== Available Agents ===");
+for (PersistentAgent a : agents) {
+    System.out.printf("%s: %s%n", a.getId(), a.getName());
+}
+```
+
+### Update Agent
+
+```java
+UpdateAgentOptions updateOptions = new UpdateAgentOptions()
+    .setName("Updated Agent Name")
+    .setInstructions("Updated instructions for the agent.");
+
+PersistentAgent updated = client.updateAgent(agentId, updateOptions);
+System.out.println("Agent updated: " + updated.getName());
+```
+
+### Delete Agent
+
+```java
+client.deleteAgent(agentId);
+System.out.println("Agent deleted: " + agentId);
+```
+
+## Thread Operations
+
+### Create Thread
+
+```java
+PersistentAgentThread thread = client.createThread();
+
+System.out.println("Thread created: " + thread.getId());
+```
+
+### Create Thread with Initial Messages
+
+```java
+import java.util.Arrays;
+
+ThreadMessageOptions initialMessage = new ThreadMessageOptions(
+    MessageRole.USER,
+    "Hello, I need help with calculus."
+);
+
+CreateThreadOptions threadOptions = new CreateThreadOptions()
+    .setMessages(Arrays.asList(initialMessage));
+
+PersistentAgentThread thread = client.createThread(threadOptions);
+```
+
+### Create Thread with Metadata
+
+```java
+import java.util.Map;
+
+CreateThreadOptions options = new CreateThreadOptions()
+    .setMetadata(Map.of(
+        "user_id", "user123",
+        "session_type", "support"
+    ));
+
+PersistentAgentThread thread = client.createThread(options);
+```
+
+### Get Thread
+
+```java
+PersistentAgentThread thread = client.getThread(threadId);
+
+System.out.println("Thread: " + thread.getId());
+System.out.println("Created: " + thread.getCreatedAt());
+System.out.println("Metadata: " + thread.getMetadata());
+```
+
+### Update Thread
+
+```java
+UpdateThreadOptions updateOptions = new UpdateThreadOptions()
+    .setMetadata(Map.of("status", "resolved"));
+
+PersistentAgentThread updated = client.updateThread(threadId, updateOptions);
+```
+
+### Delete Thread
+
+```java
+client.deleteThread(threadId);
+System.out.println("Thread deleted: " + threadId);
+```
+
+## Message Operations
+
+### Create Message
+
+```java
+PersistentThreadMessage message = client.createMessage(
+    threadId,
+    MessageRole.USER,
+    "What is the derivative of x squared?"
+);
+
+System.out.println("Message created: " + message.getId());
+```
+
+### Create Message with Attachments
+
+```java
+// First upload a file
+AgentFile file = client.uploadFile(
+    BinaryData.fromFile(new File("data.csv").toPath()),
+    AgentFilePurpose.AGENTS
+);
+
+MessageAttachment attachment = new MessageAttachment(file.getId())
+    .setTools(Arrays.asList(new CodeInterpreterToolDefinition()));
+
+CreateMessageOptions options = new CreateMessageOptions(MessageRole.USER, "Analyze this data")
+    .setAttachments(Arrays.asList(attachment));
+
+PersistentThreadMessage message = client.createMessage(threadId, options);
+```
+
+### List Messages
+
+```java
+PagedIterable<PersistentThreadMessage> messages = client.listMessages(threadId);
+
+System.out.println("=== Conversation ===");
+for (PersistentThreadMessage msg : messages) {
+    String role = msg.getRole().toString();
+    String content = extractTextContent(msg);
+    System.out.printf("[%s]: %s%n", role, content);
+}
+
+private String extractTextContent(PersistentThreadMessage message) {
+    StringBuilder text = new StringBuilder();
+    for (MessageContent content : message.getContent()) {
+        if (content instanceof MessageTextContent) {
+            text.append(((MessageTextContent) content).getText().getValue());
+        }
+    }
+    return text.toString();
+}
+```
+
+### Get Message
+
+```java
+PersistentThreadMessage message = client.getMessage(threadId, messageId);
+
+System.out.println("Message role: " + message.getRole());
+System.out.println("Created: " + message.getCreatedAt());
+```
+
+## Run Operations
+
+### Create Run
+
+```java
+ThreadRun run = client.createRun(threadId, agentId);
+
+System.out.println("Run created: " + run.getId());
+System.out.println("Status: " + run.getStatus());
+```
+
+### Create Run with Additional Instructions
+
+```java
+CreateRunOptions options = new CreateRunOptions(agentId)
+    .setAdditionalInstructions("Please be very detailed in your response.")
+    .setTemperature(0.5);
+
+ThreadRun run = client.createRun(threadId, options);
+```
+
+### Poll for Run Completion
+
+```java
+ThreadRun run = client.createRun(threadId, agentId);
+
+// Poll until completion
+while (run.getStatus() == RunStatus.QUEUED || run.getStatus() == RunStatus.IN_PROGRESS) {
+    Thread.sleep(500);  // Wait 500ms between polls
+    run = client.getRun(threadId, run.getId());
+    System.out.println("Status: " + run.getStatus());
+}
+
+// Check final status
+switch (run.getStatus()) {
+    case COMPLETED:
+        System.out.println("Run completed successfully!");
+        break;
+    case FAILED:
+        System.err.println("Run failed: " + run.getLastError().getMessage());
+        break;
+    case CANCELLED:
+        System.out.println("Run was cancelled");
+        break;
+    case EXPIRED:
+        System.out.println("Run expired");
+        break;
+    case REQUIRES_ACTION:
+        System.out.println("Run requires action (tool calls)");
+        handleRequiredActions(run);
+        break;
+}
+```
+
+### Handle Tool Calls
+
+```java
+private void handleRequiredActions(ThreadRun run) {
+    RequiredAction requiredAction = run.getRequiredAction();
+    
+    if (requiredAction instanceof SubmitToolOutputsAction) {
+        SubmitToolOutputsAction submitAction = (SubmitToolOutputsAction) requiredAction;
+        List<RequiredToolCall> toolCalls = submitAction.getSubmitToolOutputs().getToolCalls();
+        
+        List<ToolOutput> outputs = new ArrayList<>();
+        
+        for (RequiredToolCall toolCall : toolCalls) {
+            if (toolCall instanceof RequiredFunctionToolCall) {
+                RequiredFunctionToolCall funcCall = (RequiredFunctionToolCall) toolCall;
+                
+                String functionName = funcCall.getFunction().getName();
+                String arguments = funcCall.getFunction().getArguments();
+                
+                // Execute function
+                String result = executeFunction(functionName, arguments);
+                
+                outputs.add(new ToolOutput(toolCall.getId(), result));
+            }
+        }
+        
+        // Submit tool outputs
+        run = client.submitToolOutputsToRun(threadId, run.getId(), outputs);
+    }
+}
+
+private String executeFunction(String name, String arguments) {
+    if ("get_weather".equals(name)) {
+        // Parse arguments and call weather API
+        return "{\"temperature\": 72, \"condition\": \"sunny\"}";
+    }
+    return "{\"error\": \"Unknown function\"}";
+}
+```
+
+### Cancel Run
+
+```java
+ThreadRun cancelled = client.cancelRun(threadId, runId);
+System.out.println("Run cancelled: " + cancelled.getStatus());
+```
+
+### List Runs
+
+```java
+PagedIterable<ThreadRun> runs = client.listRuns(threadId);
+
+for (ThreadRun r : runs) {
+    System.out.printf("Run %s: %s%n", r.getId(), r.getStatus());
+}
+```
+
+### List Run Steps
+
+```java
+PagedIterable<RunStep> steps = client.listRunSteps(threadId, runId);
+
+System.out.println("=== Run Steps ===");
+for (RunStep step : steps) {
+    System.out.printf("Step %s: %s - %s%n",
+        step.getId(),
+        step.getType(),
+        step.getStatus());
+}
+```
+
+## Streaming Responses
+
+### Stream Run with Event Handler
+
+```java
+import com.azure.ai.agents.persistent.models.streaming.*;
+
+client.createRunStream(threadId, agentId)
+    .forEach(event -> {
+        if (event instanceof ThreadRunCreatedEvent) {
+            System.out.println("Run started");
+        } else if (event instanceof ThreadMessageDeltaEvent) {
+            ThreadMessageDeltaEvent delta = (ThreadMessageDeltaEvent) event;
+            for (MessageDeltaContent content : delta.getDelta().getContent()) {
+                if (content instanceof MessageDeltaTextContent) {
+                    String text = ((MessageDeltaTextContent) content).getText().getValue();
+                    System.out.print(text);
+                }
+            }
+        } else if (event instanceof ThreadRunCompletedEvent) {
+            System.out.println("\nRun completed");
+        }
+    });
+```
+
+### Stream with Async Client
+
+```java
+asyncClient.createRunStream(threadId, agentId)
+    .subscribe(
+        event -> handleStreamEvent(event),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Stream completed")
+    );
+```
+
+## Tools Integration
+
+### Code Interpreter
+
+```java
+// Create agent with code interpreter
+CreateAgentOptions options = new CreateAgentOptions(modelDeploymentName)
+    .setName("Code Assistant")
+    .setInstructions("You can write and run Python code to help users.")
+    .setTools(Arrays.asList(new CodeInterpreterToolDefinition()));
+
+PersistentAgent agent = client.createAgent(options);
+
+// Create thread and message
+PersistentAgentThread thread = client.createThread();
+client.createMessage(thread.getId(), MessageRole.USER, 
+    "Calculate the first 10 Fibonacci numbers");
+
+// Run and wait
+ThreadRun run = client.createRun(thread.getId(), agent.getId());
+while (run.getStatus() == RunStatus.QUEUED || run.getStatus() == RunStatus.IN_PROGRESS) {
+    Thread.sleep(500);
+    run = client.getRun(thread.getId(), run.getId());
+}
+
+// Get response with code output
+PagedIterable<PersistentThreadMessage> messages = client.listMessages(thread.getId());
+for (PersistentThreadMessage msg : messages) {
+    if (msg.getRole() == MessageRole.ASSISTANT) {
+        for (MessageContent content : msg.getContent()) {
+            if (content instanceof MessageTextContent) {
+                System.out.println(((MessageTextContent) content).getText().getValue());
+            }
+        }
+    }
+}
+```
+
+### File Search
+
+```java
+// Create vector store
+VectorStore vectorStore = client.createVectorStore(
+    new CreateVectorStoreOptions().setName("Knowledge Base")
+);
+
+// Upload files to vector store
+client.uploadFileToVectorStore(vectorStore.getId(), 
+    BinaryData.fromFile(new File("document.pdf").toPath()));
+
+// Create agent with file search
+CreateAgentOptions options = new CreateAgentOptions(modelDeploymentName)
+    .setName("Research Assistant")
+    .setInstructions("Search the uploaded documents to answer questions.")
+    .setTools(Arrays.asList(new FileSearchToolDefinition()))
+    .setToolResources(new ToolResources()
+        .setFileSearch(new FileSearchToolResource()
+            .setVectorStoreIds(Arrays.asList(vectorStore.getId()))));
+
+PersistentAgent agent = client.createAgent(options);
+```
+
+## File Operations
+
+### Upload File
+
+```java
+import java.io.File;
+
+File file = new File("data.csv");
+AgentFile uploadedFile = client.uploadFile(
+    BinaryData.fromFile(file.toPath()),
+    AgentFilePurpose.AGENTS
+);
+
+System.out.println("File uploaded: " + uploadedFile.getId());
+System.out.println("Filename: " + uploadedFile.getFilename());
+System.out.println("Size: " + uploadedFile.getBytes() + " bytes");
+```
+
+### List Files
+
+```java
+PagedIterable<AgentFile> files = client.listFiles();
+
+for (AgentFile file : files) {
+    System.out.printf("%s: %s (%d bytes)%n",
+        file.getId(),
+        file.getFilename(),
+        file.getBytes());
+}
+```
+
+### Delete File
+
+```java
+client.deleteFile(fileId);
+System.out.println("File deleted: " + fileId);
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    PersistentAgent agent = client.createAgent(
+        modelDeploymentName,
+        "Test Agent",
+        "Test instructions"
+    );
+} catch (HttpResponseException e) {
+    int statusCode = e.getResponse().getStatusCode();
+    
+    System.err.println("HTTP Status: " + statusCode);
+    System.err.println("Error: " + e.getMessage());
+    
+    switch (statusCode) {
+        case 400:
+            System.err.println("Bad request - check parameters");
+            break;
+        case 401:
+            System.err.println("Unauthorized - check credentials");
+            break;
+        case 404:
+            System.err.println("Resource not found");
+            break;
+        case 429:
+            System.err.println("Rate limited - retry with backoff");
+            break;
+        default:
+            System.err.println("Unexpected error");
+    }
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+## Complete Application Example
+
+```java
+import com.azure.ai.agents.persistent.PersistentAgentsClient;
+import com.azure.ai.agents.persistent.PersistentAgentsClientBuilder;
+import com.azure.ai.agents.persistent.models.*;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.util.*;
+
+public class MathTutorBot {
+    
+    private final PersistentAgentsClient client;
+    private final String modelDeploymentName;
+    private PersistentAgent agent;
+    
+    public MathTutorBot() {
+        this.client = new PersistentAgentsClientBuilder()
+            .endpoint(System.getenv("PROJECT_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+        this.modelDeploymentName = System.getenv("MODEL_DEPLOYMENT_NAME");
+    }
+    
+    public void initialize() {
+        // Create agent with code interpreter for math calculations
+        CreateAgentOptions options = new CreateAgentOptions(modelDeploymentName)
+            .setName("Math Tutor")
+            .setInstructions("""
+                You are a friendly math tutor. Help students understand mathematical concepts.
+                - Explain concepts clearly step by step
+                - Use Python code to demonstrate calculations
+                - Encourage students and be patient
+                - Ask clarifying questions if needed
+                """)
+            .setTools(Arrays.asList(new CodeInterpreterToolDefinition()))
+            .setTemperature(0.7);
+        
+        this.agent = client.createAgent(options);
+        System.out.println("Math Tutor initialized: " + agent.getId());
+    }
+    
+    public String chat(String threadId, String userMessage) {
+        // Create message
+        client.createMessage(threadId, MessageRole.USER, userMessage);
+        
+        // Create and wait for run
+        ThreadRun run = client.createRun(threadId, agent.getId());
+        run = waitForCompletion(threadId, run.getId());
+        
+        if (run.getStatus() != RunStatus.COMPLETED) {
+            return "I encountered an error. Please try again.";
+        }
+        
+        // Get assistant response
+        return getLatestAssistantMessage(threadId);
+    }
+    
+    private ThreadRun waitForCompletion(String threadId, String runId) {
+        ThreadRun run;
+        do {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            run = client.getRun(threadId, runId);
+        } while (run.getStatus() == RunStatus.QUEUED || run.getStatus() == RunStatus.IN_PROGRESS);
+        
+        return run;
+    }
+    
+    private String getLatestAssistantMessage(String threadId) {
+        PagedIterable<PersistentThreadMessage> messages = client.listMessages(threadId);
+        
+        for (PersistentThreadMessage msg : messages) {
+            if (msg.getRole() == MessageRole.ASSISTANT) {
+                StringBuilder response = new StringBuilder();
+                for (MessageContent content : msg.getContent()) {
+                    if (content instanceof MessageTextContent) {
+                        response.append(((MessageTextContent) content).getText().getValue());
+                    }
+                }
+                return response.toString();
+            }
+        }
+        
+        return "No response available.";
+    }
+    
+    public String createConversation() {
+        PersistentAgentThread thread = client.createThread();
+        return thread.getId();
+    }
+    
+    public void cleanup(String threadId) {
+        try {
+            client.deleteThread(threadId);
+        } catch (Exception e) {
+            System.err.println("Failed to delete thread: " + e.getMessage());
+        }
+    }
+    
+    public void shutdown() {
+        if (agent != null) {
+            try {
+                client.deleteAgent(agent.getId());
+                System.out.println("Agent cleaned up");
+            } catch (Exception e) {
+                System.err.println("Failed to delete agent: " + e.getMessage());
+            }
+        }
+    }
+    
+    public static void main(String[] args) {
+        MathTutorBot bot = new MathTutorBot();
+        
+        try {
+            // Initialize
+            bot.initialize();
+            
+            // Create conversation
+            String threadId = bot.createConversation();
+            System.out.println("Conversation started: " + threadId);
+            
+            // Chat
+            Scanner scanner = new Scanner(System.in);
+            System.out.println("\nMath Tutor ready! Type 'quit' to exit.\n");
+            
+            while (true) {
+                System.out.print("You: ");
+                String input = scanner.nextLine().trim();
+                
+                if ("quit".equalsIgnoreCase(input)) {
+                    break;
+                }
+                
+                if (input.isEmpty()) {
+                    continue;
+                }
+                
+                String response = bot.chat(threadId, input);
+                System.out.println("\nTutor: " + response + "\n");
+            }
+            
+            // Cleanup
+            bot.cleanup(threadId);
+            
+        } finally {
+            bot.shutdown();
+        }
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+MODEL_DEPLOYMENT_NAME=gpt-4o-mini
+
+# For DefaultAzureCredential
+AZURE_CLIENT_ID=<service-principal-client-id>
+AZURE_CLIENT_SECRET=<service-principal-secret>
+AZURE_TENANT_ID=<tenant-id>
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** — Prefer managed identity over API keys in production
+2. **Poll with appropriate delays** — 500ms between status checks is recommended
+3. **Clean up resources** — Delete threads and agents when no longer needed
+4. **Handle all run statuses** — Check for `REQUIRES_ACTION`, `FAILED`, `CANCELLED`, `EXPIRED`
+5. **Use async client** — For better throughput in high-concurrency scenarios
+6. **Implement retry logic** — Handle transient errors with exponential backoff
+7. **Stream for long responses** — Use streaming for better user experience
+8. **Store agent IDs** — Reuse agents across sessions instead of recreating

--- a/skills/java/foundry/agents/SKILL.md
+++ b/skills/java/foundry/agents/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: azure-ai-agents-java
+description: |
+  Azure AI Agents SDK for Java. Develop agents using Azure AI Foundry with models, tools, and capabilities from OpenAI and other providers.
+  Triggers: "AgentsClient", "azure agents java", "PromptAgent", "ConversationsClient", "ResponsesClient", "agent conversations java".
+---
+
+# Azure AI Agents SDK for Java
+
+Develop agents using Azure AI Foundry with an extensive ecosystem of models, tools, and capabilities.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-agents</artifactId>
+    <version>1.0.0-beta.1</version>
+</dependency>
+```
+
+## Environment Variables
+
+```bash
+PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+MODEL_DEPLOYMENT_NAME=gpt-4o-mini
+```
+
+## Authentication
+
+```java
+import com.azure.ai.agents.AgentsClient;
+import com.azure.ai.agents.AgentsClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+String endpoint = System.getenv("PROJECT_ENDPOINT");
+AgentsClient agentsClient = new AgentsClientBuilder()
+    .endpoint(endpoint)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Client Hierarchy
+
+The SDK provides three main sub-clients:
+
+| Client | Purpose |
+|--------|---------|
+| `AgentsClient` / `AgentsAsyncClient` | Agent CRUD operations |
+| `ConversationsClient` / `ConversationsAsyncClient` | Conversation management |
+| `ResponsesClient` / `ResponsesAsyncClient` | Response generation |
+
+```java
+AgentsClientBuilder builder = new AgentsClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint);
+
+// Build sub-clients
+AgentsClient agentsClient = builder.buildClient();
+ConversationsClient conversationsClient = builder.buildConversationsClient();
+ResponsesClient responsesClient = builder.buildResponsesClient();
+```
+
+## Core Workflow
+
+### 1. Create a Prompt Agent
+
+```java
+import com.azure.ai.agents.models.PromptAgentDefinition;
+import com.azure.ai.agents.models.AgentVersionDetails;
+
+PromptAgentDefinition definition = new PromptAgentDefinition("gpt-4o");
+AgentVersionDetails agent = agentsClient.createAgentVersion("my-agent", definition);
+```
+
+### 2. Create Conversation
+
+```java
+Conversation conversation = conversationsClient.getConversationService().create();
+```
+
+### 3. Add Messages to Conversation
+
+```java
+import com.openai.models.EasyInputMessage;
+import com.openai.models.ItemCreateParams;
+
+conversationsClient.getConversationService().items().create(
+    ItemCreateParams.builder()
+        .conversationId(conversation.id())
+        .addItem(EasyInputMessage.builder()
+            .role(EasyInputMessage.Role.SYSTEM)
+            .content("You are a helpful assistant.")
+            .build())
+        .addItem(EasyInputMessage.builder()
+            .role(EasyInputMessage.Role.USER)
+            .content("Hello, agent!")
+            .build())
+        .build()
+);
+```
+
+### 4. Generate Response
+
+```java
+import com.azure.ai.agents.models.AgentReference;
+
+AgentReference agentRef = new AgentReference(agent.getName())
+    .setVersion(agent.getVersion());
+
+Response response = responsesClient.createWithAgentConversation(
+    agentRef,
+    conversation.id()
+);
+```
+
+## Using OpenAI's Official Library
+
+The SDK transitively imports the OpenAI Java SDK:
+
+```java
+// Access OpenAI services directly
+ResponsesService responsesService = responsesClient.getOpenAIClient();
+ConversationService conversationService = conversationsClient.getOpenAIClient();
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** for production authentication
+2. **Share conversations** across multiple agents for centralized context
+3. **Use async clients** for better throughput
+4. **Clean up conversations** when no longer needed
+5. **Handle errors** with appropriate exception handling
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    AgentVersionDetails agent = agentsClient.createAgentVersion(name, definition);
+} catch (HttpResponseException e) {
+    System.err.println("Error: " + e.getResponse().getStatusCode());
+}
+```
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Product Docs | https://aka.ms/azsdk/azure-ai-agents/product-doc |
+| GitHub Source | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-agents |
+| OpenAI Java SDK | https://github.com/openai/openai-java |

--- a/skills/java/foundry/agents/references/examples.md
+++ b/skills/java/foundry/agents/references/examples.md
@@ -1,0 +1,297 @@
+# Azure AI Agents Java SDK - Examples
+
+Comprehensive code examples for the Azure AI Agents SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Setup](#client-setup)
+- [Agent CRUD Operations](#agent-crud-operations)
+- [Conversation Management](#conversation-management)
+- [Creating Responses](#creating-responses)
+- [Complete Workflow](#complete-workflow)
+
+---
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-agents</artifactId>
+    <version>1.0.0-beta.1</version>
+</dependency>
+
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.15.3</version>
+</dependency>
+```
+
+---
+
+## Client Setup
+
+### Creating Clients with DefaultAzureCredential
+
+```java
+import com.azure.ai.agents.*;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+public class ClientSetup {
+    public static void main(String[] args) {
+        String endpoint = System.getenv("AZURE_AGENTS_ENDPOINT");
+        
+        // Create the builder (reusable for all sub-clients)
+        AgentsClientBuilder builder = new AgentsClientBuilder()
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .endpoint(endpoint)
+            .serviceVersion(AgentsServiceVersion.V2025_05_15_PREVIEW);
+        
+        // Build different sub-clients from the same builder
+        AgentsClient agentsClient = builder.buildAgentsClient();
+        AgentsAsyncClient agentsAsyncClient = builder.buildAsyncClient();
+        
+        ConversationsClient conversationsClient = builder.buildConversationsClient();
+        ConversationsAsyncClient conversationsAsyncClient = builder.buildConversationsAsyncClient();
+        
+        ResponsesClient responsesClient = builder.buildResponsesClient();
+        ResponsesAsyncClient responsesAsyncClient = builder.buildResponsesAsyncClient();
+        
+        MemoryStoresClient memoryStoresClient = builder.buildMemoryStoresClient();
+    }
+}
+```
+
+---
+
+## Agent CRUD Operations
+
+### Create an Agent
+
+```java
+import com.azure.ai.agents.models.AgentVersionDetails;
+import com.azure.ai.agents.models.PromptAgentDefinition;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+public class CreateAgent {
+    public static void main(String[] args) {
+        String endpoint = System.getenv("AZURE_AGENTS_ENDPOINT");
+        String model = System.getenv("AZURE_AGENT_MODEL"); // e.g., "gpt-4o"
+        
+        AgentsClient agentsClient = new AgentsClientBuilder()
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .endpoint(endpoint)
+            .buildAgentsClient();
+
+        // Create a PromptAgentDefinition with the model
+        PromptAgentDefinition request = new PromptAgentDefinition(model);
+        
+        // Create a versioned agent
+        AgentVersionDetails agent = agentsClient.createAgentVersion("my-agent-name", request);
+
+        System.out.println("Agent ID: " + agent.getId());
+        System.out.println("Agent Name: " + agent.getName());
+        System.out.println("Agent Version: " + agent.getVersion());
+    }
+}
+```
+
+### Get an Agent
+
+```java
+import com.azure.ai.agents.models.AgentDetails;
+
+AgentDetails agent = agentsClient.getAgent("my-agent-name");
+
+System.out.println("Agent ID: " + agent.getId());
+System.out.println("Agent Name: " + agent.getName());
+System.out.println("Agent Version: " + agent.getVersions().getLatest());
+```
+
+### List All Agents
+
+```java
+System.out.println("Listing all agents:");
+for (AgentDetails agent : agentsClient.listAgents()) {
+    System.out.println("Agent ID: " + agent.getId());
+    System.out.println("Agent Name: " + agent.getName());
+    if (agent.getVersions() != null && agent.getVersions().getLatest() != null) {
+        System.out.println("Latest Version ID: " + agent.getVersions().getLatest().getId());
+    }
+    System.out.println("---");
+}
+```
+
+### Delete an Agent
+
+```java
+import com.azure.ai.agents.models.DeleteAgentResponse;
+import com.azure.ai.agents.models.DeleteAgentVersionResponse;
+
+// Delete a specific version
+DeleteAgentVersionResponse deletedVersion = agentsClient.deleteAgentVersion("my-agent-name", "1");
+System.out.println("Deleted version: " + deletedVersion.getVersion());
+System.out.println("Is deleted: " + deletedVersion.isDeleted());
+
+// Delete the entire agent (all versions)
+DeleteAgentResponse deletedAgent = agentsClient.deleteAgent("my-agent-name");
+System.out.println("Deleted agent: " + deletedAgent.getName());
+System.out.println("Is deleted: " + deletedAgent.isDeleted());
+```
+
+---
+
+## Conversation Management
+
+### Create a Conversation
+
+```java
+import com.openai.models.conversations.Conversation;
+
+Conversation conversation = conversationsClient.getConversationService().create();
+
+System.out.println("Conversation ID: " + conversation.id());
+System.out.println("Conversation Created At: " + conversation.createdAt());
+```
+
+### Add Messages to a Conversation
+
+```java
+import com.openai.models.conversations.items.ConversationItemList;
+import com.openai.models.conversations.items.ItemCreateParams;
+import com.openai.models.responses.EasyInputMessage;
+
+// Create a conversation first
+Conversation conversation = conversationsClient.getConversationService().create();
+String conversationId = conversation.id();
+
+// Add multiple messages at once
+ConversationItemList items = conversationsClient.getConversationService().items().create(
+    ItemCreateParams.builder()
+        .conversationId(conversationId)
+        .addItem(EasyInputMessage.builder()
+            .role(EasyInputMessage.Role.SYSTEM)
+            .content("You are a helpful assistant that speaks like a pirate.")
+            .build()
+        )
+        .addItem(EasyInputMessage.builder()
+            .role(EasyInputMessage.Role.USER)
+            .content("Hello, agent!")
+            .build()
+        )
+        .build()
+);
+
+System.out.println("Added " + items.data().size() + " messages to conversation");
+```
+
+### Update Conversation Metadata
+
+```java
+import com.openai.core.JsonValue;
+import com.openai.models.conversations.ConversationUpdateParams;
+
+ConversationUpdateParams.Metadata metadata = ConversationUpdateParams.Metadata.builder()
+    .putAdditionalProperty("updated_by", JsonValue.from("java_sample"))
+    .putAdditionalProperty("update_timestamp", JsonValue.from(System.currentTimeMillis()))
+    .build();
+
+ConversationUpdateParams updateParams = ConversationUpdateParams.builder()
+    .metadata(metadata)
+    .build();
+
+Conversation updatedConversation = conversationsClient.getConversationService()
+    .update(conversationId, updateParams);
+
+System.out.println("Updated Conversation ID: " + updatedConversation.id());
+```
+
+---
+
+## Creating Responses
+
+### Basic Response Creation
+
+```java
+import com.openai.models.responses.Response;
+import com.openai.models.responses.ResponseCreateParams;
+
+ResponseCreateParams responseRequest = new ResponseCreateParams.Builder()
+    .input("Hello, how can you help me?")
+    .model(model)
+    .build();
+
+Response response = responsesClient.getResponseService().create(responseRequest);
+
+System.out.println("Response ID: " + response.id());
+System.out.println("Response Model: " + response.model());
+System.out.println("Response Created At: " + response.createdAt());
+System.out.println("Response Output: " + response.output());
+```
+
+---
+
+## Complete Workflow
+
+### Agent with Conversation and Response
+
+```java
+import com.azure.ai.agents.*;
+import com.azure.ai.agents.models.*;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.openai.models.conversations.Conversation;
+import com.openai.models.conversations.items.ItemCreateParams;
+import com.openai.models.responses.EasyInputMessage;
+import com.openai.models.responses.Response;
+import com.openai.models.responses.ResponseCreateParams;
+
+public class CompleteWorkflow {
+    public static void main(String[] args) {
+        String endpoint = System.getenv("AZURE_AGENTS_ENDPOINT");
+        String model = System.getenv("AZURE_AGENT_MODEL");
+        
+        AgentsClientBuilder builder = new AgentsClientBuilder()
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .endpoint(endpoint);
+        
+        AgentsClient agentsClient = builder.buildAgentsClient();
+        ConversationsClient conversationsClient = builder.buildConversationsClient();
+        ResponsesClient responsesClient = builder.buildResponsesClient();
+
+        // 1. Create an agent
+        PromptAgentDefinition promptAgentDefinition = new PromptAgentDefinition(model);
+        AgentVersionDetails agent = agentsClient.createAgentVersion("workflow-agent", promptAgentDefinition);
+        System.out.println("Created agent: " + agent.getName());
+
+        // 2. Create a conversation
+        Conversation conversation = conversationsClient.getConversationService().create();
+        System.out.println("Created conversation: " + conversation.id());
+
+        // 3. Add messages
+        conversationsClient.getConversationService().items().create(
+            ItemCreateParams.builder()
+                .conversationId(conversation.id())
+                .addItem(EasyInputMessage.builder()
+                    .role(EasyInputMessage.Role.USER)
+                    .content("What is the capital of France?")
+                    .build())
+                .build()
+        );
+
+        // 4. Get response
+        ResponseCreateParams responseRequest = new ResponseCreateParams.Builder()
+            .input("What is the capital of France?")
+            .model(model)
+            .build();
+        
+        Response response = responsesClient.getResponseService().create(responseRequest);
+        System.out.println("Response: " + response.output());
+
+        // 5. Cleanup
+        agentsClient.deleteAgent("workflow-agent");
+        System.out.println("Deleted agent");
+    }
+}
+```

--- a/skills/java/foundry/inference/SKILL.md
+++ b/skills/java/foundry/inference/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: azure-ai-inference-java
+description: |
+  Azure AI Inference SDK for Java. Use for chat completions, embeddings, and model inference with Azure AI Foundry endpoints.
+  Triggers: "ChatCompletionsClient java", "EmbeddingsClient java", "azure inference java", "model inference java", "Foundry models java".
+---
+
+# Azure AI Inference SDK for Java
+
+Client library for Azure AI model inference with chat completions and embeddings.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-inference</artifactId>
+    <version>1.0.0-beta.5</version>
+</dependency>
+```
+
+## Environment Variables
+
+```bash
+AZURE_INFERENCE_ENDPOINT=https://<resource>.services.ai.azure.com/models
+AZURE_INFERENCE_CREDENTIAL=<your-api-key>
+AZURE_INFERENCE_MODEL=gpt-4o-mini
+```
+
+## Authentication
+
+### API Key
+
+```java
+import com.azure.ai.inference.ChatCompletionsClient;
+import com.azure.ai.inference.ChatCompletionsClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+    .endpoint(System.getenv("AZURE_INFERENCE_ENDPOINT"))
+    .credential(new AzureKeyCredential(System.getenv("AZURE_INFERENCE_CREDENTIAL")))
+    .buildClient();
+```
+
+### DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+    .endpoint(System.getenv("AZURE_INFERENCE_ENDPOINT"))
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Client Types
+
+| Client | Purpose |
+|--------|---------|
+| `ChatCompletionsClient` | Chat and text completions (sync) |
+| `ChatCompletionsAsyncClient` | Chat completions (async) |
+| `EmbeddingsClient` | Text embeddings (sync) |
+| `EmbeddingsAsyncClient` | Text embeddings (async) |
+
+## Chat Completions
+
+### Basic Completion
+
+```java
+import com.azure.ai.inference.models.*;
+import java.util.ArrayList;
+import java.util.List;
+
+List<ChatRequestMessage> messages = new ArrayList<>();
+messages.add(new ChatRequestSystemMessage("You are a helpful assistant."));
+messages.add(new ChatRequestUserMessage("What is Azure AI?"));
+
+ChatCompletions response = client.complete(new ChatCompletionsOptions(messages));
+
+for (ChatChoice choice : response.getChoices()) {
+    System.out.println(choice.getMessage().getContent());
+}
+```
+
+### Streaming Completions
+
+```java
+List<ChatRequestMessage> messages = new ArrayList<>();
+messages.add(new ChatRequestSystemMessage("You are a helpful assistant."));
+messages.add(new ChatRequestUserMessage("Write a poem about Azure."));
+
+client.completeStream(new ChatCompletionsOptions(messages))
+    .forEach(chatCompletions -> {
+        if (!CoreUtils.isNullOrEmpty(chatCompletions.getChoices())) {
+            StreamingChatResponseMessageUpdate delta = chatCompletions.getChoice().getDelta();
+            if (delta.getContent() != null) {
+                System.out.print(delta.getContent());
+            }
+        }
+    });
+```
+
+### Chat with Image URL
+
+```java
+List<ChatMessageContentItem> contentItems = new ArrayList<>();
+contentItems.add(new ChatMessageTextContentItem("Describe the image."));
+contentItems.add(new ChatMessageImageContentItem(new ChatMessageImageUrl("<URL>")));
+
+List<ChatRequestMessage> messages = new ArrayList<>();
+messages.add(new ChatRequestSystemMessage("You are a helpful assistant."));
+messages.add(ChatRequestUserMessage.fromContentItems(contentItems));
+
+ChatCompletions response = client.complete(new ChatCompletionsOptions(messages));
+System.out.println(response.getChoice().getMessage().getContent());
+```
+
+## Embeddings
+
+```java
+import com.azure.ai.inference.EmbeddingsClient;
+import com.azure.ai.inference.EmbeddingsClientBuilder;
+import com.azure.ai.inference.models.*;
+import java.util.List;
+
+EmbeddingsClient embeddingsClient = new EmbeddingsClientBuilder()
+    .endpoint(endpoint)
+    .credential(new AzureKeyCredential(key))
+    .buildClient();
+
+List<String> input = List.of("Your text string goes here");
+EmbeddingsResult result = embeddingsClient.embed(input);
+
+for (EmbeddingItem item : result.getData()) {
+    System.out.println("Dimensions: " + item.getEmbeddingList().size());
+}
+```
+
+## Message Types
+
+| Type | Description |
+|------|-------------|
+| `ChatRequestSystemMessage` | System instructions |
+| `ChatRequestUserMessage` | User input (text, images) |
+| `ChatRequestAssistantMessage` | Model responses |
+| `ChatRequestToolMessage` | Tool execution results |
+
+## Model Information
+
+```java
+ModelInfo modelInfo = client.getModelInfo();
+System.out.println("Model: " + modelInfo.getModelName());
+System.out.println("Provider: " + modelInfo.getModelProviderName());
+System.out.println("Type: " + modelInfo.getModelType());
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** for production
+2. **Use streaming** for long responses to improve UX
+3. **Specify model** when endpoint serves multiple deployments
+4. **Close async clients** explicitly or use try-with-resources
+5. **Handle rate limits** with appropriate retry logic
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    ChatCompletions response = client.complete(options);
+} catch (HttpResponseException e) {
+    System.err.println("Error: " + e.getResponse().getStatusCode());
+    System.err.println("Message: " + e.getMessage());
+}
+```
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| API Reference | https://aka.ms/azsdk/azure-ai-inference/java/reference |
+| GitHub Source | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-inference |
+| Samples | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-inference/src/samples |

--- a/skills/java/foundry/inference/references/examples.md
+++ b/skills/java/foundry/inference/references/examples.md
@@ -1,0 +1,315 @@
+# Azure AI Inference Java SDK - Examples
+
+Comprehensive code examples for the Azure AI Inference SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Basic Chat Completions](#basic-chat-completions)
+- [Chat with Message History](#chat-with-message-history)
+- [Streaming Chat Completions](#streaming-chat-completions)
+- [Text Embeddings](#text-embeddings)
+- [Vision (Image Analysis)](#vision-image-analysis)
+
+---
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-inference</artifactId>
+    <version>1.0.0-beta.5</version>
+</dependency>
+
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.15.3</version>
+</dependency>
+```
+
+---
+
+## Client Creation
+
+### Sync Client with API Key
+
+```java
+import com.azure.ai.inference.ChatCompletionsClient;
+import com.azure.ai.inference.ChatCompletionsClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+    .credential(new AzureKeyCredential("{key}"))
+    .endpoint("{endpoint}")
+    .buildClient();
+```
+
+### Async Client with API Key
+
+```java
+import com.azure.ai.inference.ChatCompletionsAsyncClient;
+
+ChatCompletionsAsyncClient asyncClient = new ChatCompletionsClientBuilder()
+    .credential(new AzureKeyCredential("{key}"))
+    .endpoint("{endpoint}")
+    .buildAsyncClient();
+```
+
+### Client with DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint("{endpoint}")
+    .buildClient();
+```
+
+---
+
+## Basic Chat Completions
+
+### Simple Prompt
+
+```java
+import com.azure.ai.inference.ChatCompletionsClient;
+import com.azure.ai.inference.ChatCompletionsClientBuilder;
+import com.azure.ai.inference.models.ChatCompletions;
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.util.Configuration;
+
+public class BasicChatSample {
+    public static void main(String[] args) {
+        String key = Configuration.getGlobalConfiguration().get("AZURE_API_KEY");
+        String endpoint = Configuration.getGlobalConfiguration().get("MODEL_ENDPOINT");
+        
+        ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+            .credential(new AzureKeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        String prompt = "Tell me 3 jokes about trains";
+
+        ChatCompletions completions = client.complete(prompt);
+
+        System.out.printf("%s.%n", completions.getChoice().getMessage().getContent());
+    }
+}
+```
+
+---
+
+## Chat with Message History
+
+```java
+import com.azure.ai.inference.models.*;
+import java.util.ArrayList;
+import java.util.List;
+
+List<ChatRequestMessage> chatMessages = new ArrayList<>();
+chatMessages.add(new ChatRequestSystemMessage("You are a helpful assistant. You will talk like a pirate."));
+chatMessages.add(new ChatRequestUserMessage("Can you help me?"));
+chatMessages.add(new ChatRequestAssistantMessage("Of course, me hearty! What can I do for ye?"));
+chatMessages.add(new ChatRequestUserMessage("What's the best way to train a parrot?"));
+
+ChatCompletions chatCompletions = client.complete(new ChatCompletionsOptions(chatMessages));
+
+System.out.printf("Model ID=%s is created at %s.%n", chatCompletions.getId(), chatCompletions.getCreated());
+for (ChatChoice choice : chatCompletions.getChoices()) {
+    ChatResponseMessage message = choice.getMessage();
+    System.out.printf("Index: %d, Chat Role: %s.%n", choice.getIndex(), message.getRole());
+    System.out.println("Message:");
+    System.out.println(message.getContent());
+}
+```
+
+---
+
+## Streaming Chat Completions
+
+```java
+import com.azure.ai.inference.ChatCompletionsClient;
+import com.azure.ai.inference.ChatCompletionsClientBuilder;
+import com.azure.ai.inference.models.*;
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.util.CoreUtils;
+import com.azure.core.util.IterableStream;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class StreamingChatSample {
+    public static void main(String[] args) {
+        String key = System.getenv("AZURE_API_KEY");
+        String endpoint = System.getenv("MODEL_ENDPOINT");
+        
+        ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+            .credential(new AzureKeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        List<ChatRequestMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new ChatRequestSystemMessage("You are a helpful assistant."));
+        chatMessages.add(new ChatRequestUserMessage("What's the best way to train a parrot?"));
+
+        IterableStream<StreamingChatCompletionsUpdate> chatCompletionsStream = 
+            client.completeStream(new ChatCompletionsOptions(chatMessages));
+
+        // Process streaming response
+        chatCompletionsStream
+            .stream()
+            .forEach(chatCompletions -> {
+                if (CoreUtils.isNullOrEmpty(chatCompletions.getChoices())) {
+                    return;
+                }
+
+                StreamingChatResponseMessageUpdate delta = chatCompletions.getChoice().getDelta();
+
+                if (delta.getRole() != null) {
+                    System.out.println("Role = " + delta.getRole());
+                }
+
+                if (delta.getContent() != null) {
+                    String content = delta.getContent();
+                    System.out.print(content);
+                }
+            });
+    }
+}
+```
+
+### Alternative: Using forEach
+
+```java
+client.completeStream(new ChatCompletionsOptions(chatMessages))
+    .forEach(chatCompletions -> {
+        if (CoreUtils.isNullOrEmpty(chatCompletions.getChoices())) {
+            return;
+        }
+        StreamingChatResponseMessageUpdate delta = chatCompletions.getChoice().getDelta();
+        if (delta.getRole() != null) {
+            System.out.println("Role = " + delta.getRole());
+        }
+        if (delta.getContent() != null) {
+            System.out.print(delta.getContent());
+        }
+    });
+```
+
+---
+
+## Text Embeddings
+
+```java
+import com.azure.ai.inference.EmbeddingsClient;
+import com.azure.ai.inference.EmbeddingsClientBuilder;
+import com.azure.ai.inference.models.EmbeddingsResult;
+import com.azure.ai.inference.models.EmbeddingItem;
+import com.azure.core.credential.AzureKeyCredential;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TextEmbeddingsSample {
+    public static void main(String[] args) {
+        String key = System.getenv("AZURE_EMBEDDINGS_KEY");
+        String endpoint = System.getenv("EMBEDDINGS_MODEL_ENDPOINT");
+        
+        EmbeddingsClient client = new EmbeddingsClientBuilder()
+            .credential(new AzureKeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        List<String> promptList = new ArrayList<>();
+        String prompt = "Tell me 3 jokes about trains";
+        promptList.add(prompt);
+
+        EmbeddingsResult embeddings = client.embed(promptList);
+
+        for (EmbeddingItem item : embeddings.getData()) {
+            System.out.printf("Index: %d.%n", item.getIndex());
+            for (Float embedding : item.getEmbeddingList()) {
+                System.out.printf("%f;", embedding);
+            }
+        }
+    }
+}
+```
+
+---
+
+## Vision (Image Analysis)
+
+### Image from URL
+
+```java
+import com.azure.ai.inference.models.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImageUrlChatSample {
+
+    private static final String TEST_URL =
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+
+    public static void main(String[] args) {
+        String key = System.getenv("AZURE_API_KEY");
+        String endpoint = System.getenv("MODEL_ENDPOINT");
+        
+        ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+            .credential(new AzureKeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        List<ChatMessageContentItem> contentItems = new ArrayList<>();
+        contentItems.add(new ChatMessageTextContentItem("Describe the image."));
+        contentItems.add(new ChatMessageImageContentItem(
+            new ChatMessageImageUrl(TEST_URL)));
+
+        List<ChatRequestMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new ChatRequestSystemMessage("You are a helpful assistant."));
+        chatMessages.add(ChatRequestUserMessage.fromContentItems(contentItems));
+
+        ChatCompletions completions = client.complete(new ChatCompletionsOptions(chatMessages));
+
+        System.out.printf("%s.%n", completions.getChoice().getMessage().getContent());
+    }
+}
+```
+
+### Image from Local File
+
+```java
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ImageFileChatSample {
+
+    private static final String TEST_IMAGE_PATH = "./src/samples/resources/sample-images/sample.png";
+    private static final String TEST_IMAGE_FORMAT = "png";
+
+    public static void main(String[] args) {
+        ChatCompletionsClient client = new ChatCompletionsClientBuilder()
+            .credential(new AzureKeyCredential(key))
+            .endpoint(endpoint)
+            .buildClient();
+
+        Path testFilePath = Paths.get(TEST_IMAGE_PATH);
+        List<ChatMessageContentItem> contentItems = new ArrayList<>();
+        contentItems.add(new ChatMessageTextContentItem("Describe the image."));
+        contentItems.add(new ChatMessageImageContentItem(testFilePath, TEST_IMAGE_FORMAT));
+
+        List<ChatRequestMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new ChatRequestSystemMessage("You are a helpful assistant."));
+        chatMessages.add(ChatRequestUserMessage.fromContentItems(contentItems));
+
+        ChatCompletions completions = client.complete(new ChatCompletionsOptions(chatMessages));
+
+        System.out.printf("%s.%n", completions.getChoice().getMessage().getContent());
+    }
+}
+```

--- a/skills/java/foundry/projects/SKILL.md
+++ b/skills/java/foundry/projects/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: azure-ai-projects-java
+description: |
+  Azure AI Projects SDK for Java. High-level SDK for Azure AI Foundry project management including connections, datasets, indexes, and evaluations.
+  Triggers: "AIProjectClient java", "azure ai projects java", "Foundry project java", "ConnectionsClient", "DatasetsClient", "IndexesClient".
+---
+
+# Azure AI Projects SDK for Java
+
+High-level SDK for Azure AI Foundry project management with access to connections, datasets, indexes, and evaluations.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-projects</artifactId>
+    <version>1.0.0-beta.1</version>
+</dependency>
+```
+
+## Environment Variables
+
+```bash
+PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+```
+
+## Authentication
+
+```java
+import com.azure.ai.projects.AIProjectClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+AIProjectClientBuilder builder = new AIProjectClientBuilder()
+    .endpoint(System.getenv("PROJECT_ENDPOINT"))
+    .credential(new DefaultAzureCredentialBuilder().build());
+```
+
+## Client Hierarchy
+
+The SDK provides multiple sub-clients for different operations:
+
+| Client | Purpose |
+|--------|---------|
+| `ConnectionsClient` | Enumerate connected Azure resources |
+| `DatasetsClient` | Upload documents and manage datasets |
+| `DeploymentsClient` | Enumerate AI model deployments |
+| `IndexesClient` | Create and manage search indexes |
+| `EvaluationsClient` | Run AI model evaluations |
+| `EvaluatorsClient` | Manage evaluator configurations |
+| `SchedulesClient` | Manage scheduled operations |
+
+```java
+// Build sub-clients from builder
+ConnectionsClient connectionsClient = builder.buildConnectionsClient();
+DatasetsClient datasetsClient = builder.buildDatasetsClient();
+DeploymentsClient deploymentsClient = builder.buildDeploymentsClient();
+IndexesClient indexesClient = builder.buildIndexesClient();
+EvaluationsClient evaluationsClient = builder.buildEvaluationsClient();
+```
+
+## Core Operations
+
+### List Connections
+
+```java
+import com.azure.ai.projects.models.Connection;
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<Connection> connections = connectionsClient.listConnections();
+for (Connection connection : connections) {
+    System.out.println("Name: " + connection.getName());
+    System.out.println("Type: " + connection.getType());
+    System.out.println("Credential Type: " + connection.getCredentials().getType());
+}
+```
+
+### List Indexes
+
+```java
+indexesClient.listLatest().forEach(index -> {
+    System.out.println("Index name: " + index.getName());
+    System.out.println("Version: " + index.getVersion());
+    System.out.println("Description: " + index.getDescription());
+});
+```
+
+### Create or Update Index
+
+```java
+import com.azure.ai.projects.models.AzureAISearchIndex;
+import com.azure.ai.projects.models.Index;
+
+String indexName = "my-index";
+String indexVersion = "1.0";
+String searchConnectionName = System.getenv("AI_SEARCH_CONNECTION_NAME");
+String searchIndexName = System.getenv("AI_SEARCH_INDEX_NAME");
+
+Index index = indexesClient.createOrUpdate(
+    indexName,
+    indexVersion,
+    new AzureAISearchIndex()
+        .setConnectionName(searchConnectionName)
+        .setIndexName(searchIndexName)
+);
+
+System.out.println("Created index: " + index.getName());
+```
+
+### Access OpenAI Evaluations
+
+The SDK exposes OpenAI's official SDK for evaluations:
+
+```java
+import com.openai.services.EvalService;
+
+EvalService evalService = evaluationsClient.getOpenAIClient();
+// Use OpenAI evaluation APIs directly
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** for production authentication
+2. **Reuse client builder** to create multiple sub-clients efficiently
+3. **Handle pagination** when listing resources with `PagedIterable`
+4. **Use environment variables** for connection names and configuration
+5. **Check connection types** before accessing credentials
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.exception.ResourceNotFoundException;
+
+try {
+    Index index = indexesClient.get(indexName, version);
+} catch (ResourceNotFoundException e) {
+    System.err.println("Index not found: " + indexName);
+} catch (HttpResponseException e) {
+    System.err.println("Error: " + e.getResponse().getStatusCode());
+}
+```
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Product Docs | https://learn.microsoft.com/azure/ai-studio/ |
+| API Reference | https://learn.microsoft.com/rest/api/aifoundry/aiprojects/ |
+| GitHub Source | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-projects |
+| Samples | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-projects/src/samples |

--- a/skills/java/foundry/projects/references/examples.md
+++ b/skills/java/foundry/projects/references/examples.md
@@ -1,0 +1,344 @@
+# Azure AI Projects Java SDK - Examples
+
+Comprehensive code examples for the Azure AI Projects SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Working with Connections](#working-with-connections)
+- [Working with Deployments](#working-with-deployments)
+- [Working with Datasets](#working-with-datasets)
+- [Async Clients](#async-clients)
+
+---
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-projects</artifactId>
+    <version>1.0.0-beta.1</version>
+</dependency>
+
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.15.3</version>
+</dependency>
+```
+
+---
+
+## Client Creation
+
+### Creating AIProjectClient and Sub-Clients
+
+```java
+import com.azure.ai.projects.*;
+import com.azure.core.util.Configuration;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+public class ClientInitializationSample {
+
+    public static void main(String[] args) {
+        // Create the builder with endpoint and credentials
+        AIProjectClientBuilder builder = new AIProjectClientBuilder()
+            .endpoint(Configuration.getGlobalConfiguration().get("AZURE_AI_PROJECTS_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build());
+
+        // Build specific sub-clients as needed
+        ConnectionsClient connectionsClient = builder.buildConnectionsClient();
+        DatasetsClient datasetsClient = builder.buildDatasetsClient();
+        DeploymentsClient deploymentsClient = builder.buildDeploymentsClient();
+        EvaluationRulesClient evaluationRulesClient = builder.buildEvaluationRulesClient();
+        EvaluationsClient evaluationsClient = builder.buildEvaluationsClient();
+        EvaluationTaxonomiesClient evaluationTaxonomiesClient = builder.buildEvaluationTaxonomiesClient();
+        EvaluatorsClient evaluatorsClient = builder.buildEvaluatorsClient();
+        IndexesClient indexesClient = builder.buildIndexesClient();
+        InsightsClient insightsClient = builder.buildInsightsClient();
+        RedTeamsClient redTeamsClient = builder.buildRedTeamsClient();
+        SchedulesClient schedulesClient = builder.buildSchedulesClient();
+        
+        // For async clients, use the async builder methods
+        ConnectionsAsyncClient connectionsAsyncClient = builder.buildConnectionsAsyncClient();
+        DatasetsAsyncClient datasetsAsyncClient = builder.buildDatasetsAsyncClient();
+        DeploymentsAsyncClient deploymentsAsyncClient = builder.buildDeploymentsAsyncClient();
+    }
+}
+```
+
+---
+
+## Working with Connections
+
+### List Connections
+
+```java
+import com.azure.ai.projects.models.Connection;
+import com.azure.ai.projects.models.ConnectionType;
+import com.azure.core.http.rest.PagedIterable;
+
+public class ConnectionsSample {
+
+    private static ConnectionsClient connectionsClient;
+
+    public static void listConnections() {
+        PagedIterable<Connection> connections = connectionsClient.listConnections();
+        for (Connection connection : connections) {
+            System.out.println("Connection name: " + connection.getName());
+            System.out.println("Connection type: " + connection.getType());
+            System.out.println("Connection credential type: " + connection.getCredentials().getType());
+            System.out.println("-------------------------------------------------");
+        }
+    }
+
+    public static void getConnectionWithoutCredentials() {
+        String connectionName = "my-connection";
+        Connection connection = connectionsClient.getConnection(connectionName);
+        System.out.printf("Connection name: %s%n", connection.getName());
+    }
+
+    public static void getConnectionWithCredentials() {
+        String connectionName = "my-connection";
+        Connection connection = connectionsClient.getConnectionWithCredentials(connectionName);
+        System.out.printf("Connection name: %s%n", connection.getName());
+        System.out.printf("Connection credentials: %s%n", connection.getCredentials().getType());
+    }
+
+    // Filter connections by type
+    public static void listConnectionsWithFilters() {
+        // List only Azure OpenAI connections
+        Iterable<Connection> azureOpenAIConnections = 
+            connectionsClient.listConnections(ConnectionType.AZURE_OPEN_AI, null);
+        
+        azureOpenAIConnections.forEach(connection -> {
+            System.out.println("Azure OpenAI Connection: " + connection.getName());
+        });
+
+        // List only default connections
+        Iterable<Connection> defaultConnections = connectionsClient.listConnections(null, true);
+        defaultConnections.forEach(connection -> {
+            System.out.println("Default Connection: " + connection.getName());
+        });
+    }
+}
+```
+
+---
+
+## Working with Deployments
+
+### List and Get Deployments
+
+```java
+import com.azure.ai.projects.models.Deployment;
+import com.azure.core.http.rest.PagedIterable;
+
+public class DeploymentsSample {
+
+    private static DeploymentsClient deploymentsClient;
+
+    public static void listDeployments() {
+        PagedIterable<Deployment> deployments = deploymentsClient.list();
+        for (Deployment deployment : deployments) {
+            System.out.printf("Deployment name: %s%n", deployment.getName());
+        }
+    }
+
+    public static void getDeployment() {
+        String deploymentName = "gpt-4o";
+        Deployment deployment = deploymentsClient.get(deploymentName);
+
+        System.out.printf("Deployment name: %s%n", deployment.getName());
+        System.out.printf("Deployment type: %s%n", deployment.getType().getValue());
+    }
+}
+```
+
+---
+
+## Working with Datasets
+
+### Create Dataset with File Upload
+
+```java
+import com.azure.ai.projects.models.DatasetVersion;
+import com.azure.ai.projects.models.FileDatasetVersion;
+
+import java.nio.file.Path;
+
+public class DatasetsSample {
+
+    private static DatasetsClient datasetsClient;
+
+    // Create a dataset by uploading a file
+    public static void createDatasetWithFile() {
+        String datasetName = "my-dataset";
+        String datasetVersionString = "1.0";
+
+        Path filePath = Path.of("product_info.md");
+
+        FileDatasetVersion createdDatasetVersion = datasetsClient.createDatasetWithFile(
+            datasetName, 
+            datasetVersionString, 
+            filePath
+        );
+
+        System.out.println("Created dataset version: " + createdDatasetVersion.getId());
+    }
+
+    // List all datasets (latest versions)
+    public static void listDatasets() {
+        System.out.println("Listing all datasets (latest versions):");
+        datasetsClient.listLatest().forEach(dataset -> {
+            System.out.println("\nDataset name: " + dataset.getName());
+            System.out.println("Dataset Id: " + dataset.getId());
+            System.out.println("Dataset version: " + dataset.getVersion());
+            System.out.println("Dataset type: " + dataset.getType());
+            if (dataset.getDescription() != null) {
+                System.out.println("Description: " + dataset.getDescription());
+            }
+        });
+    }
+
+    // List all versions of a specific dataset
+    public static void listDatasetVersions() {
+        String datasetName = "my-dataset";
+
+        System.out.println("Listing all versions of dataset: " + datasetName);
+        datasetsClient.listVersions(datasetName).forEach(version -> {
+            System.out.println("\nDataset name: " + version.getName());
+            System.out.println("Dataset version: " + version.getVersion());
+            System.out.println("Dataset type: " + version.getType());
+            if (version.getDataUri() != null) {
+                System.out.println("Data URI: " + version.getDataUri());
+            }
+        });
+    }
+
+    // Get a specific dataset version
+    public static void getDataset() {
+        String datasetName = "my-dataset";
+        String datasetVersion = "1.0";
+
+        DatasetVersion dataset = datasetsClient.getDatasetVersion(datasetName, datasetVersion);
+
+        System.out.println("Retrieved dataset:");
+        System.out.println("Name: " + dataset.getName());
+        System.out.println("Version: " + dataset.getVersion());
+        System.out.println("Type: " + dataset.getType());
+    }
+
+    // Create or update a dataset with a data URI
+    public static void createOrUpdateDataset() {
+        String datasetName = "my-dataset";
+        String datasetVersion = "1.0";
+        String dataUri = "https://example.com/data.txt";
+
+        // Create a new FileDatasetVersion with provided dataUri
+        FileDatasetVersion fileDataset = new FileDatasetVersion()
+            .setDataUri(dataUri)
+            .setDescription("Sample dataset created via SDK");
+
+        // Create or update the dataset
+        FileDatasetVersion createdDataset = (FileDatasetVersion) datasetsClient.createOrUpdateVersion(
+            datasetName, 
+            datasetVersion, 
+            fileDataset
+        );
+
+        System.out.println("Created/Updated dataset:");
+        System.out.println("Name: " + createdDataset.getName());
+        System.out.println("Version: " + createdDataset.getVersion());
+        System.out.println("Data URI: " + createdDataset.getDataUri());
+    }
+
+    // Delete a dataset version
+    public static void deleteDataset() {
+        String datasetName = "my-dataset";
+        String datasetVersion = "1.0";
+
+        datasetsClient.deleteVersion(datasetName, datasetVersion);
+        System.out.println("Dataset version deleted successfully");
+    }
+}
+```
+
+---
+
+## Async Clients
+
+### List Connections (Async)
+
+```java
+import com.azure.ai.projects.models.Connection;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class ConnectionsAsyncSample {
+
+    private static ConnectionsAsyncClient connectionsAsyncClient;
+
+    public static Flux<Connection> listConnections() {
+        return connectionsAsyncClient.listConnections()
+            .doOnNext(connection -> System.out.printf("Connection name: %s%n", connection.getName()));
+    }
+
+    public static Mono<Connection> getConnectionWithoutCredentials() {
+        String connectionName = "my-connection";
+        return connectionsAsyncClient.getConnection(connectionName)
+            .doOnNext(connection -> System.out.printf("Connection name: %s%n", connection.getName()));
+    }
+
+    public static Mono<Connection> getConnectionWithCredentials() {
+        String connectionName = "my-connection";
+        return connectionsAsyncClient.getConnectionWithCredentials(connectionName)
+            .doOnNext(connection -> {
+                System.out.printf("Connection name: %s%n", connection.getName());
+                System.out.printf("Connection credentials: %s%n", connection.getCredentials().getType());
+            });
+    }
+
+    public static void main(String[] args) {
+        // Using block() to wait for the async operations to complete in the sample
+        listConnections().blockLast();
+        getConnectionWithoutCredentials().block();
+        getConnectionWithCredentials().block();
+    }
+}
+```
+
+### Datasets (Async)
+
+```java
+import com.azure.ai.projects.models.DatasetVersion;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class DatasetsAsyncSample {
+
+    private static DatasetsAsyncClient datasetsAsyncClient;
+
+    public static Flux<DatasetVersion> listLatestDatasets() {
+        return datasetsAsyncClient.listLatest()
+            .doOnNext(dataset -> {
+                System.out.println("Dataset: " + dataset.getName());
+                System.out.println("Version: " + dataset.getVersion());
+            });
+    }
+
+    public static Mono<DatasetVersion> getDataset(String name, String version) {
+        return datasetsAsyncClient.getDatasetVersion(name, version)
+            .doOnNext(dataset -> {
+                System.out.println("Retrieved: " + dataset.getName());
+            });
+    }
+
+    public static void main(String[] args) {
+        listLatestDatasets().blockLast();
+        getDataset("my-dataset", "1.0").block();
+    }
+}
+```

--- a/skills/java/foundry/voicelive/SKILL.md
+++ b/skills/java/foundry/voicelive/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: azure-ai-voicelive-java
+description: |
+  Azure AI VoiceLive SDK for Java. Real-time bidirectional voice conversations with AI assistants using WebSocket.
+  Triggers: "VoiceLiveClient java", "voice assistant java", "real-time voice java", "audio streaming java", "voice activity detection java".
+---
+
+# Azure AI VoiceLive SDK for Java
+
+Real-time, bidirectional voice conversations with AI assistants using WebSocket technology.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-voicelive</artifactId>
+    <version>1.0.0-beta.2</version>
+</dependency>
+```
+
+## Environment Variables
+
+```bash
+AZURE_VOICELIVE_ENDPOINT=https://<resource>.openai.azure.com/
+AZURE_VOICELIVE_API_KEY=<your-api-key>
+```
+
+## Authentication
+
+### API Key
+
+```java
+import com.azure.ai.voicelive.VoiceLiveAsyncClient;
+import com.azure.ai.voicelive.VoiceLiveClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+VoiceLiveAsyncClient client = new VoiceLiveClientBuilder()
+    .endpoint(System.getenv("AZURE_VOICELIVE_ENDPOINT"))
+    .credential(new AzureKeyCredential(System.getenv("AZURE_VOICELIVE_API_KEY")))
+    .buildAsyncClient();
+```
+
+### DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+VoiceLiveAsyncClient client = new VoiceLiveClientBuilder()
+    .endpoint(System.getenv("AZURE_VOICELIVE_ENDPOINT"))
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| `VoiceLiveAsyncClient` | Main entry point for voice sessions |
+| `VoiceLiveSessionAsyncClient` | Active WebSocket connection for streaming |
+| `VoiceLiveSessionOptions` | Configuration for session behavior |
+
+### Audio Requirements
+
+- **Sample Rate**: 24kHz (24000 Hz)
+- **Bit Depth**: 16-bit PCM
+- **Channels**: Mono (1 channel)
+- **Format**: Signed PCM, little-endian
+
+## Core Workflow
+
+### 1. Start Session
+
+```java
+import reactor.core.publisher.Mono;
+
+client.startSession("gpt-4o-realtime-preview")
+    .flatMap(session -> {
+        System.out.println("Session started");
+        
+        // Subscribe to events
+        session.receiveEvents()
+            .subscribe(
+                event -> System.out.println("Event: " + event.getType()),
+                error -> System.err.println("Error: " + error.getMessage())
+            );
+        
+        return Mono.just(session);
+    })
+    .block();
+```
+
+### 2. Configure Session Options
+
+```java
+import com.azure.ai.voicelive.models.*;
+import java.util.Arrays;
+
+ServerVadTurnDetection turnDetection = new ServerVadTurnDetection()
+    .setThreshold(0.5)                    // Sensitivity (0.0-1.0)
+    .setPrefixPaddingMs(300)              // Audio before speech
+    .setSilenceDurationMs(500)            // Silence to end turn
+    .setInterruptResponse(true)           // Allow interruptions
+    .setAutoTruncate(true)
+    .setCreateResponse(true);
+
+AudioInputTranscriptionOptions transcription = new AudioInputTranscriptionOptions(
+    AudioInputTranscriptionOptionsModel.WHISPER_1);
+
+VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+    .setInstructions("You are a helpful AI voice assistant.")
+    .setVoice(BinaryData.fromObject(new OpenAIVoice(OpenAIVoiceName.ALLOY)))
+    .setModalities(Arrays.asList(InteractionModality.TEXT, InteractionModality.AUDIO))
+    .setInputAudioFormat(InputAudioFormat.PCM16)
+    .setOutputAudioFormat(OutputAudioFormat.PCM16)
+    .setInputAudioSamplingRate(24000)
+    .setInputAudioNoiseReduction(new AudioNoiseReduction(AudioNoiseReductionType.NEAR_FIELD))
+    .setInputAudioEchoCancellation(new AudioEchoCancellation())
+    .setInputAudioTranscription(transcription)
+    .setTurnDetection(turnDetection);
+
+// Send configuration
+ClientEventSessionUpdate updateEvent = new ClientEventSessionUpdate(options);
+session.sendEvent(updateEvent).subscribe();
+```
+
+### 3. Send Audio Input
+
+```java
+byte[] audioData = readAudioChunk(); // Your PCM16 audio data
+session.sendInputAudio(BinaryData.fromBytes(audioData)).subscribe();
+```
+
+### 4. Handle Events
+
+```java
+session.receiveEvents().subscribe(event -> {
+    ServerEventType eventType = event.getType();
+    
+    if (ServerEventType.SESSION_CREATED.equals(eventType)) {
+        System.out.println("Session created");
+    } else if (ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED.equals(eventType)) {
+        System.out.println("User started speaking");
+    } else if (ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED.equals(eventType)) {
+        System.out.println("User stopped speaking");
+    } else if (ServerEventType.RESPONSE_AUDIO_DELTA.equals(eventType)) {
+        if (event instanceof SessionUpdateResponseAudioDelta) {
+            SessionUpdateResponseAudioDelta audioEvent = (SessionUpdateResponseAudioDelta) event;
+            playAudioChunk(audioEvent.getDelta());
+        }
+    } else if (ServerEventType.RESPONSE_DONE.equals(eventType)) {
+        System.out.println("Response complete");
+    } else if (ServerEventType.ERROR.equals(eventType)) {
+        if (event instanceof SessionUpdateError) {
+            SessionUpdateError errorEvent = (SessionUpdateError) event;
+            System.err.println("Error: " + errorEvent.getError().getMessage());
+        }
+    }
+});
+```
+
+## Voice Configuration
+
+### OpenAI Voices
+
+```java
+// Available: ALLOY, ASH, BALLAD, CORAL, ECHO, SAGE, SHIMMER, VERSE
+VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+    .setVoice(BinaryData.fromObject(new OpenAIVoice(OpenAIVoiceName.ALLOY)));
+```
+
+### Azure Voices
+
+```java
+// Azure Standard Voice
+options.setVoice(BinaryData.fromObject(new AzureStandardVoice("en-US-JennyNeural")));
+
+// Azure Custom Voice
+options.setVoice(BinaryData.fromObject(new AzureCustomVoice("myVoice", "endpointId")));
+
+// Azure Personal Voice
+options.setVoice(BinaryData.fromObject(
+    new AzurePersonalVoice("speakerProfileId", PersonalVoiceModels.PHOENIX_LATEST_NEURAL)));
+```
+
+## Function Calling
+
+```java
+VoiceLiveFunctionDefinition weatherFunction = new VoiceLiveFunctionDefinition("get_weather")
+    .setDescription("Get current weather for a location")
+    .setParameters(BinaryData.fromObject(parametersSchema));
+
+VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+    .setTools(Arrays.asList(weatherFunction))
+    .setInstructions("You have access to weather information.");
+```
+
+## Best Practices
+
+1. **Use async client** — VoiceLive requires reactive patterns
+2. **Configure turn detection** for natural conversation flow
+3. **Enable noise reduction** for better speech recognition
+4. **Handle interruptions** gracefully with `setInterruptResponse(true)`
+5. **Use Whisper transcription** for input audio transcription
+6. **Close sessions** properly when conversation ends
+
+## Error Handling
+
+```java
+session.receiveEvents()
+    .doOnError(error -> System.err.println("Connection error: " + error.getMessage()))
+    .onErrorResume(error -> {
+        // Attempt reconnection or cleanup
+        return Flux.empty();
+    })
+    .subscribe();
+```
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| GitHub Source | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-voicelive |
+| Samples | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/ai/azure-ai-voicelive/src/samples |

--- a/skills/java/foundry/voicelive/references/examples.md
+++ b/skills/java/foundry/voicelive/references/examples.md
@@ -1,0 +1,780 @@
+# Azure AI VoiceLive Java SDK - Examples
+
+Comprehensive code examples for the Azure AI VoiceLive SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Session Management](#session-management)
+- [Session Configuration](#session-configuration)
+- [Audio Streaming](#audio-streaming)
+- [Event Handling](#event-handling)
+- [Voice Configuration](#voice-configuration)
+- [Function Calling](#function-calling)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-ai-voicelive</artifactId>
+    <version>1.0.0-beta.2</version>
+</dependency>
+
+<!-- For DefaultAzureCredential -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+
+<!-- Reactor for reactive streams -->
+<dependency>
+    <groupId>io.projectreactor</groupId>
+    <artifactId>reactor-core</artifactId>
+    <version>3.6.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### With API Key
+
+```java
+import com.azure.ai.voicelive.VoiceLiveAsyncClient;
+import com.azure.ai.voicelive.VoiceLiveClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+String endpoint = System.getenv("AZURE_VOICELIVE_ENDPOINT");
+String key = System.getenv("AZURE_VOICELIVE_API_KEY");
+
+VoiceLiveAsyncClient client = new VoiceLiveClientBuilder()
+    .endpoint(endpoint)
+    .credential(new AzureKeyCredential(key))
+    .buildAsyncClient();
+```
+
+### With DefaultAzureCredential (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+VoiceLiveAsyncClient client = new VoiceLiveClientBuilder()
+    .endpoint(System.getenv("AZURE_VOICELIVE_ENDPOINT"))
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+## Session Management
+
+### Start Session
+
+```java
+import com.azure.ai.voicelive.VoiceLiveSessionAsyncClient;
+import reactor.core.publisher.Mono;
+
+String modelDeployment = "gpt-4o-realtime-preview";
+
+client.startSession(modelDeployment)
+    .flatMap(session -> {
+        System.out.println("Session started successfully");
+        
+        // Subscribe to events
+        session.receiveEvents()
+            .subscribe(
+                event -> handleEvent(event),
+                error -> System.err.println("Error: " + error.getMessage()),
+                () -> System.out.println("Session ended")
+            );
+        
+        return Mono.just(session);
+    })
+    .subscribe();
+```
+
+### Basic Session Flow
+
+```java
+client.startSession("gpt-4o-realtime-preview")
+    .flatMap(session -> {
+        // 1. Configure session
+        return configureSession(session)
+            .then(Mono.just(session));
+    })
+    .flatMap(session -> {
+        // 2. Start receiving events
+        session.receiveEvents()
+            .subscribe(event -> processEvent(event));
+        
+        // 3. Send audio
+        return sendAudioStream(session);
+    })
+    .subscribe(
+        result -> System.out.println("Audio sent"),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+## Session Configuration
+
+### Configure with Turn Detection
+
+```java
+import com.azure.ai.voicelive.models.*;
+import com.azure.core.util.BinaryData;
+import java.util.Arrays;
+
+// Server-side Voice Activity Detection (VAD)
+ServerVadTurnDetection turnDetection = new ServerVadTurnDetection()
+    .setThreshold(0.5)                    // Sensitivity (0.0-1.0)
+    .setPrefixPaddingMs(300)              // Audio to keep before speech
+    .setSilenceDurationMs(500)            // Silence to end turn
+    .setInterruptResponse(true)           // Allow user interruptions
+    .setAutoTruncate(true)
+    .setCreateResponse(true);
+
+// Input transcription
+AudioInputTranscriptionOptions transcription = new AudioInputTranscriptionOptions(
+    AudioInputTranscriptionOptionsModel.WHISPER_1);
+
+// Session options
+VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+    .setInstructions("You are a helpful AI voice assistant. Be concise and friendly.")
+    .setVoice(BinaryData.fromObject(new OpenAIVoice(OpenAIVoiceName.ALLOY)))
+    .setModalities(Arrays.asList(InteractionModality.TEXT, InteractionModality.AUDIO))
+    .setInputAudioFormat(InputAudioFormat.PCM16)
+    .setOutputAudioFormat(OutputAudioFormat.PCM16)
+    .setInputAudioSamplingRate(24000)
+    .setInputAudioNoiseReduction(new AudioNoiseReduction(AudioNoiseReductionType.NEAR_FIELD))
+    .setInputAudioEchoCancellation(new AudioEchoCancellation())
+    .setInputAudioTranscription(transcription)
+    .setTurnDetection(turnDetection);
+
+// Send configuration
+ClientEventSessionUpdate updateEvent = new ClientEventSessionUpdate(options);
+session.sendEvent(updateEvent).subscribe();
+```
+
+### Configure for Text-Only Response
+
+```java
+VoiceLiveSessionOptions textOnlyOptions = new VoiceLiveSessionOptions()
+    .setInstructions("You are a helpful assistant.")
+    .setModalities(Arrays.asList(InteractionModality.TEXT))  // Text only
+    .setInputAudioFormat(InputAudioFormat.PCM16)
+    .setInputAudioSamplingRate(24000)
+    .setTurnDetection(new ServerVadTurnDetection()
+        .setCreateResponse(true));
+
+session.sendEvent(new ClientEventSessionUpdate(textOnlyOptions)).subscribe();
+```
+
+## Audio Streaming
+
+### Audio Requirements
+
+- **Sample Rate**: 24kHz (24000 Hz)
+- **Bit Depth**: 16-bit PCM
+- **Channels**: Mono (1 channel)
+- **Format**: Signed PCM, little-endian
+
+### Send Audio Input
+
+```java
+import com.azure.core.util.BinaryData;
+
+// Read audio from microphone or file (PCM16 format)
+byte[] audioData = readAudioChunk();  // Your audio data
+
+// Send audio to session
+session.sendInputAudio(BinaryData.fromBytes(audioData))
+    .subscribe(
+        () -> System.out.println("Audio sent"),
+        error -> System.err.println("Error sending audio: " + error.getMessage())
+    );
+```
+
+### Stream Audio from Microphone
+
+```java
+import javax.sound.sampled.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public void streamFromMicrophone(VoiceLiveSessionAsyncClient session) {
+    AtomicBoolean recording = new AtomicBoolean(true);
+    
+    // Audio format: 24kHz, 16-bit, mono, signed, little-endian
+    AudioFormat format = new AudioFormat(24000, 16, 1, true, false);
+    
+    try {
+        DataLine.Info info = new DataLine.Info(TargetDataLine.class, format);
+        TargetDataLine microphone = (TargetDataLine) AudioSystem.getLine(info);
+        microphone.open(format);
+        microphone.start();
+        
+        // Stream in chunks
+        byte[] buffer = new byte[4800];  // 100ms of audio at 24kHz
+        
+        Thread audioThread = new Thread(() -> {
+            while (recording.get()) {
+                int bytesRead = microphone.read(buffer, 0, buffer.length);
+                if (bytesRead > 0) {
+                    byte[] audioChunk = new byte[bytesRead];
+                    System.arraycopy(buffer, 0, audioChunk, 0, bytesRead);
+                    
+                    session.sendInputAudio(BinaryData.fromBytes(audioChunk))
+                        .subscribe();
+                }
+            }
+            microphone.close();
+        });
+        
+        audioThread.start();
+        
+        // Stop after some time or user action
+        Thread.sleep(30000);
+        recording.set(false);
+        
+    } catch (Exception e) {
+        System.err.println("Error streaming audio: " + e.getMessage());
+    }
+}
+```
+
+### Commit Audio Buffer
+
+Signal end of user input:
+
+```java
+session.sendEvent(new ClientEventInputAudioBufferCommit())
+    .subscribe();
+```
+
+### Clear Audio Buffer
+
+Cancel current input:
+
+```java
+session.sendEvent(new ClientEventInputAudioBufferClear())
+    .subscribe();
+```
+
+## Event Handling
+
+### Handle All Event Types
+
+```java
+import com.azure.ai.voicelive.models.*;
+
+private void handleEvent(ServerEvent event) {
+    ServerEventType eventType = event.getType();
+    
+    switch (eventType) {
+        case SESSION_CREATED:
+            handleSessionCreated((SessionCreatedEvent) event);
+            break;
+            
+        case SESSION_UPDATED:
+            System.out.println("Session configuration updated");
+            break;
+            
+        case INPUT_AUDIO_BUFFER_SPEECH_STARTED:
+            System.out.println("User started speaking");
+            break;
+            
+        case INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
+            System.out.println("User stopped speaking");
+            break;
+            
+        case INPUT_AUDIO_BUFFER_COMMITTED:
+            System.out.println("Audio buffer committed");
+            break;
+            
+        case CONVERSATION_ITEM_CREATED:
+            handleConversationItemCreated(event);
+            break;
+            
+        case RESPONSE_CREATED:
+            System.out.println("Response generation started");
+            break;
+            
+        case RESPONSE_AUDIO_DELTA:
+            handleAudioDelta(event);
+            break;
+            
+        case RESPONSE_AUDIO_TRANSCRIPT_DELTA:
+            handleTranscriptDelta(event);
+            break;
+            
+        case RESPONSE_TEXT_DELTA:
+            handleTextDelta(event);
+            break;
+            
+        case RESPONSE_DONE:
+            System.out.println("Response complete");
+            break;
+            
+        case ERROR:
+            handleError(event);
+            break;
+            
+        default:
+            System.out.println("Event: " + eventType);
+    }
+}
+
+private void handleSessionCreated(SessionCreatedEvent event) {
+    System.out.println("Session created: " + event.getSession().getId());
+}
+
+private void handleAudioDelta(ServerEvent event) {
+    if (event instanceof ResponseAudioDeltaEvent) {
+        ResponseAudioDeltaEvent audioEvent = (ResponseAudioDeltaEvent) event;
+        byte[] audioData = audioEvent.getDelta();
+        
+        // Play audio through speakers
+        playAudio(audioData);
+    }
+}
+
+private void handleTranscriptDelta(ServerEvent event) {
+    if (event instanceof ResponseAudioTranscriptDeltaEvent) {
+        ResponseAudioTranscriptDeltaEvent transcriptEvent = (ResponseAudioTranscriptDeltaEvent) event;
+        System.out.print(transcriptEvent.getDelta());  // Print as it arrives
+    }
+}
+
+private void handleTextDelta(ServerEvent event) {
+    if (event instanceof ResponseTextDeltaEvent) {
+        ResponseTextDeltaEvent textEvent = (ResponseTextDeltaEvent) event;
+        System.out.print(textEvent.getDelta());
+    }
+}
+
+private void handleError(ServerEvent event) {
+    if (event instanceof ErrorEvent) {
+        ErrorEvent errorEvent = (ErrorEvent) event;
+        System.err.println("Error: " + errorEvent.getError().getMessage());
+    }
+}
+```
+
+### Play Audio Response
+
+```java
+import javax.sound.sampled.*;
+
+private SourceDataLine speakerLine;
+
+private void initializeSpeaker() throws LineUnavailableException {
+    AudioFormat format = new AudioFormat(24000, 16, 1, true, false);
+    DataLine.Info info = new DataLine.Info(SourceDataLine.class, format);
+    speakerLine = (SourceDataLine) AudioSystem.getLine(info);
+    speakerLine.open(format);
+    speakerLine.start();
+}
+
+private void playAudio(byte[] audioData) {
+    if (speakerLine != null) {
+        speakerLine.write(audioData, 0, audioData.length);
+    }
+}
+
+private void closeSpeaker() {
+    if (speakerLine != null) {
+        speakerLine.drain();
+        speakerLine.close();
+    }
+}
+```
+
+## Voice Configuration
+
+### OpenAI Voices
+
+```java
+// Available voices: ALLOY, ASH, BALLAD, CORAL, ECHO, SAGE, SHIMMER, VERSE
+VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+    .setVoice(BinaryData.fromObject(new OpenAIVoice(OpenAIVoiceName.ALLOY)));
+
+// Other voices
+// OpenAIVoiceName.ASH      - Warm, friendly
+// OpenAIVoiceName.BALLAD   - Expressive, dramatic
+// OpenAIVoiceName.CORAL    - Clear, professional
+// OpenAIVoiceName.ECHO     - Soft, calming
+// OpenAIVoiceName.SAGE     - Wise, measured
+// OpenAIVoiceName.SHIMMER  - Bright, energetic
+// OpenAIVoiceName.VERSE    - Neutral, versatile
+```
+
+### Azure Neural Voices
+
+```java
+// Azure Standard Voice
+AzureStandardVoice standardVoice = new AzureStandardVoice("en-US-JennyNeural");
+options.setVoice(BinaryData.fromObject(standardVoice));
+
+// Azure Custom Voice
+AzureCustomVoice customVoice = new AzureCustomVoice("myCustomVoice", "endpointId");
+options.setVoice(BinaryData.fromObject(customVoice));
+
+// Azure Personal Voice
+AzurePersonalVoice personalVoice = new AzurePersonalVoice(
+    "speakerProfileId", 
+    PersonalVoiceModels.PHOENIX_LATEST_NEURAL
+);
+options.setVoice(BinaryData.fromObject(personalVoice));
+```
+
+## Function Calling
+
+### Define Functions
+
+```java
+import java.util.Map;
+
+// Define function schema
+Map<String, Object> weatherParams = Map.of(
+    "type", "object",
+    "properties", Map.of(
+        "location", Map.of(
+            "type", "string",
+            "description", "City name, e.g., San Francisco"
+        ),
+        "unit", Map.of(
+            "type", "string",
+            "enum", new String[]{"celsius", "fahrenheit"},
+            "description", "Temperature unit"
+        )
+    ),
+    "required", new String[]{"location"}
+);
+
+VoiceLiveFunctionDefinition weatherFunction = new VoiceLiveFunctionDefinition("get_weather")
+    .setDescription("Get current weather for a location")
+    .setParameters(BinaryData.fromObject(weatherParams));
+
+// Add to session options
+VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+    .setInstructions("You are a helpful assistant with access to weather information.")
+    .setTools(Arrays.asList(weatherFunction));
+```
+
+### Handle Function Calls
+
+```java
+private void handleFunctionCall(ServerEvent event) {
+    if (event instanceof ResponseFunctionCallArgumentsDoneEvent) {
+        ResponseFunctionCallArgumentsDoneEvent funcEvent = 
+            (ResponseFunctionCallArgumentsDoneEvent) event;
+        
+        String functionName = funcEvent.getName();
+        String arguments = funcEvent.getArguments();
+        String callId = funcEvent.getCallId();
+        
+        System.out.println("Function call: " + functionName);
+        System.out.println("Arguments: " + arguments);
+        
+        // Execute function and get result
+        String result = executeFunction(functionName, arguments);
+        
+        // Send result back
+        ConversationItemFunctionCallOutput output = new ConversationItemFunctionCallOutput(
+            callId,
+            result
+        );
+        
+        session.sendEvent(new ClientEventConversationItemCreate(output))
+            .then(session.sendEvent(new ClientEventResponseCreate()))
+            .subscribe();
+    }
+}
+
+private String executeFunction(String name, String arguments) {
+    if ("get_weather".equals(name)) {
+        // Parse arguments and call weather API
+        return "{\"temperature\": 72, \"condition\": \"sunny\"}";
+    }
+    return "{\"error\": \"Unknown function\"}";
+}
+```
+
+## Error Handling
+
+### Handle Connection Errors
+
+```java
+session.receiveEvents()
+    .doOnError(error -> {
+        System.err.println("Connection error: " + error.getMessage());
+        
+        if (error instanceof java.net.SocketException) {
+            System.err.println("Network disconnected - attempting reconnect");
+            reconnect();
+        }
+    })
+    .onErrorResume(error -> {
+        // Log and continue or terminate
+        return Flux.empty();
+    })
+    .subscribe(event -> handleEvent(event));
+```
+
+### Handle API Errors
+
+```java
+private void handleError(ServerEvent event) {
+    if (event instanceof ErrorEvent) {
+        ErrorEvent errorEvent = (ErrorEvent) event;
+        ErrorDetails error = errorEvent.getError();
+        
+        System.err.println("Error type: " + error.getType());
+        System.err.println("Error message: " + error.getMessage());
+        System.err.println("Error code: " + error.getCode());
+        
+        // Handle specific errors
+        String errorType = error.getType();
+        if ("invalid_request_error".equals(errorType)) {
+            System.err.println("Invalid request - check parameters");
+        } else if ("rate_limit_error".equals(errorType)) {
+            System.err.println("Rate limited - slow down requests");
+        } else if ("server_error".equals(errorType)) {
+            System.err.println("Server error - retry later");
+        }
+    }
+}
+```
+
+## Complete Application Example
+
+```java
+import com.azure.ai.voicelive.VoiceLiveAsyncClient;
+import com.azure.ai.voicelive.VoiceLiveClientBuilder;
+import com.azure.ai.voicelive.VoiceLiveSessionAsyncClient;
+import com.azure.ai.voicelive.models.*;
+import com.azure.core.util.BinaryData;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import reactor.core.Disposable;
+
+import javax.sound.sampled.*;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class VoiceAssistant {
+    
+    private final VoiceLiveAsyncClient client;
+    private VoiceLiveSessionAsyncClient session;
+    private SourceDataLine speakerLine;
+    private TargetDataLine microphoneLine;
+    private AtomicBoolean running = new AtomicBoolean(false);
+    private CountDownLatch sessionLatch;
+    
+    public VoiceAssistant() {
+        this.client = new VoiceLiveClientBuilder()
+            .endpoint(System.getenv("AZURE_VOICELIVE_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildAsyncClient();
+    }
+    
+    public void start() throws Exception {
+        sessionLatch = new CountDownLatch(1);
+        running.set(true);
+        
+        // Initialize audio
+        initializeAudio();
+        
+        // Start session
+        client.startSession("gpt-4o-realtime-preview")
+            .doOnNext(s -> {
+                this.session = s;
+                System.out.println("Session started");
+            })
+            .flatMap(this::configureSession)
+            .subscribe(
+                session -> {
+                    // Start receiving events
+                    session.receiveEvents()
+                        .subscribe(
+                            this::handleEvent,
+                            error -> {
+                                System.err.println("Error: " + error.getMessage());
+                                stop();
+                            },
+                            () -> {
+                                System.out.println("Session ended");
+                                sessionLatch.countDown();
+                            }
+                        );
+                    
+                    // Start microphone streaming
+                    startMicrophoneStream();
+                },
+                error -> {
+                    System.err.println("Failed to start session: " + error.getMessage());
+                    sessionLatch.countDown();
+                }
+            );
+        
+        System.out.println("Voice assistant started. Speak into the microphone...");
+        System.out.println("Press Enter to stop.");
+        
+        // Wait for user to press Enter
+        System.in.read();
+        stop();
+        
+        sessionLatch.await();
+    }
+    
+    private reactor.core.publisher.Mono<VoiceLiveSessionAsyncClient> configureSession(
+            VoiceLiveSessionAsyncClient session) {
+        
+        ServerVadTurnDetection turnDetection = new ServerVadTurnDetection()
+            .setThreshold(0.5)
+            .setPrefixPaddingMs(300)
+            .setSilenceDurationMs(500)
+            .setInterruptResponse(true)
+            .setAutoTruncate(true)
+            .setCreateResponse(true);
+        
+        VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+            .setInstructions("You are a helpful voice assistant. Keep responses concise.")
+            .setVoice(BinaryData.fromObject(new OpenAIVoice(OpenAIVoiceName.ALLOY)))
+            .setModalities(Arrays.asList(InteractionModality.TEXT, InteractionModality.AUDIO))
+            .setInputAudioFormat(InputAudioFormat.PCM16)
+            .setOutputAudioFormat(OutputAudioFormat.PCM16)
+            .setInputAudioSamplingRate(24000)
+            .setInputAudioTranscription(new AudioInputTranscriptionOptions(
+                AudioInputTranscriptionOptionsModel.WHISPER_1))
+            .setTurnDetection(turnDetection);
+        
+        return session.sendEvent(new ClientEventSessionUpdate(options))
+            .thenReturn(session);
+    }
+    
+    private void initializeAudio() throws LineUnavailableException {
+        AudioFormat format = new AudioFormat(24000, 16, 1, true, false);
+        
+        // Speaker
+        DataLine.Info speakerInfo = new DataLine.Info(SourceDataLine.class, format);
+        speakerLine = (SourceDataLine) AudioSystem.getLine(speakerInfo);
+        speakerLine.open(format);
+        speakerLine.start();
+        
+        // Microphone
+        DataLine.Info micInfo = new DataLine.Info(TargetDataLine.class, format);
+        microphoneLine = (TargetDataLine) AudioSystem.getLine(micInfo);
+        microphoneLine.open(format);
+        microphoneLine.start();
+    }
+    
+    private void startMicrophoneStream() {
+        Thread micThread = new Thread(() -> {
+            byte[] buffer = new byte[4800];  // 100ms chunks
+            
+            while (running.get()) {
+                int bytesRead = microphoneLine.read(buffer, 0, buffer.length);
+                if (bytesRead > 0 && session != null) {
+                    byte[] chunk = new byte[bytesRead];
+                    System.arraycopy(buffer, 0, chunk, 0, bytesRead);
+                    session.sendInputAudio(BinaryData.fromBytes(chunk)).subscribe();
+                }
+            }
+        });
+        micThread.setDaemon(true);
+        micThread.start();
+    }
+    
+    private void handleEvent(ServerEvent event) {
+        switch (event.getType()) {
+            case INPUT_AUDIO_BUFFER_SPEECH_STARTED:
+                System.out.println("\n[You are speaking...]");
+                break;
+                
+            case INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
+                System.out.println("[Processing...]");
+                break;
+                
+            case RESPONSE_AUDIO_DELTA:
+                if (event instanceof ResponseAudioDeltaEvent) {
+                    byte[] audio = ((ResponseAudioDeltaEvent) event).getDelta();
+                    speakerLine.write(audio, 0, audio.length);
+                }
+                break;
+                
+            case RESPONSE_AUDIO_TRANSCRIPT_DELTA:
+                if (event instanceof ResponseAudioTranscriptDeltaEvent) {
+                    System.out.print(((ResponseAudioTranscriptDeltaEvent) event).getDelta());
+                }
+                break;
+                
+            case RESPONSE_DONE:
+                System.out.println("\n");
+                break;
+                
+            case ERROR:
+                if (event instanceof ErrorEvent) {
+                    System.err.println("Error: " + ((ErrorEvent) event).getError().getMessage());
+                }
+                break;
+                
+            default:
+                // Ignore other events
+                break;
+        }
+    }
+    
+    public void stop() {
+        running.set(false);
+        
+        if (microphoneLine != null) {
+            microphoneLine.stop();
+            microphoneLine.close();
+        }
+        
+        if (speakerLine != null) {
+            speakerLine.drain();
+            speakerLine.stop();
+            speakerLine.close();
+        }
+        
+        System.out.println("Voice assistant stopped");
+    }
+    
+    public static void main(String[] args) {
+        try {
+            VoiceAssistant assistant = new VoiceAssistant();
+            assistant.start();
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_VOICELIVE_ENDPOINT=https://<resource>.openai.azure.com/
+AZURE_VOICELIVE_API_KEY=<your-api-key>
+
+# For DefaultAzureCredential
+AZURE_CLIENT_ID=<service-principal-client-id>
+AZURE_CLIENT_SECRET=<service-principal-secret>
+AZURE_TENANT_ID=<tenant-id>
+```
+
+## Best Practices
+
+1. **Use async client** — VoiceLive requires reactive patterns for real-time streaming
+2. **Configure turn detection** — Tune VAD settings for natural conversation flow
+3. **Enable noise reduction** — Use `AudioNoiseReduction` for better speech recognition
+4. **Handle interruptions** — Set `setInterruptResponse(true)` for natural conversations
+5. **Use Whisper transcription** — Enable for input audio transcription
+6. **Close sessions properly** — Clean up resources when conversation ends
+7. **Buffer audio appropriately** — Send audio in ~100ms chunks for optimal latency
+8. **Implement error recovery** — Handle connection drops with reconnection logic

--- a/skills/java/identity/azure-identity/SKILL.md
+++ b/skills/java/identity/azure-identity/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: azure-identity-java
+description: Azure Identity Java SDK for authentication with Azure services. Use when implementing DefaultAzureCredential, managed identity, service principal, or any Azure authentication pattern in Java applications.
+---
+
+# Azure Identity (Java)
+
+Authenticate Java applications with Azure services using Microsoft Entra ID (Azure AD).
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.15.0</version>
+</dependency>
+```
+
+## Key Concepts
+
+| Credential | Use Case |
+|------------|----------|
+| `DefaultAzureCredential` | **Recommended** - Works in dev and production |
+| `ManagedIdentityCredential` | Azure-hosted apps (App Service, Functions, VMs) |
+| `EnvironmentCredential` | CI/CD pipelines with env vars |
+| `ClientSecretCredential` | Service principals with secret |
+| `ClientCertificateCredential` | Service principals with certificate |
+| `AzureCliCredential` | Local dev using `az login` |
+| `InteractiveBrowserCredential` | Interactive login flow |
+| `DeviceCodeCredential` | Headless device authentication |
+
+## DefaultAzureCredential (Recommended)
+
+The `DefaultAzureCredential` tries multiple authentication methods in order:
+
+1. Environment variables
+2. Workload Identity
+3. Managed Identity
+4. Azure CLI
+5. Azure PowerShell
+6. Azure Developer CLI
+
+```java
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// Simple usage
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+
+// Use with any Azure client
+BlobServiceClient blobClient = new BlobServiceClientBuilder()
+    .endpoint("https://<storage-account>.blob.core.windows.net")
+    .credential(credential)
+    .buildClient();
+
+KeyClient keyClient = new KeyClientBuilder()
+    .vaultUrl("https://<vault-name>.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### Configure DefaultAzureCredential
+
+```java
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder()
+    .managedIdentityClientId("<user-assigned-identity-client-id>")  // For user-assigned MI
+    .tenantId("<tenant-id>")                                        // Limit to specific tenant
+    .excludeEnvironmentCredential()                                 // Skip env vars
+    .excludeAzureCliCredential()                                    // Skip Azure CLI
+    .build();
+```
+
+## Managed Identity
+
+For Azure-hosted applications (App Service, Functions, AKS, VMs).
+
+```java
+import com.azure.identity.ManagedIdentityCredential;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// System-assigned managed identity
+ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+    .build();
+
+// User-assigned managed identity (by client ID)
+ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+    .clientId("<user-assigned-client-id>")
+    .build();
+
+// User-assigned managed identity (by resource ID)
+ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+    .resourceId("/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>")
+    .build();
+```
+
+## Service Principal with Secret
+
+```java
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+
+ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+    .tenantId("<tenant-id>")
+    .clientId("<client-id>")
+    .clientSecret("<client-secret>")
+    .build();
+```
+
+## Service Principal with Certificate
+
+```java
+import com.azure.identity.ClientCertificateCredential;
+import com.azure.identity.ClientCertificateCredentialBuilder;
+
+// From PEM file
+ClientCertificateCredential credential = new ClientCertificateCredentialBuilder()
+    .tenantId("<tenant-id>")
+    .clientId("<client-id>")
+    .pemCertificate("<path-to-cert.pem>")
+    .build();
+
+// From PFX file with password
+ClientCertificateCredential credential = new ClientCertificateCredentialBuilder()
+    .tenantId("<tenant-id>")
+    .clientId("<client-id>")
+    .pfxCertificate("<path-to-cert.pfx>", "<pfx-password>")
+    .build();
+
+// Send certificate chain for SNI
+ClientCertificateCredential credential = new ClientCertificateCredentialBuilder()
+    .tenantId("<tenant-id>")
+    .clientId("<client-id>")
+    .pemCertificate("<path-to-cert.pem>")
+    .sendCertificateChain(true)
+    .build();
+```
+
+## Environment Credential
+
+Reads credentials from environment variables.
+
+```java
+import com.azure.identity.EnvironmentCredential;
+import com.azure.identity.EnvironmentCredentialBuilder;
+
+EnvironmentCredential credential = new EnvironmentCredentialBuilder().build();
+```
+
+### Required Environment Variables
+
+**For service principal with secret:**
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+```
+
+**For service principal with certificate:**
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_CERTIFICATE_PATH=/path/to/cert.pem
+AZURE_CLIENT_CERTIFICATE_PASSWORD=<optional-password>
+```
+
+**For username/password:**
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_USERNAME=<username>
+AZURE_PASSWORD=<password>
+```
+
+## Azure CLI Credential
+
+For local development using `az login`.
+
+```java
+import com.azure.identity.AzureCliCredential;
+import com.azure.identity.AzureCliCredentialBuilder;
+
+AzureCliCredential credential = new AzureCliCredentialBuilder()
+    .tenantId("<tenant-id>")  // Optional: specific tenant
+    .build();
+```
+
+## Interactive Browser
+
+For desktop applications requiring user login.
+
+```java
+import com.azure.identity.InteractiveBrowserCredential;
+import com.azure.identity.InteractiveBrowserCredentialBuilder;
+
+InteractiveBrowserCredential credential = new InteractiveBrowserCredentialBuilder()
+    .clientId("<client-id>")
+    .redirectUrl("http://localhost:8080")  // Must match app registration
+    .build();
+```
+
+## Device Code
+
+For headless devices (IoT, CLI tools).
+
+```java
+import com.azure.identity.DeviceCodeCredential;
+import com.azure.identity.DeviceCodeCredentialBuilder;
+
+DeviceCodeCredential credential = new DeviceCodeCredentialBuilder()
+    .clientId("<client-id>")
+    .challengeConsumer(challenge -> {
+        // Display to user
+        System.out.println(challenge.getMessage());
+    })
+    .build();
+```
+
+## Chained Credential
+
+Create custom authentication chains.
+
+```java
+import com.azure.identity.ChainedTokenCredential;
+import com.azure.identity.ChainedTokenCredentialBuilder;
+
+ChainedTokenCredential credential = new ChainedTokenCredentialBuilder()
+    .addFirst(new ManagedIdentityCredentialBuilder().build())
+    .addLast(new AzureCliCredentialBuilder().build())
+    .build();
+```
+
+## Workload Identity (AKS)
+
+For Azure Kubernetes Service with workload identity.
+
+```java
+import com.azure.identity.WorkloadIdentityCredential;
+import com.azure.identity.WorkloadIdentityCredentialBuilder;
+
+// Reads from AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
+WorkloadIdentityCredential credential = new WorkloadIdentityCredentialBuilder().build();
+
+// Or explicit configuration
+WorkloadIdentityCredential credential = new WorkloadIdentityCredentialBuilder()
+    .tenantId("<tenant-id>")
+    .clientId("<client-id>")
+    .tokenFilePath("/var/run/secrets/azure/tokens/azure-identity-token")
+    .build();
+```
+
+## Token Caching
+
+Enable persistent token caching for better performance.
+
+```java
+// Enable token caching (in-memory by default)
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder()
+    .enableAccountIdentifierLogging()
+    .build();
+
+// With shared token cache (for multi-credential scenarios)
+SharedTokenCacheCredential credential = new SharedTokenCacheCredentialBuilder()
+    .clientId("<client-id>")
+    .build();
+```
+
+## Sovereign Clouds
+
+```java
+import com.azure.identity.AzureAuthorityHosts;
+
+// Azure Government
+DefaultAzureCredential govCredential = new DefaultAzureCredentialBuilder()
+    .authorityHost(AzureAuthorityHosts.AZURE_GOVERNMENT)
+    .build();
+
+// Azure China
+DefaultAzureCredential chinaCredential = new DefaultAzureCredentialBuilder()
+    .authorityHost(AzureAuthorityHosts.AZURE_CHINA)
+    .build();
+```
+
+## Error Handling
+
+```java
+import com.azure.identity.CredentialUnavailableException;
+import com.azure.core.exception.ClientAuthenticationException;
+
+try {
+    DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+    AccessToken token = credential.getToken(new TokenRequestContext()
+        .addScopes("https://management.azure.com/.default"));
+} catch (CredentialUnavailableException e) {
+    // No credential could authenticate
+    System.out.println("Authentication failed: " + e.getMessage());
+} catch (ClientAuthenticationException e) {
+    // Authentication error (wrong credentials, expired, etc.)
+    System.out.println("Auth error: " + e.getMessage());
+}
+```
+
+## Logging
+
+Enable authentication logging for debugging.
+
+```java
+// Via environment variable
+// AZURE_LOG_LEVEL=verbose
+
+// Or programmatically
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder()
+    .enableAccountIdentifierLogging()  // Log account info
+    .build();
+```
+
+## Environment Variables
+
+```bash
+# DefaultAzureCredential configuration
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+
+# Managed Identity
+AZURE_CLIENT_ID=<user-assigned-mi-client-id>
+
+# Workload Identity (AKS)
+AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token
+
+# Logging
+AZURE_LOG_LEVEL=verbose
+
+# Authority host
+AZURE_AUTHORITY_HOST=https://login.microsoftonline.com/
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** - Works seamlessly from dev to production
+2. **Managed Identity in Production** - No secrets to manage, automatic rotation
+3. **Azure CLI for Local Dev** - Run `az login` before running your app
+4. **Least Privilege** - Grant only required permissions to service principals
+5. **Token Caching** - Enabled by default, reduces auth round-trips
+6. **Environment Variables** - Use for CI/CD, not hardcoded secrets
+
+## Credential Selection Matrix
+
+| Environment | Recommended Credential |
+|-------------|----------------------|
+| Local Development | `DefaultAzureCredential` (uses Azure CLI) |
+| Azure App Service | `DefaultAzureCredential` (uses Managed Identity) |
+| Azure Functions | `DefaultAzureCredential` (uses Managed Identity) |
+| Azure Kubernetes Service | `WorkloadIdentityCredential` |
+| Azure VMs | `DefaultAzureCredential` (uses Managed Identity) |
+| CI/CD Pipeline | `EnvironmentCredential` |
+| Desktop App | `InteractiveBrowserCredential` |
+| CLI Tool | `DeviceCodeCredential` |
+
+## Trigger Phrases
+
+- "Azure authentication Java", "DefaultAzureCredential Java"
+- "managed identity Java", "service principal Java"
+- "Azure login Java", "Azure credentials Java"
+- "AZURE_CLIENT_ID", "AZURE_TENANT_ID"

--- a/skills/java/identity/azure-identity/references/examples.md
+++ b/skills/java/identity/azure-identity/references/examples.md
@@ -1,0 +1,506 @@
+# Azure Identity SDK for Java - Examples
+
+Comprehensive code examples for the Azure Identity SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [DefaultAzureCredential](#defaultazurecredential)
+- [ChainedTokenCredential](#chainedtokencredential)
+- [ClientSecretCredential](#clientsecretcredential)
+- [ClientCertificateCredential](#clientcertificatecredential)
+- [ManagedIdentityCredential](#managedidentitycredential)
+- [EnvironmentCredential](#environmentcredential)
+- [InteractiveBrowserCredential](#interactivebrowsercredential)
+- [DeviceCodeCredential](#devicecodecredential)
+- [AzureCliCredential](#azureclicredential)
+- [Using Credentials with Azure SDK Clients](#using-credentials-with-azure-sdk-clients)
+
+## Maven Dependency
+
+```xml
+<!-- Using Azure SDK BOM (recommended) -->
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>1.2.29</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-identity</artifactId>
+    </dependency>
+</dependencies>
+
+<!-- Or direct dependency -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.18.2</version>
+</dependency>
+```
+
+## DefaultAzureCredential
+
+The recommended credential for most scenarios. Tries multiple authentication methods in order.
+
+### Basic Usage
+
+```java
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+
+// Basic usage
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+
+// Use with Azure SDK clients
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### With User-Assigned Managed Identity
+
+```java
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder()
+    .managedIdentityClientId("<MANAGED_IDENTITY_CLIENT_ID>")
+    .build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### Authentication Order
+
+DefaultAzureCredential tries these methods in order:
+1. EnvironmentCredential
+2. WorkloadIdentityCredential
+3. ManagedIdentityCredential
+4. AzureDeveloperCliCredential
+5. IntelliJCredential
+6. AzureCliCredential
+7. AzurePowerShellCredential
+
+## ChainedTokenCredential
+
+Create a custom chain of credentials to try in sequence.
+
+### Managed Identity with Interactive Browser Fallback
+
+```java
+import com.azure.identity.ChainedTokenCredential;
+import com.azure.identity.ChainedTokenCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredential;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+import com.azure.identity.InteractiveBrowserCredential;
+import com.azure.identity.InteractiveBrowserCredentialBuilder;
+
+ManagedIdentityCredential managedIdentityCredential = new ManagedIdentityCredentialBuilder().build();
+InteractiveBrowserCredential interactiveBrowserCredential = new InteractiveBrowserCredentialBuilder()
+    .clientId(clientId)
+    .redirectUrl("https://localhost:8765")
+    .build();
+
+ChainedTokenCredential credential = new ChainedTokenCredentialBuilder()
+    .addLast(managedIdentityCredential)
+    .addLast(interactiveBrowserCredential)
+    .build();
+```
+
+### Azure CLI with IntelliJ for Development
+
+```java
+import com.azure.identity.AzureCliCredential;
+import com.azure.identity.AzureCliCredentialBuilder;
+import com.azure.identity.IntelliJCredential;
+import com.azure.identity.IntelliJCredentialBuilder;
+
+AzureCliCredential cliCredential = new AzureCliCredentialBuilder().build();
+IntelliJCredential ijCredential = new IntelliJCredentialBuilder().build();
+
+ChainedTokenCredential credential = new ChainedTokenCredentialBuilder()
+    .addLast(cliCredential)
+    .addLast(ijCredential)
+    .build();
+```
+
+## ClientSecretCredential
+
+Authenticate a service principal using a client secret.
+
+### Basic Usage
+
+```java
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+
+String tenantId = System.getenv("AZURE_TENANT_ID");
+String clientId = System.getenv("AZURE_CLIENT_ID");
+String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
+
+ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+    .tenantId(tenantId)
+    .clientId(clientId)
+    .clientSecret(clientSecret)
+    .build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### With Proxy Configuration
+
+```java
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.ProxyOptions.Type;
+import java.net.InetSocketAddress;
+
+ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+    .tenantId(tenantId)
+    .clientId(clientId)
+    .clientSecret(clientSecret)
+    .proxyOptions(new ProxyOptions(Type.HTTP, new InetSocketAddress("10.21.32.43", 5465)))
+    .build();
+```
+
+## ClientCertificateCredential
+
+Authenticate a service principal using a certificate.
+
+### Using PEM Certificate File
+
+```java
+import com.azure.identity.ClientCertificateCredential;
+import com.azure.identity.ClientCertificateCredentialBuilder;
+
+ClientCertificateCredential credential = new ClientCertificateCredentialBuilder()
+    .tenantId(tenantId)
+    .clientId(clientId)
+    .pemCertificate("<PATH-TO-PEM-CERTIFICATE>")
+    .build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### Using PFX Certificate with Password
+
+```java
+ClientCertificateCredential credential = new ClientCertificateCredentialBuilder()
+    .tenantId(tenantId)
+    .clientId(clientId)
+    .pfxCertificate("<PATH-TO-PFX-CERTIFICATE>", "P@s$w0rd")
+    .build();
+```
+
+### Using Certificate from InputStream
+
+```java
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+byte[] certificateBytes = Files.readAllBytes(Paths.get("certificate.pem"));
+ByteArrayInputStream certificateStream = new ByteArrayInputStream(certificateBytes);
+
+ClientCertificateCredential credential = new ClientCertificateCredentialBuilder()
+    .tenantId(tenantId)
+    .clientId(clientId)
+    .pemCertificate(certificateStream)
+    .build();
+```
+
+### With Proxy Configuration
+
+```java
+ClientCertificateCredential credential = new ClientCertificateCredentialBuilder()
+    .tenantId(tenantId)
+    .clientId(clientId)
+    .pfxCertificate("<PATH-TO-PFX-CERTIFICATE>", "P@s$w0rd")
+    .proxyOptions(new ProxyOptions(Type.HTTP, new InetSocketAddress("10.21.32.43", 5465)))
+    .build();
+```
+
+## ManagedIdentityCredential
+
+Authenticate using Azure managed identity (system-assigned or user-assigned).
+
+### System-Assigned Managed Identity
+
+```java
+import com.azure.identity.ManagedIdentityCredential;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// No clientId needed for system-assigned
+ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder().build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### User-Assigned Managed Identity (by Client ID)
+
+```java
+ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+    .clientId("<USER-ASSIGNED-MANAGED-IDENTITY-CLIENT-ID>")
+    .build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### User-Assigned Managed Identity (by Resource ID)
+
+```java
+ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+    .resourceId("/subscriptions/<subscriptionID>/resourcegroups/<resource-group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<MI-name>")
+    .build();
+```
+
+### User-Assigned Managed Identity (by Object ID)
+
+```java
+ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+    .objectId("<USER-ASSIGNED-MANAGED-IDENTITY-OBJECT-ID>")
+    .build();
+```
+
+## EnvironmentCredential
+
+Authenticates using environment variables. Supports service principal with secret, certificate, or username/password.
+
+### Required Environment Variables
+
+For service principal with secret:
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+```
+
+For service principal with certificate:
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_CERTIFICATE_PATH=<path-to-certificate>
+AZURE_CLIENT_CERTIFICATE_PASSWORD=<certificate-password>  # Optional
+```
+
+For username/password:
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_USERNAME=<username>
+AZURE_PASSWORD=<password>
+```
+
+### Usage
+
+```java
+import com.azure.identity.EnvironmentCredential;
+import com.azure.identity.EnvironmentCredentialBuilder;
+
+EnvironmentCredential credential = new EnvironmentCredentialBuilder().build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+## InteractiveBrowserCredential
+
+Authenticate interactively via browser. Suitable for development.
+
+```java
+import com.azure.identity.InteractiveBrowserCredential;
+import com.azure.identity.InteractiveBrowserCredentialBuilder;
+
+InteractiveBrowserCredential credential = new InteractiveBrowserCredentialBuilder()
+    .clientId("<client-id>")
+    .redirectUrl("http://localhost:8765")
+    .build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### With Tenant ID
+
+```java
+InteractiveBrowserCredential credential = new InteractiveBrowserCredentialBuilder()
+    .clientId("<client-id>")
+    .tenantId("<tenant-id>")
+    .redirectUrl("http://localhost:8765")
+    .build();
+```
+
+## DeviceCodeCredential
+
+Authenticate using device code flow. User enters code at microsoft.com/devicelogin.
+
+```java
+import com.azure.identity.DeviceCodeCredential;
+import com.azure.identity.DeviceCodeCredentialBuilder;
+
+DeviceCodeCredential credential = new DeviceCodeCredentialBuilder()
+    .clientId("<client-id>")
+    .challengeConsumer(challenge -> {
+        // Display the device code message to the user
+        System.out.println(challenge.getMessage());
+    })
+    .build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+## AzureCliCredential
+
+Authenticate using Azure CLI. User must be logged in via `az login`.
+
+```java
+import com.azure.identity.AzureCliCredential;
+import com.azure.identity.AzureCliCredentialBuilder;
+
+AzureCliCredential credential = new AzureCliCredentialBuilder().build();
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{YOUR_VAULT_NAME}.vault.azure.net")
+    .credential(credential)
+    .buildClient();
+```
+
+### With Specific Tenant
+
+```java
+AzureCliCredential credential = new AzureCliCredentialBuilder()
+    .tenantId("<tenant-id>")
+    .build();
+```
+
+## Using Credentials with Azure SDK Clients
+
+### Key Vault Secrets
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+
+SecretClient client = new SecretClientBuilder()
+    .vaultUrl("https://{vault-name}.vault.azure.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+// Use the client
+String secretValue = client.getSecret("my-secret").getValue();
+```
+
+### Blob Storage
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+
+BlobServiceClient client = new BlobServiceClientBuilder()
+    .endpoint("https://{storage-account}.blob.core.windows.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### Cosmos DB
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.CosmosClient;
+
+CosmosClient client = new CosmosClientBuilder()
+    .endpoint("https://{cosmos-account}.documents.azure.com:443/")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### Event Hubs
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.messaging.eventhubs.EventHubClientBuilder;
+import com.azure.messaging.eventhubs.EventHubProducerClient;
+
+EventHubProducerClient producer = new EventHubClientBuilder()
+    .fullyQualifiedNamespace("{namespace}.servicebus.windows.net")
+    .eventHubName("{event-hub-name}")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildProducerClient();
+```
+
+### Service Bus
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.messaging.servicebus.ServiceBusClientBuilder;
+import com.azure.messaging.servicebus.ServiceBusSenderClient;
+
+ServiceBusSenderClient sender = new ServiceBusClientBuilder()
+    .fullyQualifiedNamespace("{namespace}.servicebus.windows.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .sender()
+    .queueName("{queue-name}")
+    .buildClient();
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.ClientAuthenticationException;
+import com.azure.identity.CredentialUnavailableException;
+
+try {
+    DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+    // Use credential...
+} catch (CredentialUnavailableException e) {
+    System.err.println("No credential available: " + e.getMessage());
+} catch (ClientAuthenticationException e) {
+    System.err.println("Authentication failed: " + e.getMessage());
+}
+```
+
+## Logging and Debugging
+
+Enable logging to troubleshoot authentication issues:
+
+```java
+import com.azure.core.util.logging.ClientLogger;
+
+// Set environment variable
+// AZURE_LOG_LEVEL=verbose
+
+// Or programmatically
+System.setProperty("AZURE_LOG_LEVEL", "verbose");
+```

--- a/skills/java/integration/appconfiguration/SKILL.md
+++ b/skills/java/integration/appconfiguration/SKILL.md
@@ -1,0 +1,469 @@
+---
+name: azure-appconfiguration-java
+description: |
+  Azure App Configuration SDK for Java. Centralized application configuration management with key-value settings, feature flags, and snapshots.
+  Triggers: "ConfigurationClient java", "app configuration java", "feature flag java", "configuration setting java", "azure config java".
+---
+
+# Azure App Configuration SDK for Java
+
+Client library for Azure App Configuration, a managed service for centralizing application configurations.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-data-appconfiguration</artifactId>
+    <version>1.8.0</version>
+</dependency>
+```
+
+Or use Azure SDK BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-data-appconfiguration</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## Prerequisites
+
+- Azure App Configuration store
+- Connection string or Entra ID credentials
+
+## Environment Variables
+
+```bash
+AZURE_APPCONFIG_CONNECTION_STRING=Endpoint=https://<store>.azconfig.io;Id=<id>;Secret=<secret>
+AZURE_APPCONFIG_ENDPOINT=https://<store>.azconfig.io
+```
+
+## Client Creation
+
+### With Connection String
+
+```java
+import com.azure.data.appconfiguration.ConfigurationClient;
+import com.azure.data.appconfiguration.ConfigurationClientBuilder;
+
+ConfigurationClient configClient = new ConfigurationClientBuilder()
+    .connectionString(System.getenv("AZURE_APPCONFIG_CONNECTION_STRING"))
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.data.appconfiguration.ConfigurationAsyncClient;
+
+ConfigurationAsyncClient asyncClient = new ConfigurationClientBuilder()
+    .connectionString(connectionString)
+    .buildAsyncClient();
+```
+
+### With Entra ID (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+ConfigurationClient configClient = new ConfigurationClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(System.getenv("AZURE_APPCONFIG_ENDPOINT"))
+    .buildClient();
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Configuration Setting | Key-value pair with optional label |
+| Label | Dimension for separating settings (e.g., environments) |
+| Feature Flag | Special setting for feature management |
+| Secret Reference | Setting pointing to Key Vault secret |
+| Snapshot | Point-in-time immutable view of settings |
+
+## Configuration Setting Operations
+
+### Create Setting (Add)
+
+Creates only if setting doesn't exist:
+
+```java
+import com.azure.data.appconfiguration.models.ConfigurationSetting;
+
+ConfigurationSetting setting = configClient.addConfigurationSetting(
+    "app/database/connection", 
+    "Production", 
+    "Server=prod.db.com;Database=myapp"
+);
+```
+
+### Create or Update Setting (Set)
+
+Creates or overwrites:
+
+```java
+ConfigurationSetting setting = configClient.setConfigurationSetting(
+    "app/cache/enabled", 
+    "Production", 
+    "true"
+);
+```
+
+### Get Setting
+
+```java
+ConfigurationSetting setting = configClient.getConfigurationSetting(
+    "app/database/connection", 
+    "Production"
+);
+System.out.println("Value: " + setting.getValue());
+System.out.println("Content-Type: " + setting.getContentType());
+System.out.println("Last Modified: " + setting.getLastModified());
+```
+
+### Conditional Get (If Changed)
+
+```java
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+
+Response<ConfigurationSetting> response = configClient.getConfigurationSettingWithResponse(
+    setting,      // Setting with ETag
+    null,         // Accept datetime
+    true,         // ifChanged - only fetch if modified
+    Context.NONE
+);
+
+if (response.getStatusCode() == 304) {
+    System.out.println("Setting not modified");
+} else {
+    ConfigurationSetting updated = response.getValue();
+}
+```
+
+### Update Setting
+
+```java
+ConfigurationSetting updated = configClient.setConfigurationSetting(
+    "app/cache/enabled", 
+    "Production", 
+    "false"
+);
+```
+
+### Conditional Update (If Unchanged)
+
+```java
+// Only update if ETag matches (no concurrent modifications)
+Response<ConfigurationSetting> response = configClient.setConfigurationSettingWithResponse(
+    setting,     // Setting with current ETag
+    true,        // ifUnchanged
+    Context.NONE
+);
+```
+
+### Delete Setting
+
+```java
+ConfigurationSetting deleted = configClient.deleteConfigurationSetting(
+    "app/cache/enabled", 
+    "Production"
+);
+```
+
+### Conditional Delete
+
+```java
+Response<ConfigurationSetting> response = configClient.deleteConfigurationSettingWithResponse(
+    setting,     // Setting with ETag
+    true,        // ifUnchanged
+    Context.NONE
+);
+```
+
+## List and Filter Settings
+
+### List by Key Pattern
+
+```java
+import com.azure.data.appconfiguration.models.SettingSelector;
+import com.azure.core.http.rest.PagedIterable;
+
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("app/*");
+
+PagedIterable<ConfigurationSetting> settings = configClient.listConfigurationSettings(selector);
+for (ConfigurationSetting s : settings) {
+    System.out.println(s.getKey() + " = " + s.getValue());
+}
+```
+
+### List by Label
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("*")
+    .setLabelFilter("Production");
+
+PagedIterable<ConfigurationSetting> settings = configClient.listConfigurationSettings(selector);
+```
+
+### List by Multiple Keys
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("app/database/*,app/cache/*");
+
+PagedIterable<ConfigurationSetting> settings = configClient.listConfigurationSettings(selector);
+```
+
+### List Revisions
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("app/database/connection");
+
+PagedIterable<ConfigurationSetting> revisions = configClient.listRevisions(selector);
+for (ConfigurationSetting revision : revisions) {
+    System.out.println("Value: " + revision.getValue() + ", Modified: " + revision.getLastModified());
+}
+```
+
+## Feature Flags
+
+### Create Feature Flag
+
+```java
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting;
+import com.azure.data.appconfiguration.models.FeatureFlagFilter;
+import java.util.Arrays;
+
+FeatureFlagFilter percentageFilter = new FeatureFlagFilter("Microsoft.Percentage")
+    .addParameter("Value", 50);
+
+FeatureFlagConfigurationSetting featureFlag = new FeatureFlagConfigurationSetting("beta-feature", true)
+    .setDescription("Beta feature rollout")
+    .setClientFilters(Arrays.asList(percentageFilter));
+
+FeatureFlagConfigurationSetting created = (FeatureFlagConfigurationSetting)
+    configClient.addConfigurationSetting(featureFlag);
+```
+
+### Get Feature Flag
+
+```java
+FeatureFlagConfigurationSetting flag = (FeatureFlagConfigurationSetting)
+    configClient.getConfigurationSetting(featureFlag);
+
+System.out.println("Feature: " + flag.getFeatureId());
+System.out.println("Enabled: " + flag.isEnabled());
+System.out.println("Filters: " + flag.getClientFilters());
+```
+
+### Update Feature Flag
+
+```java
+featureFlag.setEnabled(false);
+FeatureFlagConfigurationSetting updated = (FeatureFlagConfigurationSetting)
+    configClient.setConfigurationSetting(featureFlag);
+```
+
+## Secret References
+
+### Create Secret Reference
+
+```java
+import com.azure.data.appconfiguration.models.SecretReferenceConfigurationSetting;
+
+SecretReferenceConfigurationSetting secretRef = new SecretReferenceConfigurationSetting(
+    "app/secrets/api-key",
+    "https://myvault.vault.azure.net/secrets/api-key"
+);
+
+SecretReferenceConfigurationSetting created = (SecretReferenceConfigurationSetting)
+    configClient.addConfigurationSetting(secretRef);
+```
+
+### Get Secret Reference
+
+```java
+SecretReferenceConfigurationSetting ref = (SecretReferenceConfigurationSetting)
+    configClient.getConfigurationSetting(secretRef);
+
+System.out.println("Secret URI: " + ref.getSecretId());
+```
+
+## Read-Only Settings
+
+### Set Read-Only
+
+```java
+ConfigurationSetting readOnly = configClient.setReadOnly(
+    "app/critical/setting", 
+    "Production", 
+    true
+);
+```
+
+### Clear Read-Only
+
+```java
+ConfigurationSetting writable = configClient.setReadOnly(
+    "app/critical/setting", 
+    "Production", 
+    false
+);
+```
+
+## Snapshots
+
+### Create Snapshot
+
+```java
+import com.azure.data.appconfiguration.models.ConfigurationSnapshot;
+import com.azure.data.appconfiguration.models.ConfigurationSettingsFilter;
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.core.util.polling.PollOperationDetails;
+
+List<ConfigurationSettingsFilter> filters = new ArrayList<>();
+filters.add(new ConfigurationSettingsFilter("app/*"));
+
+SyncPoller<PollOperationDetails, ConfigurationSnapshot> poller = configClient.beginCreateSnapshot(
+    "release-v1.0",
+    new ConfigurationSnapshot(filters),
+    Context.NONE
+);
+poller.setPollInterval(Duration.ofSeconds(10));
+poller.waitForCompletion();
+
+ConfigurationSnapshot snapshot = poller.getFinalResult();
+System.out.println("Snapshot: " + snapshot.getName() + ", Status: " + snapshot.getStatus());
+```
+
+### Get Snapshot
+
+```java
+ConfigurationSnapshot snapshot = configClient.getSnapshot("release-v1.0");
+System.out.println("Created: " + snapshot.getCreatedAt());
+System.out.println("Items: " + snapshot.getItemCount());
+```
+
+### List Settings in Snapshot
+
+```java
+PagedIterable<ConfigurationSetting> settings = 
+    configClient.listConfigurationSettingsForSnapshot("release-v1.0");
+
+for (ConfigurationSetting setting : settings) {
+    System.out.println(setting.getKey() + " = " + setting.getValue());
+}
+```
+
+### Archive Snapshot
+
+```java
+ConfigurationSnapshot archived = configClient.archiveSnapshot("release-v1.0");
+System.out.println("Status: " + archived.getStatus()); // archived
+```
+
+### Recover Snapshot
+
+```java
+ConfigurationSnapshot recovered = configClient.recoverSnapshot("release-v1.0");
+System.out.println("Status: " + recovered.getStatus()); // ready
+```
+
+### List All Snapshots
+
+```java
+import com.azure.data.appconfiguration.models.SnapshotSelector;
+
+SnapshotSelector selector = new SnapshotSelector().setNameFilter("release-*");
+PagedIterable<ConfigurationSnapshot> snapshots = configClient.listSnapshots(selector);
+
+for (ConfigurationSnapshot snap : snapshots) {
+    System.out.println(snap.getName() + " - " + snap.getStatus());
+}
+```
+
+## Labels
+
+### List Labels
+
+```java
+import com.azure.data.appconfiguration.models.SettingLabelSelector;
+
+configClient.listLabels(new SettingLabelSelector().setNameFilter("*"))
+    .forEach(label -> System.out.println("Label: " + label.getName()));
+```
+
+## Async Operations
+
+```java
+ConfigurationAsyncClient asyncClient = new ConfigurationClientBuilder()
+    .connectionString(connectionString)
+    .buildAsyncClient();
+
+// Async list with reactive streams
+asyncClient.listConfigurationSettings(new SettingSelector().setLabelFilter("Production"))
+    .subscribe(
+        setting -> System.out.println(setting.getKey() + " = " + setting.getValue()),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Completed")
+    );
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    configClient.getConfigurationSetting("nonexistent", null);
+} catch (HttpResponseException e) {
+    if (e.getResponse().getStatusCode() == 404) {
+        System.err.println("Setting not found");
+    } else {
+        System.err.println("Error: " + e.getMessage());
+    }
+}
+```
+
+## Best Practices
+
+1. **Use labels** — Separate configurations by environment (Dev, Staging, Production)
+2. **Use snapshots** — Create immutable snapshots for releases
+3. **Feature flags** — Use for gradual rollouts and A/B testing
+4. **Secret references** — Store sensitive values in Key Vault
+5. **Conditional requests** — Use ETags for optimistic concurrency
+6. **Read-only protection** — Lock critical production settings
+7. **Use Entra ID** — Preferred over connection strings
+8. **Async client** — Use for high-throughput scenarios
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Maven Package | https://central.sonatype.com/artifact/com.azure/azure-data-appconfiguration |
+| GitHub | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/appconfiguration/azure-data-appconfiguration |
+| API Documentation | https://aka.ms/java-docs |
+| Product Docs | https://learn.microsoft.com/azure/azure-app-configuration |
+| Samples | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/appconfiguration/azure-data-appconfiguration/src/samples |
+| Troubleshooting | https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/appconfiguration/azure-data-appconfiguration/TROUBLESHOOTING.md |

--- a/skills/java/integration/appconfiguration/references/examples.md
+++ b/skills/java/integration/appconfiguration/references/examples.md
@@ -1,0 +1,862 @@
+# Azure App Configuration Java SDK - Examples
+
+Comprehensive code examples for the Azure App Configuration SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Configuration Settings CRUD](#configuration-settings-crud)
+- [List and Filter Settings](#list-and-filter-settings)
+- [Feature Flags](#feature-flags)
+- [Secret References](#secret-references)
+- [Read-Only Settings](#read-only-settings)
+- [Snapshots](#snapshots)
+- [Labels](#labels)
+- [Async Operations](#async-operations)
+- [Error Handling](#error-handling)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-data-appconfiguration</artifactId>
+    <version>1.8.0</version>
+</dependency>
+
+<!-- For DefaultAzureCredential -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.2</version>
+</dependency>
+```
+
+Or use Azure SDK BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>1.2.28</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-data-appconfiguration</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## Client Creation
+
+### With Connection String
+
+```java
+import com.azure.data.appconfiguration.ConfigurationClient;
+import com.azure.data.appconfiguration.ConfigurationClientBuilder;
+
+String connectionString = System.getenv("AZURE_APPCONFIG_CONNECTION_STRING");
+
+ConfigurationClient client = new ConfigurationClientBuilder()
+    .connectionString(connectionString)
+    .buildClient();
+```
+
+### With Entra ID (Recommended)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+String endpoint = System.getenv("AZURE_APPCONFIG_ENDPOINT");
+
+ConfigurationClient client = new ConfigurationClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.data.appconfiguration.ConfigurationAsyncClient;
+
+ConfigurationAsyncClient asyncClient = new ConfigurationClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildAsyncClient();
+```
+
+## Configuration Settings CRUD
+
+### Create Setting (Add)
+
+Creates only if setting doesn't exist:
+
+```java
+import com.azure.data.appconfiguration.models.ConfigurationSetting;
+
+// Add with key, label, and value
+ConfigurationSetting setting = client.addConfigurationSetting(
+    "app/database/connection",    // key
+    "Production",                  // label (can be null)
+    "Server=prod.db.com;Database=myapp"  // value
+);
+
+System.out.println("Setting created:");
+System.out.println("  Key: " + setting.getKey());
+System.out.println("  Label: " + setting.getLabel());
+System.out.println("  Value: " + setting.getValue());
+System.out.println("  ETag: " + setting.getETag());
+```
+
+### Create or Update Setting (Set)
+
+Creates or overwrites:
+
+```java
+ConfigurationSetting setting = client.setConfigurationSetting(
+    "app/cache/enabled",
+    "Production",
+    "true"
+);
+
+System.out.println("Setting set: " + setting.getKey() + " = " + setting.getValue());
+```
+
+### Create with ConfigurationSetting Object
+
+```java
+ConfigurationSetting newSetting = new ConfigurationSetting()
+    .setKey("app/feature/timeout")
+    .setLabel("Production")
+    .setValue("30000")
+    .setContentType("application/json");
+
+ConfigurationSetting created = client.addConfigurationSetting(newSetting);
+```
+
+### Get Setting
+
+```java
+ConfigurationSetting setting = client.getConfigurationSetting(
+    "app/database/connection",
+    "Production"
+);
+
+System.out.println("=== Setting Details ===");
+System.out.println("Key: " + setting.getKey());
+System.out.println("Label: " + setting.getLabel());
+System.out.println("Value: " + setting.getValue());
+System.out.println("Content-Type: " + setting.getContentType());
+System.out.println("Last Modified: " + setting.getLastModified());
+System.out.println("ETag: " + setting.getETag());
+System.out.println("Read-Only: " + setting.isReadOnly());
+```
+
+### Conditional Get (If Changed)
+
+Only fetch if modified since last retrieval:
+
+```java
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+
+// First, get the setting with its ETag
+ConfigurationSetting setting = client.getConfigurationSetting("app/cache/enabled", "Production");
+
+// Later, check if it changed
+Response<ConfigurationSetting> response = client.getConfigurationSettingWithResponse(
+    setting,      // Setting with ETag
+    null,         // Accept datetime
+    true,         // ifChanged - only fetch if modified
+    Context.NONE
+);
+
+if (response.getStatusCode() == 304) {
+    System.out.println("Setting not modified since last fetch");
+} else {
+    ConfigurationSetting updated = response.getValue();
+    System.out.println("Setting was modified: " + updated.getValue());
+}
+```
+
+### Update Setting
+
+```java
+// Simple update
+ConfigurationSetting updated = client.setConfigurationSetting(
+    "app/cache/enabled",
+    "Production",
+    "false"
+);
+
+System.out.println("Updated value: " + updated.getValue());
+```
+
+### Conditional Update (If Unchanged)
+
+Only update if no concurrent modifications:
+
+```java
+// Get current setting with ETag
+ConfigurationSetting current = client.getConfigurationSetting("app/timeout", "Production");
+
+// Modify the value
+current.setValue("60000");
+
+// Update only if ETag matches (optimistic concurrency)
+Response<ConfigurationSetting> response = client.setConfigurationSettingWithResponse(
+    current,     // Setting with current ETag
+    true,        // ifUnchanged - only update if ETag matches
+    Context.NONE
+);
+
+if (response.getStatusCode() == 200) {
+    System.out.println("Update successful");
+} else {
+    System.out.println("Conflict - setting was modified by another process");
+}
+```
+
+### Delete Setting
+
+```java
+ConfigurationSetting deleted = client.deleteConfigurationSetting(
+    "app/cache/enabled",
+    "Production"
+);
+
+if (deleted != null) {
+    System.out.println("Deleted setting: " + deleted.getKey());
+}
+```
+
+### Conditional Delete
+
+```java
+Response<ConfigurationSetting> response = client.deleteConfigurationSettingWithResponse(
+    setting,     // Setting with ETag
+    true,        // ifUnchanged
+    Context.NONE
+);
+
+if (response.getStatusCode() == 200) {
+    System.out.println("Setting deleted");
+}
+```
+
+## List and Filter Settings
+
+### List All Settings
+
+```java
+import com.azure.data.appconfiguration.models.SettingSelector;
+import com.azure.core.http.rest.PagedIterable;
+
+PagedIterable<ConfigurationSetting> settings = client.listConfigurationSettings(
+    new SettingSelector()
+);
+
+System.out.println("=== All Settings ===");
+for (ConfigurationSetting s : settings) {
+    System.out.printf("%s [%s] = %s%n", s.getKey(), s.getLabel(), s.getValue());
+}
+```
+
+### List by Key Pattern
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("app/*");  // Wildcard pattern
+
+PagedIterable<ConfigurationSetting> settings = client.listConfigurationSettings(selector);
+
+for (ConfigurationSetting s : settings) {
+    System.out.println(s.getKey() + " = " + s.getValue());
+}
+```
+
+### List by Label
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("*")
+    .setLabelFilter("Production");
+
+PagedIterable<ConfigurationSetting> settings = client.listConfigurationSettings(selector);
+```
+
+### List by Multiple Keys
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("app/database/*,app/cache/*");  // Comma-separated patterns
+
+PagedIterable<ConfigurationSetting> settings = client.listConfigurationSettings(selector);
+```
+
+### List Null Labels Only
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("*")
+    .setLabelFilter("\0");  // Null label filter
+
+PagedIterable<ConfigurationSetting> settings = client.listConfigurationSettings(selector);
+```
+
+### Select Specific Fields
+
+```java
+import com.azure.data.appconfiguration.models.SettingFields;
+import java.util.EnumSet;
+
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("*")
+    .setFields(EnumSet.of(SettingFields.KEY, SettingFields.VALUE, SettingFields.LAST_MODIFIED));
+
+PagedIterable<ConfigurationSetting> settings = client.listConfigurationSettings(selector);
+```
+
+### List Revisions
+
+View history of changes:
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter("app/database/connection");
+
+PagedIterable<ConfigurationSetting> revisions = client.listRevisions(selector);
+
+System.out.println("=== Setting Revisions ===");
+for (ConfigurationSetting revision : revisions) {
+    System.out.printf("Value: %s, Modified: %s%n",
+        revision.getValue(),
+        revision.getLastModified());
+}
+```
+
+## Feature Flags
+
+### Create Feature Flag
+
+```java
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting;
+import com.azure.data.appconfiguration.models.FeatureFlagFilter;
+import java.util.Arrays;
+
+// Simple feature flag
+FeatureFlagConfigurationSetting simpleFlag = new FeatureFlagConfigurationSetting("dark-mode", true)
+    .setDescription("Enable dark mode theme");
+
+client.addConfigurationSetting(simpleFlag);
+
+// Feature flag with percentage filter
+FeatureFlagFilter percentageFilter = new FeatureFlagFilter("Microsoft.Percentage")
+    .addParameter("Value", 50);  // 50% rollout
+
+FeatureFlagConfigurationSetting betaFlag = new FeatureFlagConfigurationSetting("beta-feature", true)
+    .setDescription("Beta feature with gradual rollout")
+    .setClientFilters(Arrays.asList(percentageFilter));
+
+FeatureFlagConfigurationSetting created = (FeatureFlagConfigurationSetting)
+    client.addConfigurationSetting(betaFlag);
+
+System.out.println("Feature flag created: " + created.getFeatureId());
+```
+
+### Create Feature Flag with Targeting Filter
+
+```java
+import java.util.HashMap;
+import java.util.Map;
+
+Map<String, Object> targetingParams = new HashMap<>();
+targetingParams.put("Audience", Map.of(
+    "Users", Arrays.asList("user1@example.com", "user2@example.com"),
+    "Groups", Arrays.asList(
+        Map.of("Name", "beta-testers", "RolloutPercentage", 100),
+        Map.of("Name", "employees", "RolloutPercentage", 50)
+    ),
+    "DefaultRolloutPercentage", 10
+));
+
+FeatureFlagFilter targetingFilter = new FeatureFlagFilter("Microsoft.Targeting")
+    .setParameters(targetingParams);
+
+FeatureFlagConfigurationSetting targetedFlag = new FeatureFlagConfigurationSetting("new-dashboard", true)
+    .setDescription("New dashboard with targeted rollout")
+    .setClientFilters(Arrays.asList(targetingFilter));
+
+client.addConfigurationSetting(targetedFlag);
+```
+
+### Get Feature Flag
+
+```java
+FeatureFlagConfigurationSetting flag = (FeatureFlagConfigurationSetting)
+    client.getConfigurationSetting(
+        ".appconfig.featureflag/beta-feature",  // Key format for feature flags
+        null
+    );
+
+System.out.println("=== Feature Flag ===");
+System.out.println("Feature ID: " + flag.getFeatureId());
+System.out.println("Enabled: " + flag.isEnabled());
+System.out.println("Description: " + flag.getDescription());
+System.out.println("Filters: " + flag.getClientFilters());
+```
+
+### Update Feature Flag
+
+```java
+FeatureFlagConfigurationSetting flag = (FeatureFlagConfigurationSetting)
+    client.getConfigurationSetting(".appconfig.featureflag/beta-feature", null);
+
+// Disable the feature
+flag.setEnabled(false);
+
+FeatureFlagConfigurationSetting updated = (FeatureFlagConfigurationSetting)
+    client.setConfigurationSetting(flag);
+
+System.out.println("Feature flag updated. Enabled: " + updated.isEnabled());
+```
+
+### List Feature Flags
+
+```java
+SettingSelector selector = new SettingSelector()
+    .setKeyFilter(".appconfig.featureflag/*");
+
+PagedIterable<ConfigurationSetting> flags = client.listConfigurationSettings(selector);
+
+System.out.println("=== Feature Flags ===");
+for (ConfigurationSetting setting : flags) {
+    if (setting instanceof FeatureFlagConfigurationSetting) {
+        FeatureFlagConfigurationSetting flag = (FeatureFlagConfigurationSetting) setting;
+        System.out.printf("%s: %s%n", flag.getFeatureId(), flag.isEnabled() ? "ON" : "OFF");
+    }
+}
+```
+
+## Secret References
+
+### Create Secret Reference
+
+```java
+import com.azure.data.appconfiguration.models.SecretReferenceConfigurationSetting;
+
+SecretReferenceConfigurationSetting secretRef = new SecretReferenceConfigurationSetting(
+    "app/secrets/api-key",                                    // Key
+    "https://myvault.vault.azure.net/secrets/api-key"        // Key Vault secret URI
+);
+
+SecretReferenceConfigurationSetting created = (SecretReferenceConfigurationSetting)
+    client.addConfigurationSetting(secretRef);
+
+System.out.println("Secret reference created: " + created.getKey());
+System.out.println("Points to: " + created.getSecretId());
+```
+
+### Get Secret Reference
+
+```java
+SecretReferenceConfigurationSetting ref = (SecretReferenceConfigurationSetting)
+    client.getConfigurationSetting("app/secrets/api-key", null);
+
+System.out.println("Secret URI: " + ref.getSecretId());
+
+// To get the actual secret value, use Key Vault SDK
+// SecretClient kvClient = new SecretClientBuilder()...
+// KeyVaultSecret secret = kvClient.getSecret("api-key");
+```
+
+### Update Secret Reference
+
+```java
+SecretReferenceConfigurationSetting ref = (SecretReferenceConfigurationSetting)
+    client.getConfigurationSetting("app/secrets/api-key", null);
+
+// Point to a different secret version
+ref.setSecretId("https://myvault.vault.azure.net/secrets/api-key/abc123");
+
+client.setConfigurationSetting(ref);
+```
+
+## Read-Only Settings
+
+### Set Read-Only
+
+```java
+ConfigurationSetting readOnly = client.setReadOnly(
+    "app/critical/setting",
+    "Production",
+    true  // isReadOnly
+);
+
+System.out.println("Setting is now read-only: " + readOnly.isReadOnly());
+```
+
+### Clear Read-Only
+
+```java
+ConfigurationSetting writable = client.setReadOnly(
+    "app/critical/setting",
+    "Production",
+    false  // make writable
+);
+
+System.out.println("Setting is writable: " + !writable.isReadOnly());
+```
+
+## Snapshots
+
+### Create Snapshot
+
+```java
+import com.azure.data.appconfiguration.models.ConfigurationSnapshot;
+import com.azure.data.appconfiguration.models.ConfigurationSettingsFilter;
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.core.util.polling.PollOperationDetails;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+List<ConfigurationSettingsFilter> filters = new ArrayList<>();
+filters.add(new ConfigurationSettingsFilter("app/*"));  // Include all app/* keys
+
+SyncPoller<PollOperationDetails, ConfigurationSnapshot> poller = client.beginCreateSnapshot(
+    "release-v1.0",
+    new ConfigurationSnapshot(filters),
+    Context.NONE
+);
+
+poller.setPollInterval(Duration.ofSeconds(10));
+poller.waitForCompletion();
+
+ConfigurationSnapshot snapshot = poller.getFinalResult();
+
+System.out.println("=== Snapshot Created ===");
+System.out.println("Name: " + snapshot.getName());
+System.out.println("Status: " + snapshot.getStatus());
+System.out.println("Item Count: " + snapshot.getItemCount());
+System.out.println("Size: " + snapshot.getSizeInBytes() + " bytes");
+System.out.println("Created: " + snapshot.getCreatedAt());
+```
+
+### Get Snapshot
+
+```java
+ConfigurationSnapshot snapshot = client.getSnapshot("release-v1.0");
+
+System.out.println("Snapshot: " + snapshot.getName());
+System.out.println("Status: " + snapshot.getStatus());
+System.out.println("Items: " + snapshot.getItemCount());
+System.out.println("Retention: " + snapshot.getRetentionPeriod());
+```
+
+### List Settings in Snapshot
+
+```java
+PagedIterable<ConfigurationSetting> settings = 
+    client.listConfigurationSettingsForSnapshot("release-v1.0");
+
+System.out.println("=== Settings in Snapshot ===");
+for (ConfigurationSetting setting : settings) {
+    System.out.printf("%s = %s%n", setting.getKey(), setting.getValue());
+}
+```
+
+### Archive Snapshot
+
+```java
+ConfigurationSnapshot archived = client.archiveSnapshot("release-v1.0");
+System.out.println("Status: " + archived.getStatus());  // archived
+```
+
+### Recover Snapshot
+
+```java
+ConfigurationSnapshot recovered = client.recoverSnapshot("release-v1.0");
+System.out.println("Status: " + recovered.getStatus());  // ready
+```
+
+### List All Snapshots
+
+```java
+import com.azure.data.appconfiguration.models.SnapshotSelector;
+
+SnapshotSelector selector = new SnapshotSelector()
+    .setNameFilter("release-*");
+
+PagedIterable<ConfigurationSnapshot> snapshots = client.listSnapshots(selector);
+
+System.out.println("=== Snapshots ===");
+for (ConfigurationSnapshot snap : snapshots) {
+    System.out.printf("%s - %s (%d items)%n",
+        snap.getName(),
+        snap.getStatus(),
+        snap.getItemCount());
+}
+```
+
+## Labels
+
+### List Labels
+
+```java
+import com.azure.data.appconfiguration.models.SettingLabelSelector;
+
+PagedIterable<SettingLabel> labels = client.listLabels(
+    new SettingLabelSelector().setNameFilter("*")
+);
+
+System.out.println("=== Labels ===");
+for (SettingLabel label : labels) {
+    System.out.println("Label: " + (label.getName() == null ? "(null)" : label.getName()));
+}
+```
+
+## Async Operations
+
+### Async List with Reactive Streams
+
+```java
+ConfigurationAsyncClient asyncClient = new ConfigurationClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(endpoint)
+    .buildAsyncClient();
+
+asyncClient.listConfigurationSettings(new SettingSelector().setLabelFilter("Production"))
+    .subscribe(
+        setting -> System.out.println(setting.getKey() + " = " + setting.getValue()),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Completed listing")
+    );
+
+// Keep application running for async operations
+Thread.sleep(5000);
+```
+
+### Async Get and Set
+
+```java
+asyncClient.getConfigurationSetting("app/timeout", "Production")
+    .flatMap(setting -> {
+        setting.setValue("45000");
+        return asyncClient.setConfigurationSetting(setting);
+    })
+    .subscribe(
+        updated -> System.out.println("Updated: " + updated.getValue()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.exception.ResourceNotFoundException;
+
+try {
+    ConfigurationSetting setting = client.getConfigurationSetting("nonexistent", null);
+} catch (ResourceNotFoundException e) {
+    System.err.println("Setting not found");
+} catch (HttpResponseException e) {
+    int statusCode = e.getResponse().getStatusCode();
+    
+    switch (statusCode) {
+        case 401:
+            System.err.println("Unauthorized - check credentials");
+            break;
+        case 403:
+            System.err.println("Forbidden - check permissions");
+            break;
+        case 409:
+            System.err.println("Conflict - setting already exists or ETag mismatch");
+            break;
+        case 412:
+            System.err.println("Precondition failed - setting was modified");
+            break;
+        case 429:
+            System.err.println("Rate limited - retry with backoff");
+            break;
+        default:
+            System.err.println("Error: " + e.getMessage());
+    }
+}
+```
+
+## Complete Application Example
+
+```java
+import com.azure.data.appconfiguration.ConfigurationClient;
+import com.azure.data.appconfiguration.ConfigurationClientBuilder;
+import com.azure.data.appconfiguration.models.*;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.util.*;
+
+public class AppConfigurationManager {
+    
+    private final ConfigurationClient client;
+    private final String environment;
+    
+    public AppConfigurationManager(String environment) {
+        this.client = new ConfigurationClientBuilder()
+            .endpoint(System.getenv("AZURE_APPCONFIG_ENDPOINT"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+        this.environment = environment;
+    }
+    
+    public String getSetting(String key) {
+        try {
+            ConfigurationSetting setting = client.getConfigurationSetting(key, environment);
+            return setting.getValue();
+        } catch (Exception e) {
+            // Try without label
+            try {
+                ConfigurationSetting setting = client.getConfigurationSetting(key, null);
+                return setting.getValue();
+            } catch (Exception ex) {
+                return null;
+            }
+        }
+    }
+    
+    public void setSetting(String key, String value) {
+        client.setConfigurationSetting(key, environment, value);
+    }
+    
+    public boolean isFeatureEnabled(String featureId) {
+        try {
+            String key = ".appconfig.featureflag/" + featureId;
+            ConfigurationSetting setting = client.getConfigurationSetting(key, environment);
+            
+            if (setting instanceof FeatureFlagConfigurationSetting) {
+                return ((FeatureFlagConfigurationSetting) setting).isEnabled();
+            }
+            
+            // Try without label
+            setting = client.getConfigurationSetting(key, null);
+            if (setting instanceof FeatureFlagConfigurationSetting) {
+                return ((FeatureFlagConfigurationSetting) setting).isEnabled();
+            }
+        } catch (Exception e) {
+            // Feature flag doesn't exist - default to disabled
+        }
+        return false;
+    }
+    
+    public void setFeatureEnabled(String featureId, boolean enabled) {
+        String key = ".appconfig.featureflag/" + featureId;
+        
+        try {
+            FeatureFlagConfigurationSetting flag = (FeatureFlagConfigurationSetting)
+                client.getConfigurationSetting(key, environment);
+            flag.setEnabled(enabled);
+            client.setConfigurationSetting(flag);
+        } catch (Exception e) {
+            // Create new feature flag
+            FeatureFlagConfigurationSetting newFlag = new FeatureFlagConfigurationSetting(featureId, enabled);
+            newFlag.setLabel(environment);
+            client.addConfigurationSetting(newFlag);
+        }
+    }
+    
+    public Map<String, String> getAllSettings(String prefix) {
+        Map<String, String> result = new HashMap<>();
+        
+        SettingSelector selector = new SettingSelector()
+            .setKeyFilter(prefix + "*")
+            .setLabelFilter(environment);
+        
+        PagedIterable<ConfigurationSetting> settings = client.listConfigurationSettings(selector);
+        
+        for (ConfigurationSetting setting : settings) {
+            if (!(setting instanceof FeatureFlagConfigurationSetting) 
+                && !(setting instanceof SecretReferenceConfigurationSetting)) {
+                result.put(setting.getKey(), setting.getValue());
+            }
+        }
+        
+        return result;
+    }
+    
+    public void createSnapshot(String snapshotName, String keyPrefix) {
+        List<ConfigurationSettingsFilter> filters = new ArrayList<>();
+        filters.add(new ConfigurationSettingsFilter(keyPrefix + "*")
+            .setLabel(environment));
+        
+        var poller = client.beginCreateSnapshot(snapshotName, new ConfigurationSnapshot(filters), null);
+        poller.waitForCompletion();
+        
+        ConfigurationSnapshot snapshot = poller.getFinalResult();
+        System.out.printf("Snapshot '%s' created with %d items%n", 
+            snapshot.getName(), snapshot.getItemCount());
+    }
+    
+    public static void main(String[] args) {
+        AppConfigurationManager config = new AppConfigurationManager("Production");
+        
+        // Set some configuration
+        config.setSetting("app/database/timeout", "30000");
+        config.setSetting("app/cache/ttl", "3600");
+        
+        // Get configuration
+        String timeout = config.getSetting("app/database/timeout");
+        System.out.println("Database timeout: " + timeout);
+        
+        // Feature flags
+        config.setFeatureEnabled("dark-mode", true);
+        
+        if (config.isFeatureEnabled("dark-mode")) {
+            System.out.println("Dark mode is enabled");
+        }
+        
+        // Get all app settings
+        Map<String, String> appSettings = config.getAllSettings("app/");
+        System.out.println("\n=== All App Settings ===");
+        appSettings.forEach((key, value) -> 
+            System.out.printf("%s = %s%n", key, value));
+        
+        // Create a snapshot for release
+        config.createSnapshot("release-" + System.currentTimeMillis(), "app/");
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_APPCONFIG_CONNECTION_STRING=Endpoint=https://<store>.azconfig.io;Id=<id>;Secret=<secret>
+AZURE_APPCONFIG_ENDPOINT=https://<store>.azconfig.io
+
+# For DefaultAzureCredential
+AZURE_CLIENT_ID=<service-principal-client-id>
+AZURE_CLIENT_SECRET=<service-principal-secret>
+AZURE_TENANT_ID=<tenant-id>
+```
+
+## Best Practices
+
+1. **Use labels** — Separate configurations by environment (Dev, Staging, Production)
+2. **Use snapshots** — Create immutable snapshots for releases
+3. **Feature flags** — Use for gradual rollouts and A/B testing
+4. **Secret references** — Store sensitive values in Key Vault, not App Configuration
+5. **Conditional requests** — Use ETags for optimistic concurrency
+6. **Read-only protection** — Lock critical production settings
+7. **Use Entra ID** — Preferred over connection strings for security
+8. **Async client** — Use for high-throughput scenarios

--- a/skills/java/messaging/eventgrid/SKILL.md
+++ b/skills/java/messaging/eventgrid/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: azure-messaging-eventgrid-java
+description: Build event-driven applications with Azure Event Grid SDK for Java. Use when publishing events, implementing pub/sub patterns, or integrating with Azure services via events.
+---
+
+# Azure Event Grid SDK for Java
+
+Build event-driven applications using the Azure Event Grid SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-eventgrid</artifactId>
+    <version>4.27.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### EventGridPublisherClient
+
+```java
+import com.azure.messaging.eventgrid.EventGridPublisherClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+// With API Key
+EventGridPublisherClient<EventGridEvent> client = new EventGridPublisherClientBuilder()
+    .endpoint("<topic-endpoint>")
+    .credential(new AzureKeyCredential("<access-key>"))
+    .buildEventGridEventPublisherClient();
+
+// For CloudEvents
+EventGridPublisherClient<CloudEvent> cloudClient = new EventGridPublisherClientBuilder()
+    .endpoint("<topic-endpoint>")
+    .credential(new AzureKeyCredential("<access-key>"))
+    .buildCloudEventPublisherClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+EventGridPublisherClient<EventGridEvent> client = new EventGridPublisherClientBuilder()
+    .endpoint("<topic-endpoint>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildEventGridEventPublisherClient();
+```
+
+### Async Client
+
+```java
+import com.azure.messaging.eventgrid.EventGridPublisherAsyncClient;
+
+EventGridPublisherAsyncClient<EventGridEvent> asyncClient = new EventGridPublisherClientBuilder()
+    .endpoint("<topic-endpoint>")
+    .credential(new AzureKeyCredential("<access-key>"))
+    .buildEventGridEventPublisherAsyncClient();
+```
+
+## Event Types
+
+| Type | Description |
+|------|-------------|
+| `EventGridEvent` | Azure Event Grid native schema |
+| `CloudEvent` | CNCF CloudEvents 1.0 specification |
+| `BinaryData` | Custom schema events |
+
+## Core Patterns
+
+### Publish EventGridEvent
+
+```java
+import com.azure.messaging.eventgrid.EventGridEvent;
+import com.azure.core.util.BinaryData;
+
+EventGridEvent event = new EventGridEvent(
+    "resource/path",           // subject
+    "MyApp.Events.OrderCreated", // eventType
+    BinaryData.fromObject(new OrderData("order-123", 99.99)), // data
+    "1.0"                      // dataVersion
+);
+
+client.sendEvent(event);
+```
+
+### Publish Multiple Events
+
+```java
+List<EventGridEvent> events = Arrays.asList(
+    new EventGridEvent("orders/1", "Order.Created", 
+        BinaryData.fromObject(order1), "1.0"),
+    new EventGridEvent("orders/2", "Order.Created", 
+        BinaryData.fromObject(order2), "1.0")
+);
+
+client.sendEvents(events);
+```
+
+### Publish CloudEvent
+
+```java
+import com.azure.core.models.CloudEvent;
+import com.azure.core.models.CloudEventDataFormat;
+
+CloudEvent cloudEvent = new CloudEvent(
+    "/myapp/orders",           // source
+    "order.created",           // type
+    BinaryData.fromObject(orderData), // data
+    CloudEventDataFormat.JSON  // dataFormat
+);
+cloudEvent.setSubject("orders/12345");
+cloudEvent.setId(UUID.randomUUID().toString());
+
+cloudClient.sendEvent(cloudEvent);
+```
+
+### Publish CloudEvents Batch
+
+```java
+List<CloudEvent> cloudEvents = Arrays.asList(
+    new CloudEvent("/app", "event.type1", BinaryData.fromString("data1"), CloudEventDataFormat.JSON),
+    new CloudEvent("/app", "event.type2", BinaryData.fromString("data2"), CloudEventDataFormat.JSON)
+);
+
+cloudClient.sendEvents(cloudEvents);
+```
+
+### Async Publishing
+
+```java
+asyncClient.sendEvent(event)
+    .subscribe(
+        unused -> System.out.println("Event sent successfully"),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+
+// With multiple events
+asyncClient.sendEvents(events)
+    .doOnSuccess(unused -> System.out.println("All events sent"))
+    .doOnError(error -> System.err.println("Failed: " + error))
+    .block(); // Block if needed
+```
+
+### Custom Event Data Class
+
+```java
+public class OrderData {
+    private String orderId;
+    private double amount;
+    private String customerId;
+    
+    public OrderData(String orderId, double amount) {
+        this.orderId = orderId;
+        this.amount = amount;
+    }
+    
+    // Getters and setters
+}
+
+// Usage
+OrderData order = new OrderData("ORD-123", 150.00);
+EventGridEvent event = new EventGridEvent(
+    "orders/" + order.getOrderId(),
+    "MyApp.Order.Created",
+    BinaryData.fromObject(order),
+    "1.0"
+);
+```
+
+## Receiving Events
+
+### Parse EventGridEvent
+
+```java
+import com.azure.messaging.eventgrid.EventGridEvent;
+
+// From JSON string (e.g., webhook payload)
+String jsonPayload = "[{\"id\": \"...\", ...}]";
+List<EventGridEvent> events = EventGridEvent.fromString(jsonPayload);
+
+for (EventGridEvent event : events) {
+    System.out.println("Event Type: " + event.getEventType());
+    System.out.println("Subject: " + event.getSubject());
+    System.out.println("Event Time: " + event.getEventTime());
+    
+    // Get data
+    BinaryData data = event.getData();
+    OrderData orderData = data.toObject(OrderData.class);
+}
+```
+
+### Parse CloudEvent
+
+```java
+import com.azure.core.models.CloudEvent;
+
+String cloudEventJson = "[{\"specversion\": \"1.0\", ...}]";
+List<CloudEvent> cloudEvents = CloudEvent.fromString(cloudEventJson);
+
+for (CloudEvent event : cloudEvents) {
+    System.out.println("Type: " + event.getType());
+    System.out.println("Source: " + event.getSource());
+    System.out.println("ID: " + event.getId());
+    
+    MyEventData data = event.getData().toObject(MyEventData.class);
+}
+```
+
+### Handle System Events
+
+```java
+import com.azure.messaging.eventgrid.systemevents.*;
+
+for (EventGridEvent event : events) {
+    if (event.getEventType().equals("Microsoft.Storage.BlobCreated")) {
+        StorageBlobCreatedEventData blobData = 
+            event.getData().toObject(StorageBlobCreatedEventData.class);
+        System.out.println("Blob URL: " + blobData.getUrl());
+    }
+}
+```
+
+## Event Grid Namespaces (MQTT/Pull)
+
+### Receive from Namespace Topic
+
+```java
+import com.azure.messaging.eventgrid.namespaces.EventGridReceiverClient;
+import com.azure.messaging.eventgrid.namespaces.EventGridReceiverClientBuilder;
+import com.azure.messaging.eventgrid.namespaces.models.*;
+
+EventGridReceiverClient receiverClient = new EventGridReceiverClientBuilder()
+    .endpoint("<namespace-endpoint>")
+    .credential(new AzureKeyCredential("<key>"))
+    .topicName("my-topic")
+    .subscriptionName("my-subscription")
+    .buildClient();
+
+// Receive events
+ReceiveResult result = receiverClient.receive(10, Duration.ofSeconds(30));
+
+for (ReceiveDetails detail : result.getValue()) {
+    CloudEvent event = detail.getEvent();
+    System.out.println("Event: " + event.getType());
+    
+    // Acknowledge the event
+    receiverClient.acknowledge(Arrays.asList(detail.getBrokerProperties().getLockToken()));
+}
+```
+
+### Reject or Release Events
+
+```java
+// Reject (don't retry)
+receiverClient.reject(Arrays.asList(lockToken));
+
+// Release (retry later)
+receiverClient.release(Arrays.asList(lockToken));
+
+// Release with delay
+receiverClient.release(Arrays.asList(lockToken), 
+    new ReleaseOptions().setDelay(ReleaseDelay.BY_60_SECONDS));
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    client.sendEvent(event);
+} catch (HttpResponseException e) {
+    System.out.println("Status: " + e.getResponse().getStatusCode());
+    System.out.println("Error: " + e.getMessage());
+}
+```
+
+## Environment Variables
+
+```bash
+EVENT_GRID_TOPIC_ENDPOINT=https://<topic-name>.<region>.eventgrid.azure.net/api/events
+EVENT_GRID_ACCESS_KEY=<your-access-key>
+```
+
+## Best Practices
+
+1. **Batch Events**: Send multiple events in one call when possible
+2. **Idempotency**: Include unique event IDs for deduplication
+3. **Schema Validation**: Use strongly-typed event data classes
+4. **Retry Logic**: Built-in, but consider dead-letter for failures
+5. **Event Size**: Keep events under 1MB (64KB for basic tier)
+
+## Trigger Phrases
+
+- "Event Grid Java"
+- "publish events Azure"
+- "CloudEvent SDK"
+- "event-driven messaging"
+- "pub/sub Azure"
+- "webhook events"

--- a/skills/java/messaging/eventgrid/references/examples.md
+++ b/skills/java/messaging/eventgrid/references/examples.md
@@ -1,0 +1,391 @@
+# Azure Event Grid SDK for Java - Examples
+
+Comprehensive code examples for the Azure Event Grid SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Publishing CloudEvents](#publishing-cloudevents)
+- [Publishing EventGridEvents](#publishing-eventgridevents)
+- [Publishing Custom Events](#publishing-custom-events)
+- [Async Client Patterns](#async-client-patterns)
+- [Batch Publishing](#batch-publishing)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-eventgrid</artifactId>
+    <version>4.32.0-beta.1</version>
+</dependency>
+
+<!-- For DefaultAzureCredential authentication -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.18.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### Sync Client with DefaultAzureCredential
+
+```java
+import com.azure.core.models.CloudEvent;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.messaging.eventgrid.EventGridPublisherClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+
+EventGridPublisherClient<CloudEvent> cloudEventClient = new EventGridPublisherClientBuilder()
+    .endpoint("<endpoint of your event grid topic/domain that accepts CloudEvent schema>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildCloudEventPublisherClient();
+```
+
+### Async Client with DefaultAzureCredential
+
+```java
+import com.azure.messaging.eventgrid.EventGridPublisherAsyncClient;
+
+EventGridPublisherAsyncClient<CloudEvent> cloudEventAsyncClient = new EventGridPublisherClientBuilder()
+    .endpoint("<endpoint of your event grid topic/domain that accepts CloudEvent schema>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildCloudEventPublisherAsyncClient();
+```
+
+### Client with AzureKeyCredential
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+
+EventGridPublisherClient<CloudEvent> client = new EventGridPublisherClientBuilder()
+    .endpoint(System.getenv("AZURE_EVENTGRID_CLOUDEVENT_ENDPOINT"))
+    .credential(new AzureKeyCredential(System.getenv("AZURE_EVENTGRID_CLOUDEVENT_KEY")))
+    .buildCloudEventPublisherClient();
+```
+
+## Publishing CloudEvents
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.models.CloudEvent;
+import com.azure.core.models.CloudEventDataFormat;
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridPublisherClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishCloudEventsToTopic {
+    public static void main(String[] args) {
+        EventGridPublisherClient<CloudEvent> publisherClient = new EventGridPublisherClientBuilder()
+            .endpoint(System.getenv("AZURE_EVENTGRID_CLOUDEVENT_ENDPOINT"))
+            .credential(new AzureKeyCredential(System.getenv("AZURE_EVENTGRID_CLOUDEVENT_KEY")))
+            .buildCloudEventPublisherClient();
+
+        // CloudEvent with String data
+        String str = "FirstName: John1, LastName:James";
+        CloudEvent cloudEventStr = new CloudEvent("https://com.example.myapp", "User.Created.Text",
+            BinaryData.fromObject(str), CloudEventDataFormat.JSON, "text/plain");
+
+        // CloudEvent with Object data
+        User newUser = new User("John2", "James");
+        CloudEvent cloudEventModel = new CloudEvent("https://com.example.myapp", "User.Created.Object",
+            BinaryData.fromObject(newUser), CloudEventDataFormat.JSON, "application/json");
+        
+        // CloudEvent with bytes data
+        byte[] byteSample = "FirstName: John3, LastName: James".getBytes(StandardCharsets.UTF_8);
+        CloudEvent cloudEventBytes = new CloudEvent("https://com.example.myapp", "User.Created.Binary",
+            BinaryData.fromBytes(byteSample), CloudEventDataFormat.BYTES, "application/octet-stream");
+
+        // CloudEvent with extension attributes
+        CloudEvent cloudEventWithExtension = cloudEventBytes.addExtensionAttribute("extension", "value");
+
+        // Send batch
+        List<CloudEvent> events = new ArrayList<>();
+        events.add(cloudEventStr);
+        events.add(cloudEventModel);
+        events.add(cloudEventBytes);
+        events.add(cloudEventWithExtension);
+        
+        publisherClient.sendEvents(events);
+    }
+}
+```
+
+## Publishing EventGridEvents
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridEvent;
+import com.azure.messaging.eventgrid.EventGridPublisherClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishEventGridEventsToTopic {
+    public static void main(String[] args) {
+        EventGridPublisherClient<EventGridEvent> publisherClient = new EventGridPublisherClientBuilder()
+            .endpoint(System.getenv("AZURE_EVENTGRID_EVENT_ENDPOINT"))
+            .credential(new AzureKeyCredential(System.getenv("AZURE_EVENTGRID_EVENT_KEY")))
+            .buildEventGridEventPublisherClient();
+
+        // EventGridEvent with String data
+        String str = "FirstName: John1, LastName: James";
+        EventGridEvent eventJson = new EventGridEvent(
+            "com/example/MyApp",           // subject
+            "User.Created.Text",           // eventType
+            BinaryData.fromObject(str),    // data
+            "0.1"                          // dataVersion
+        );
+        
+        // EventGridEvent with Object data
+        User newUser = new User("John2", "James");
+        EventGridEvent eventModelClass = new EventGridEvent(
+            "com/example/MyApp",
+            "User.Created.Object",
+            BinaryData.fromObject(newUser),
+            "0.1"
+        );
+
+        List<EventGridEvent> events = new ArrayList<>();
+        events.add(eventJson);
+        events.add(eventModelClass);
+
+        publisherClient.sendEvents(events);
+    }
+}
+```
+
+## Publishing Custom Events
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridPublisherClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+public class PublishCustomEvents {
+    public static void main(String[] args) {
+        // Create custom event publisher client
+        EventGridPublisherClient<BinaryData> customEventClient = new EventGridPublisherClientBuilder()
+            .endpoint("<endpoint of your event grid topic/domain that accepts custom event schema>")
+            .credential(new AzureKeyCredential("<key for the endpoint>"))
+            .buildCustomEventPublisherClient();
+
+        // Build custom event as a map
+        List<BinaryData> events = new ArrayList<>();
+        events.add(BinaryData.fromObject(new HashMap<String, String>() {
+            {
+                put("id", UUID.randomUUID().toString());
+                put("time", OffsetDateTime.now().toString());
+                put("subject", "Test");
+                put("foo", "bar");
+                put("type", "Microsoft.MockPublisher.TestEvent");
+                put("data", "example data");
+                put("dataVersion", "0.1");
+            }
+        }));
+        
+        customEventClient.sendEvents(events);
+    }
+}
+```
+
+## Async Client Patterns
+
+### Async CloudEvent Publishing
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.models.CloudEvent;
+import com.azure.core.models.CloudEventDataFormat;
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridPublisherAsyncClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishCloudEventsAsynchronously {
+    public static void main(String[] args) throws Exception {
+        EventGridPublisherAsyncClient<CloudEvent> publisherClient = new EventGridPublisherClientBuilder()
+            .endpoint(System.getenv("AZURE_EVENTGRID_CLOUDEVENT_ENDPOINT"))
+            .credential(new AzureKeyCredential(System.getenv("AZURE_EVENTGRID_CLOUDEVENT_KEY")))
+            .buildCloudEventPublisherAsyncClient();
+
+        // Create CloudEvents
+        User newUser = new User("John2", "James");
+        CloudEvent cloudEventModel = new CloudEvent("https://com.example.myapp", "User.Created.Object",
+            BinaryData.fromObject(newUser), CloudEventDataFormat.JSON, "application/json");
+
+        byte[] byteSample = "FirstName: John3, LastName: James".getBytes(StandardCharsets.UTF_8);
+        CloudEvent cloudEventBytes = new CloudEvent("https://com.example.myapp", "User.Created.Binary",
+            BinaryData.fromBytes(byteSample), CloudEventDataFormat.BYTES, "application/octet-stream");
+
+        List<CloudEvent> events = new ArrayList<>();
+        events.add(cloudEventModel);
+        events.add(cloudEventBytes);
+
+        // Non-blocking send with subscribe()
+        publisherClient.sendEvents(events)
+            .subscribe(
+                unused -> System.out.println("Events sent successfully"),
+                error -> System.err.println("Error sending events: " + error.getMessage()),
+                () -> System.out.println("Send operation completed")
+            );
+
+        // Keep application alive for async operation
+        Thread.sleep(5000);
+    }
+}
+```
+
+### Async EventGridEvent Publishing
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridEvent;
+import com.azure.messaging.eventgrid.EventGridPublisherAsyncClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishEventGridEventsAsynchronously {
+    public static void main(String[] args) throws Exception {
+        EventGridPublisherAsyncClient<EventGridEvent> publisherClient = new EventGridPublisherClientBuilder()
+            .endpoint(System.getenv("AZURE_EVENTGRID_EVENT_ENDPOINT"))
+            .credential(new AzureKeyCredential(System.getenv("AZURE_EVENTGRID_EVENT_KEY")))
+            .buildEventGridEventPublisherAsyncClient();
+
+        String str = "FirstName: John1, LastName: James";
+        EventGridEvent eventJson = new EventGridEvent("com/example/MyApp", "User.Created.Text", 
+            BinaryData.fromObject(str), "0.1");
+        
+        User newUser = new User("John2", "James");
+        EventGridEvent eventModelClass = new EventGridEvent("com/example/MyApp", "User.Created.Object", 
+            BinaryData.fromObject(newUser), "0.1");
+
+        List<EventGridEvent> events = new ArrayList<>();
+        events.add(eventJson);
+        events.add(eventModelClass);
+
+        // Non-blocking send
+        publisherClient.sendEvents(events)
+            .subscribe();
+
+        Thread.sleep(5000);
+    }
+}
+```
+
+## Batch Publishing
+
+All `sendEvents()` methods accept a `List` and publish as a batch:
+
+```java
+// CloudEvents batch
+List<CloudEvent> cloudEvents = new ArrayList<>();
+cloudEvents.add(event1);
+cloudEvents.add(event2);
+cloudEvents.add(event3);
+publisherClient.sendEvents(cloudEvents);
+
+// EventGridEvents batch
+List<EventGridEvent> gridEvents = new ArrayList<>();
+gridEvents.add(gridEvent1);
+gridEvents.add(gridEvent2);
+publisherClient.sendEvents(gridEvents);
+
+// Custom events batch
+List<BinaryData> customEvents = new ArrayList<>();
+customEvents.add(BinaryData.fromObject(customEvent1));
+customEvents.add(BinaryData.fromObject(customEvent2));
+customEventClient.sendEvents(customEvents);
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.models.CloudEvent;
+import com.azure.messaging.eventgrid.EventGridPublisherClient;
+
+public class EventGridErrorHandling {
+    public static void main(String[] args) {
+        EventGridPublisherClient<CloudEvent> client = /* create client */;
+        
+        try {
+            client.sendEvents(events);
+        } catch (HttpResponseException e) {
+            System.err.println("HTTP Status Code: " + e.getResponse().getStatusCode());
+            System.err.println("Error Message: " + e.getMessage());
+            
+            // Handle specific status codes
+            int statusCode = e.getResponse().getStatusCode();
+            if (statusCode == 401 || statusCode == 403) {
+                System.err.println("Authentication/Authorization error");
+            } else if (statusCode == 404) {
+                System.err.println("Topic/Domain not found");
+            } else if (statusCode >= 500) {
+                System.err.println("Server error - consider retry");
+            }
+        } catch (Exception e) {
+            System.err.println("Unexpected error: " + e.getMessage());
+        }
+    }
+}
+```
+
+### Async Error Handling
+
+```java
+publisherClient.sendEvents(events)
+    .subscribe(
+        unused -> System.out.println("Success"),
+        error -> {
+            if (error instanceof HttpResponseException) {
+                HttpResponseException httpError = (HttpResponseException) error;
+                System.err.println("HTTP error: " + httpError.getResponse().getStatusCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        },
+        () -> System.out.println("Completed")
+    );
+```
+
+## Helper Class
+
+```java
+public class User {
+    private String firstName;
+    private String lastName;
+
+    public User(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+}
+```

--- a/skills/java/messaging/eventhubs/SKILL.md
+++ b/skills/java/messaging/eventhubs/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: azure-messaging-eventhubs-java
+description: Build real-time streaming applications with Azure Event Hubs SDK for Java. Use when implementing event streaming, high-throughput data ingestion, or building event-driven architectures.
+---
+
+# Azure Event Hubs SDK for Java
+
+Build real-time streaming applications using the Azure Event Hubs SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-eventhubs</artifactId>
+    <version>5.19.0</version>
+</dependency>
+
+<!-- For checkpoint store (production) -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-eventhubs-checkpointstore-blob</artifactId>
+    <version>1.20.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### EventHubProducerClient
+
+```java
+import com.azure.messaging.eventhubs.EventHubProducerClient;
+import com.azure.messaging.eventhubs.EventHubClientBuilder;
+
+// With connection string
+EventHubProducerClient producer = new EventHubClientBuilder()
+    .connectionString("<connection-string>", "<event-hub-name>")
+    .buildProducerClient();
+
+// Full connection string with EntityPath
+EventHubProducerClient producer = new EventHubClientBuilder()
+    .connectionString("<connection-string-with-entity-path>")
+    .buildProducerClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+EventHubProducerClient producer = new EventHubClientBuilder()
+    .fullyQualifiedNamespace("<namespace>.servicebus.windows.net")
+    .eventHubName("<event-hub-name>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildProducerClient();
+```
+
+### EventHubConsumerClient
+
+```java
+import com.azure.messaging.eventhubs.EventHubConsumerClient;
+
+EventHubConsumerClient consumer = new EventHubClientBuilder()
+    .connectionString("<connection-string>", "<event-hub-name>")
+    .consumerGroup(EventHubClientBuilder.DEFAULT_CONSUMER_GROUP_NAME)
+    .buildConsumerClient();
+```
+
+### Async Clients
+
+```java
+import com.azure.messaging.eventhubs.EventHubProducerAsyncClient;
+import com.azure.messaging.eventhubs.EventHubConsumerAsyncClient;
+
+EventHubProducerAsyncClient asyncProducer = new EventHubClientBuilder()
+    .connectionString("<connection-string>", "<event-hub-name>")
+    .buildAsyncProducerClient();
+
+EventHubConsumerAsyncClient asyncConsumer = new EventHubClientBuilder()
+    .connectionString("<connection-string>", "<event-hub-name>")
+    .consumerGroup("$Default")
+    .buildAsyncConsumerClient();
+```
+
+## Core Patterns
+
+### Send Single Event
+
+```java
+import com.azure.messaging.eventhubs.EventData;
+
+EventData eventData = new EventData("Hello, Event Hubs!");
+producer.send(Collections.singletonList(eventData));
+```
+
+### Send Event Batch
+
+```java
+import com.azure.messaging.eventhubs.EventDataBatch;
+import com.azure.messaging.eventhubs.models.CreateBatchOptions;
+
+// Create batch
+EventDataBatch batch = producer.createBatch();
+
+// Add events (returns false if batch is full)
+for (int i = 0; i < 100; i++) {
+    EventData event = new EventData("Event " + i);
+    if (!batch.tryAdd(event)) {
+        // Batch is full, send and create new batch
+        producer.send(batch);
+        batch = producer.createBatch();
+        batch.tryAdd(event);
+    }
+}
+
+// Send remaining events
+if (batch.getCount() > 0) {
+    producer.send(batch);
+}
+```
+
+### Send to Specific Partition
+
+```java
+CreateBatchOptions options = new CreateBatchOptions()
+    .setPartitionId("0");
+
+EventDataBatch batch = producer.createBatch(options);
+batch.tryAdd(new EventData("Partition 0 event"));
+producer.send(batch);
+```
+
+### Send with Partition Key
+
+```java
+CreateBatchOptions options = new CreateBatchOptions()
+    .setPartitionKey("customer-123");
+
+EventDataBatch batch = producer.createBatch(options);
+batch.tryAdd(new EventData("Customer event"));
+producer.send(batch);
+```
+
+### Event with Properties
+
+```java
+EventData event = new EventData("Order created");
+event.getProperties().put("orderId", "ORD-123");
+event.getProperties().put("customerId", "CUST-456");
+event.getProperties().put("priority", 1);
+
+producer.send(Collections.singletonList(event));
+```
+
+### Receive Events (Simple)
+
+```java
+import com.azure.messaging.eventhubs.models.EventPosition;
+import com.azure.messaging.eventhubs.models.PartitionEvent;
+
+// Receive from specific partition
+Iterable<PartitionEvent> events = consumer.receiveFromPartition(
+    "0",                           // partitionId
+    10,                            // maxEvents
+    EventPosition.earliest(),      // startingPosition
+    Duration.ofSeconds(30)         // timeout
+);
+
+for (PartitionEvent partitionEvent : events) {
+    EventData event = partitionEvent.getData();
+    System.out.println("Body: " + event.getBodyAsString());
+    System.out.println("Sequence: " + event.getSequenceNumber());
+    System.out.println("Offset: " + event.getOffset());
+}
+```
+
+### EventProcessorClient (Production)
+
+```java
+import com.azure.messaging.eventhubs.EventProcessorClient;
+import com.azure.messaging.eventhubs.EventProcessorClientBuilder;
+import com.azure.messaging.eventhubs.checkpointstore.blob.BlobCheckpointStore;
+import com.azure.storage.blob.BlobContainerAsyncClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+
+// Create checkpoint store
+BlobContainerAsyncClient blobClient = new BlobContainerClientBuilder()
+    .connectionString("<storage-connection-string>")
+    .containerName("checkpoints")
+    .buildAsyncClient();
+
+// Create processor
+EventProcessorClient processor = new EventProcessorClientBuilder()
+    .connectionString("<eventhub-connection-string>", "<event-hub-name>")
+    .consumerGroup("$Default")
+    .checkpointStore(new BlobCheckpointStore(blobClient))
+    .processEvent(eventContext -> {
+        EventData event = eventContext.getEventData();
+        System.out.println("Processing: " + event.getBodyAsString());
+        
+        // Checkpoint after processing
+        eventContext.updateCheckpoint();
+    })
+    .processError(errorContext -> {
+        System.err.println("Error: " + errorContext.getThrowable().getMessage());
+        System.err.println("Partition: " + errorContext.getPartitionContext().getPartitionId());
+    })
+    .buildEventProcessorClient();
+
+// Start processing
+processor.start();
+
+// Keep running...
+Thread.sleep(Duration.ofMinutes(5).toMillis());
+
+// Stop gracefully
+processor.stop();
+```
+
+### Batch Processing
+
+```java
+EventProcessorClient processor = new EventProcessorClientBuilder()
+    .connectionString("<connection-string>", "<event-hub-name>")
+    .consumerGroup("$Default")
+    .checkpointStore(new BlobCheckpointStore(blobClient))
+    .processEventBatch(eventBatchContext -> {
+        List<EventData> events = eventBatchContext.getEvents();
+        System.out.printf("Received %d events%n", events.size());
+        
+        for (EventData event : events) {
+            // Process each event
+            System.out.println(event.getBodyAsString());
+        }
+        
+        // Checkpoint after batch
+        eventBatchContext.updateCheckpoint();
+    }, 50) // maxBatchSize
+    .processError(errorContext -> {
+        System.err.println("Error: " + errorContext.getThrowable());
+    })
+    .buildEventProcessorClient();
+```
+
+### Async Receiving
+
+```java
+asyncConsumer.receiveFromPartition("0", EventPosition.latest())
+    .subscribe(
+        partitionEvent -> {
+            EventData event = partitionEvent.getData();
+            System.out.println("Received: " + event.getBodyAsString());
+        },
+        error -> System.err.println("Error: " + error),
+        () -> System.out.println("Complete")
+    );
+```
+
+### Get Event Hub Properties
+
+```java
+// Get hub info
+EventHubProperties hubProps = producer.getEventHubProperties();
+System.out.println("Hub: " + hubProps.getName());
+System.out.println("Partitions: " + hubProps.getPartitionIds());
+
+// Get partition info
+PartitionProperties partitionProps = producer.getPartitionProperties("0");
+System.out.println("Begin sequence: " + partitionProps.getBeginningSequenceNumber());
+System.out.println("Last sequence: " + partitionProps.getLastEnqueuedSequenceNumber());
+System.out.println("Last offset: " + partitionProps.getLastEnqueuedOffset());
+```
+
+## Event Positions
+
+```java
+// Start from beginning
+EventPosition.earliest()
+
+// Start from end (new events only)
+EventPosition.latest()
+
+// From specific offset
+EventPosition.fromOffset(12345L)
+
+// From specific sequence number
+EventPosition.fromSequenceNumber(100L)
+
+// From specific time
+EventPosition.fromEnqueuedTime(Instant.now().minus(Duration.ofHours(1)))
+```
+
+## Error Handling
+
+```java
+import com.azure.messaging.eventhubs.models.ErrorContext;
+
+.processError(errorContext -> {
+    Throwable error = errorContext.getThrowable();
+    String partitionId = errorContext.getPartitionContext().getPartitionId();
+    
+    if (error instanceof AmqpException) {
+        AmqpException amqpError = (AmqpException) error;
+        if (amqpError.isTransient()) {
+            System.out.println("Transient error, will retry");
+        }
+    }
+    
+    System.err.printf("Error on partition %s: %s%n", partitionId, error.getMessage());
+})
+```
+
+## Resource Cleanup
+
+```java
+// Always close clients
+try {
+    producer.send(batch);
+} finally {
+    producer.close();
+}
+
+// Or use try-with-resources
+try (EventHubProducerClient producer = new EventHubClientBuilder()
+        .connectionString(connectionString, eventHubName)
+        .buildProducerClient()) {
+    producer.send(events);
+}
+```
+
+## Environment Variables
+
+```bash
+EVENT_HUBS_CONNECTION_STRING=Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=...
+EVENT_HUBS_NAME=<event-hub-name>
+STORAGE_CONNECTION_STRING=<for-checkpointing>
+```
+
+## Best Practices
+
+1. **Use EventProcessorClient**: For production, provides load balancing and checkpointing
+2. **Batch Events**: Use `EventDataBatch` for efficient sending
+3. **Partition Keys**: Use for ordering guarantees within a partition
+4. **Checkpointing**: Checkpoint after processing to avoid reprocessing
+5. **Error Handling**: Handle transient errors with retries
+6. **Close Clients**: Always close producer/consumer when done
+
+## Trigger Phrases
+
+- "Event Hubs Java"
+- "event streaming Azure"
+- "real-time data ingestion"
+- "EventProcessorClient"
+- "event hub producer consumer"
+- "partition processing"

--- a/skills/java/messaging/eventhubs/references/examples.md
+++ b/skills/java/messaging/eventhubs/references/examples.md
@@ -1,0 +1,405 @@
+# Azure Event Hubs Java SDK - Examples
+
+Comprehensive code examples for the Azure Event Hubs SDK for Java.
+
+## Table of Contents
+
+- [Maven Dependency](#maven-dependency)
+- [EventHubProducerClient](#eventhubproducerclient)
+- [EventHubConsumerClient](#eventhubconsumerclient)
+- [EventProcessorClient](#eventprocessorclient)
+- [Checkpointing Patterns](#checkpointing-patterns)
+- [Partition Handling](#partition-handling)
+
+---
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-eventhubs</artifactId>
+    <version>5.21.0</version>
+</dependency>
+
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.18.2</version>
+</dependency>
+
+<!-- For EventProcessorClient with blob checkpointing -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-eventhubs-checkpointstore-blob</artifactId>
+    <version>1.21.0</version>
+</dependency>
+```
+
+---
+
+## EventHubProducerClient
+
+### Basic Producer with Azure Identity
+
+```java
+import com.azure.messaging.eventhubs.*;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class PublishEventsWithAzureIdentity {
+    public static void main(String[] args) {
+        List<EventData> telemetryEvents = Arrays.asList(
+            new EventData("Roast beef".getBytes(UTF_8)),
+            new EventData("Cheese".getBytes(UTF_8)),
+            new EventData("Tofu".getBytes(UTF_8)),
+            new EventData("Turkey".getBytes(UTF_8)));
+
+        // Create a producer
+        // "<<fully-qualified-namespace>>" = "{your-namespace}.servicebus.windows.net"
+        EventHubProducerClient producer = new EventHubClientBuilder()
+            .credential(
+                "<<fully-qualified-namespace>>",
+                "<<event-hub-name>>",
+                new DefaultAzureCredentialBuilder().build())
+            .buildProducerClient();
+
+        // Create batch - Event Hubs auto-routes to available partitions
+        EventDataBatch currentBatch = producer.createBatch();
+
+        // Add events to batch, send when full
+        for (EventData event : telemetryEvents) {
+            if (currentBatch.tryAdd(event)) {
+                continue;
+            }
+
+            // Batch is full - send and create new batch
+            producer.send(currentBatch);
+            currentBatch = producer.createBatch();
+
+            if (!currentBatch.tryAdd(event)) {
+                System.err.printf("Event is too large for an empty batch. Max size: %s.%n",
+                    currentBatch.getMaxSizeInBytes());
+            }
+        }
+
+        // Send remaining events
+        producer.send(currentBatch);
+        
+        producer.close();
+    }
+}
+```
+
+### Producer with Connection String
+
+```java
+String connectionString = "Endpoint={endpoint};SharedAccessKeyName={sharedAccessKeyName};"
+    + "SharedAccessKey={sharedAccessKey};EntityPath={eventHubName}";
+
+EventHubProducerClient producer = new EventHubClientBuilder()
+    .connectionString(connectionString)
+    .buildProducerClient();
+```
+
+### Send to Specific Partition
+
+```java
+import com.azure.messaging.eventhubs.models.CreateBatchOptions;
+
+// Route all events in batch to partition "0"
+CreateBatchOptions options = new CreateBatchOptions().setPartitionId("0");
+EventDataBatch batch = producer.createBatch(options);
+
+batch.tryAdd(new EventData("Event for partition 0"));
+producer.send(batch);
+```
+
+### Send with Partition Key (Hash-based Routing)
+
+```java
+import com.azure.messaging.eventhubs.models.SendOptions;
+
+List<EventData> events = Arrays.asList(
+    new EventData("Melbourne"), 
+    new EventData("London"),
+    new EventData("New York"));
+
+// Events with same partition key go to same partition
+SendOptions sendOptions = new SendOptions().setPartitionKey("cities");
+producer.send(events, sendOptions);
+```
+
+---
+
+## EventHubConsumerClient
+
+### Synchronous Consumer
+
+```java
+import com.azure.core.util.IterableStream;
+import com.azure.messaging.eventhubs.*;
+import com.azure.messaging.eventhubs.models.EventPosition;
+import com.azure.messaging.eventhubs.models.PartitionEvent;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.time.Duration;
+import java.time.Instant;
+
+EventHubConsumerClient consumer = new EventHubClientBuilder()
+    .credential("<<fully-qualified-namespace>>", "<<event-hub-name>>",
+        new DefaultAzureCredentialBuilder().build())
+    .consumerGroup(EventHubClientBuilder.DEFAULT_CONSUMER_GROUP_NAME)
+    .buildConsumerClient();
+
+// Start from 12 hours ago
+Instant twelveHoursAgo = Instant.now().minus(Duration.ofHours(12));
+EventPosition startingPosition = EventPosition.fromEnqueuedTime(twelveHoursAgo);
+String partitionId = "0";
+
+// Receive up to 100 events or wait 30 seconds
+IterableStream<PartitionEvent> events = consumer.receiveFromPartition(
+    partitionId, 100, startingPosition, Duration.ofSeconds(30));
+
+Long lastSequenceNumber = -1L;
+for (PartitionEvent partitionEvent : events) {
+    System.out.print("Event received: " + partitionEvent.getData().getSequenceNumber());
+    lastSequenceNumber = partitionEvent.getData().getSequenceNumber();
+}
+
+// Continue from last processed event
+if (lastSequenceNumber != -1L) {
+    EventPosition nextPosition = EventPosition.fromSequenceNumber(lastSequenceNumber, false);
+    IterableStream<PartitionEvent> nextEvents = consumer.receiveFromPartition(
+        partitionId, 100, nextPosition, Duration.ofSeconds(30));
+}
+
+consumer.close();
+```
+
+### Asynchronous Consumer (Reactive)
+
+```java
+import com.azure.messaging.eventhubs.*;
+import com.azure.messaging.eventhubs.models.PartitionContext;
+import reactor.core.Disposable;
+
+EventHubConsumerAsyncClient consumer = new EventHubClientBuilder()
+    .credential("<<fully-qualified-namespace>>", "<<event-hub-name>>",
+        new DefaultAzureCredentialBuilder().build())
+    .consumerGroup(EventHubClientBuilder.DEFAULT_CONSUMER_GROUP_NAME)
+    .buildAsyncConsumerClient();
+
+String partitionId = "0";
+EventPosition startingPosition = EventPosition.latest();
+
+// Non-blocking - returns immediately
+Disposable subscription = consumer.receiveFromPartition(partitionId, startingPosition)
+    .subscribe(partitionEvent -> {
+        PartitionContext partitionContext = partitionEvent.getPartitionContext();
+        EventData event = partitionEvent.getData();
+
+        System.out.printf("Received event from partition '%s'%n", partitionContext.getPartitionId());
+        System.out.printf("Contents: '%s'%n", event.getBodyAsString());
+    }, error -> {
+        System.err.print("An error occurred: " + error);
+    }, () -> {
+        System.out.print("Stream has ended.");
+    });
+
+// When done receiving
+subscription.dispose();
+consumer.close();
+```
+
+---
+
+## EventProcessorClient
+
+### Basic EventProcessorClient with Checkpointing
+
+```java
+import com.azure.messaging.eventhubs.*;
+import com.azure.messaging.eventhubs.checkpointstore.blob.BlobCheckpointStore;
+import com.azure.messaging.eventhubs.models.ErrorContext;
+import com.azure.messaging.eventhubs.models.EventContext;
+import com.azure.storage.blob.BlobContainerAsyncClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public class EventProcessorClientSample {
+    public static void main(String[] args) throws Exception {
+        
+        // Event handler - processes each event and checkpoints
+        Consumer<EventContext> processEvent = eventContext -> {
+            System.out.printf("Processing event: partition=%s, sequence=%d%n",
+                eventContext.getPartitionContext().getPartitionId(),
+                eventContext.getEventData().getSequenceNumber());
+
+            // Checkpoint after processing each event
+            eventContext.updateCheckpoint();
+        };
+
+        // Error handler - logs errors, processor keeps running
+        Consumer<ErrorContext> processError = errorContext -> {
+            System.err.printf("Error while processing partition %s: %s%n", 
+                errorContext.getPartitionContext().getPartitionId(),
+                errorContext.getThrowable().getMessage());
+        };
+
+        // Create blob container client for checkpoint store
+        BlobContainerAsyncClient blobContainerAsyncClient = new BlobContainerClientBuilder()
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .endpoint("<storage-account-url>")
+            .containerName("checkpoints")
+            .buildAsyncClient();
+
+        EventProcessorClient eventProcessorClient = new EventProcessorClientBuilder()
+            .consumerGroup(EventHubClientBuilder.DEFAULT_CONSUMER_GROUP_NAME)
+            .credential("<<fully-qualified-namespace>>", "<<event-hub-name>>",
+                new DefaultAzureCredentialBuilder().build())
+            .processEvent(processEvent)
+            .processError(processError)
+            .checkpointStore(new BlobCheckpointStore(blobContainerAsyncClient))
+            .buildEventProcessorClient();
+        
+        System.out.println("Starting event processor");
+        eventProcessorClient.start();
+
+        // Processor runs in background - do other work
+        Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+
+        System.out.println("Stopping event processor");
+        eventProcessorClient.stop();
+    }
+}
+```
+
+---
+
+## Checkpointing Patterns
+
+### Batch Processing with Periodic Checkpointing
+
+```java
+import com.azure.messaging.eventhubs.*;
+import com.azure.messaging.eventhubs.models.EventBatchContext;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+// Process 50 events in a batch OR wait up to 30 seconds
+Consumer<EventBatchContext> processBatch = batchContext -> {
+    if (batchContext.getEvents().isEmpty()) {
+        return;
+    }
+
+    for (EventData event : batchContext.getEvents()) {
+        System.out.printf("Processing event: partition=%s, sequence=%d%n",
+            batchContext.getPartitionContext().getPartitionId(),
+            event.getSequenceNumber());
+    }
+
+    // Checkpoint after processing entire batch
+    batchContext.updateCheckpoint();
+};
+
+EventProcessorClient processor = new EventProcessorClientBuilder()
+    .consumerGroup(EventHubClientBuilder.DEFAULT_CONSUMER_GROUP_NAME)
+    .credential("<<fully-qualified-namespace>>", "<<event-hub-name>>",
+        new DefaultAzureCredentialBuilder().build())
+    .processEventBatch(processBatch, 50, Duration.ofSeconds(30))
+    .processError(processError)
+    .checkpointStore(new BlobCheckpointStore(blobContainerAsyncClient))
+    .buildEventProcessorClient();
+
+processor.start();
+```
+
+### Checkpoint After N Events
+
+```java
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+// Track events per partition
+Map<String, AtomicInteger> partitionCounters = new ConcurrentHashMap<>();
+int checkpointAfterN = 100;
+
+Consumer<EventContext> processEvent = eventContext -> {
+    String partitionId = eventContext.getPartitionContext().getPartitionId();
+    
+    // Process event
+    System.out.println("Event: " + eventContext.getEventData().getBodyAsString());
+    
+    // Increment counter for this partition
+    AtomicInteger counter = partitionCounters.computeIfAbsent(
+        partitionId, k -> new AtomicInteger(0));
+    
+    if (counter.incrementAndGet() >= checkpointAfterN) {
+        eventContext.updateCheckpoint();
+        counter.set(0);
+        System.out.printf("Checkpointed partition %s%n", partitionId);
+    }
+};
+```
+
+---
+
+## Partition Handling
+
+### Get Partition Information
+
+```java
+EventHubProducerClient producer = new EventHubClientBuilder()
+    .credential("<<namespace>>", "<<event-hub>>",
+        new DefaultAzureCredentialBuilder().build())
+    .buildProducerClient();
+
+// Get Event Hub properties
+EventHubProperties eventHubProperties = producer.getEventHubProperties();
+System.out.println("Event Hub: " + eventHubProperties.getName());
+System.out.println("Partitions: " + eventHubProperties.getPartitionIds());
+
+// Get specific partition properties
+for (String partitionId : eventHubProperties.getPartitionIds()) {
+    PartitionProperties partitionProperties = producer.getPartitionProperties(partitionId);
+    System.out.printf("Partition %s: begin=%d, end=%d%n",
+        partitionId,
+        partitionProperties.getBeginningSequenceNumber(),
+        partitionProperties.getLastEnqueuedSequenceNumber());
+}
+```
+
+### Event Position Options
+
+```java
+import com.azure.messaging.eventhubs.models.EventPosition;
+import java.time.Instant;
+
+// From beginning of partition
+EventPosition fromStart = EventPosition.earliest();
+
+// From end (new events only)
+EventPosition fromEnd = EventPosition.latest();
+
+// From specific sequence number (exclusive)
+EventPosition fromSequence = EventPosition.fromSequenceNumber(12345L, false);
+
+// From specific sequence number (inclusive)
+EventPosition fromSequenceInclusive = EventPosition.fromSequenceNumber(12345L, true);
+
+// From specific time
+EventPosition fromTime = EventPosition.fromEnqueuedTime(Instant.now().minusSeconds(3600));
+
+// From specific offset
+EventPosition fromOffset = EventPosition.fromOffset(1000L);
+```

--- a/skills/java/messaging/webpubsub/SKILL.md
+++ b/skills/java/messaging/webpubsub/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: azure-messaging-webpubsub-java
+description: Build real-time web applications with Azure Web PubSub SDK for Java. Use when implementing WebSocket-based messaging, live updates, chat applications, or server-to-client push notifications.
+---
+
+# Azure Web PubSub SDK for Java
+
+Build real-time web applications using the Azure Web PubSub SDK for Java.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-webpubsub</artifactId>
+    <version>1.5.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### With Connection String
+
+```java
+import com.azure.messaging.webpubsub.WebPubSubServiceClient;
+import com.azure.messaging.webpubsub.WebPubSubServiceClientBuilder;
+
+WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
+    .connectionString("<connection-string>")
+    .hub("chat")
+    .buildClient();
+```
+
+### With Access Key
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+
+WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
+    .credential(new AzureKeyCredential("<access-key>"))
+    .endpoint("<endpoint>")
+    .hub("chat")
+    .buildClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint("<endpoint>")
+    .hub("chat")
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.messaging.webpubsub.WebPubSubServiceAsyncClient;
+
+WebPubSubServiceAsyncClient asyncClient = new WebPubSubServiceClientBuilder()
+    .connectionString("<connection-string>")
+    .hub("chat")
+    .buildAsyncClient();
+```
+
+## Key Concepts
+
+- **Hub**: Logical isolation unit for connections
+- **Group**: Subset of connections within a hub
+- **Connection**: Individual WebSocket client connection
+- **User**: Entity that can have multiple connections
+
+## Core Patterns
+
+### Send to All Connections
+
+```java
+import com.azure.messaging.webpubsub.models.WebPubSubContentType;
+
+// Send text message
+client.sendToAll("Hello everyone!", WebPubSubContentType.TEXT_PLAIN);
+
+// Send JSON
+String jsonMessage = "{\"type\": \"notification\", \"message\": \"New update!\"}";
+client.sendToAll(jsonMessage, WebPubSubContentType.APPLICATION_JSON);
+```
+
+### Send to All with Filter
+
+```java
+import com.azure.core.http.rest.RequestOptions;
+import com.azure.core.util.BinaryData;
+
+BinaryData message = BinaryData.fromString("Hello filtered users!");
+
+// Filter by userId
+client.sendToAllWithResponse(
+    message,
+    WebPubSubContentType.TEXT_PLAIN,
+    message.getLength(),
+    new RequestOptions().addQueryParam("filter", "userId ne 'user1'"));
+
+// Filter by groups
+client.sendToAllWithResponse(
+    message,
+    WebPubSubContentType.TEXT_PLAIN,
+    message.getLength(),
+    new RequestOptions().addQueryParam("filter", "'GroupA' in groups and not('GroupB' in groups)"));
+```
+
+### Send to Group
+
+```java
+// Send to all connections in a group
+client.sendToGroup("java-developers", "Hello Java devs!", WebPubSubContentType.TEXT_PLAIN);
+
+// Send JSON to group
+String json = "{\"event\": \"update\", \"data\": {\"version\": \"2.0\"}}";
+client.sendToGroup("subscribers", json, WebPubSubContentType.APPLICATION_JSON);
+```
+
+### Send to Specific Connection
+
+```java
+// Send to a specific connection by ID
+client.sendToConnection("connectionId123", "Private message", WebPubSubContentType.TEXT_PLAIN);
+```
+
+### Send to User
+
+```java
+// Send to all connections for a specific user
+client.sendToUser("andy", "Hello Andy!", WebPubSubContentType.TEXT_PLAIN);
+```
+
+### Manage Groups
+
+```java
+// Add connection to group
+client.addConnectionToGroup("premium-users", "connectionId123");
+
+// Remove connection from group
+client.removeConnectionFromGroup("premium-users", "connectionId123");
+
+// Add user to group (all their connections)
+client.addUserToGroup("admin-group", "userId456");
+
+// Remove user from group
+client.removeUserFromGroup("admin-group", "userId456");
+
+// Check if user is in group
+boolean exists = client.userExistsInGroup("admin-group", "userId456");
+```
+
+### Manage Connections
+
+```java
+// Check if connection exists
+boolean connected = client.connectionExists("connectionId123");
+
+// Close a connection
+client.closeConnection("connectionId123");
+
+// Close with reason
+client.closeConnection("connectionId123", "Session expired");
+
+// Check if user exists (has any connections)
+boolean userOnline = client.userExists("userId456");
+
+// Close all connections for a user
+client.closeUserConnections("userId456");
+
+// Close all connections in a group
+client.closeGroupConnections("inactive-group");
+```
+
+### Generate Client Access Token
+
+```java
+import com.azure.messaging.webpubsub.models.GetClientAccessTokenOptions;
+import com.azure.messaging.webpubsub.models.WebPubSubClientAccessToken;
+
+// Basic token
+WebPubSubClientAccessToken token = client.getClientAccessToken(
+    new GetClientAccessTokenOptions());
+System.out.println("URL: " + token.getUrl());
+
+// With user ID
+WebPubSubClientAccessToken userToken = client.getClientAccessToken(
+    new GetClientAccessTokenOptions().setUserId("user123"));
+
+// With roles (permissions)
+WebPubSubClientAccessToken roleToken = client.getClientAccessToken(
+    new GetClientAccessTokenOptions()
+        .setUserId("user123")
+        .addRole("webpubsub.joinLeaveGroup")
+        .addRole("webpubsub.sendToGroup"));
+
+// With groups to join on connect
+WebPubSubClientAccessToken groupToken = client.getClientAccessToken(
+    new GetClientAccessTokenOptions()
+        .setUserId("user123")
+        .addGroup("announcements")
+        .addGroup("updates"));
+
+// With custom expiration
+WebPubSubClientAccessToken expToken = client.getClientAccessToken(
+    new GetClientAccessTokenOptions()
+        .setUserId("user123")
+        .setExpiresAfter(Duration.ofHours(2)));
+```
+
+### Grant/Revoke Permissions
+
+```java
+import com.azure.messaging.webpubsub.models.WebPubSubPermission;
+
+// Grant permission to send to a group
+client.grantPermission(
+    WebPubSubPermission.SEND_TO_GROUP,
+    "connectionId123",
+    new RequestOptions().addQueryParam("targetName", "chat-room"));
+
+// Revoke permission
+client.revokePermission(
+    WebPubSubPermission.SEND_TO_GROUP,
+    "connectionId123",
+    new RequestOptions().addQueryParam("targetName", "chat-room"));
+
+// Check permission
+boolean hasPermission = client.checkPermission(
+    WebPubSubPermission.SEND_TO_GROUP,
+    "connectionId123",
+    new RequestOptions().addQueryParam("targetName", "chat-room"));
+```
+
+### Async Operations
+
+```java
+asyncClient.sendToAll("Async message!", WebPubSubContentType.TEXT_PLAIN)
+    .subscribe(
+        unused -> System.out.println("Message sent"),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+
+asyncClient.sendToGroup("developers", "Group message", WebPubSubContentType.TEXT_PLAIN)
+    .doOnSuccess(v -> System.out.println("Sent to group"))
+    .doOnError(e -> System.err.println("Failed: " + e))
+    .subscribe();
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    client.sendToConnection("invalid-id", "test", WebPubSubContentType.TEXT_PLAIN);
+} catch (HttpResponseException e) {
+    System.out.println("Status: " + e.getResponse().getStatusCode());
+    System.out.println("Error: " + e.getMessage());
+}
+```
+
+## Environment Variables
+
+```bash
+WEB_PUBSUB_CONNECTION_STRING=Endpoint=https://<resource>.webpubsub.azure.com;AccessKey=...
+WEB_PUBSUB_ENDPOINT=https://<resource>.webpubsub.azure.com
+WEB_PUBSUB_ACCESS_KEY=<your-access-key>
+```
+
+## Client Roles
+
+| Role | Permission |
+|------|------------|
+| `webpubsub.joinLeaveGroup` | Join/leave any group |
+| `webpubsub.sendToGroup` | Send to any group |
+| `webpubsub.joinLeaveGroup.<group>` | Join/leave specific group |
+| `webpubsub.sendToGroup.<group>` | Send to specific group |
+
+## Best Practices
+
+1. **Use Groups**: Organize connections into groups for targeted messaging
+2. **User IDs**: Associate connections with user IDs for user-level messaging
+3. **Token Expiration**: Set appropriate token expiration for security
+4. **Roles**: Grant minimal required permissions via roles
+5. **Hub Isolation**: Use separate hubs for different application features
+6. **Connection Management**: Clean up inactive connections
+
+## Trigger Phrases
+
+- "Web PubSub Java"
+- "WebSocket messaging Azure"
+- "real-time push notifications"
+- "server-sent events"
+- "chat application backend"
+- "live updates broadcasting"

--- a/skills/java/messaging/webpubsub/references/examples.md
+++ b/skills/java/messaging/webpubsub/references/examples.md
@@ -1,0 +1,456 @@
+# Azure Web PubSub Java SDK - Examples
+
+Comprehensive code examples for the Azure Web PubSub SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Send Messages](#send-messages)
+- [Group Management](#group-management)
+- [Connection Management](#connection-management)
+- [Client Access Tokens](#client-access-tokens)
+- [Permissions](#permissions)
+- [Async Operations](#async-operations)
+- [Complete Application Example](#complete-application-example)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-messaging-webpubsub</artifactId>
+    <version>1.5.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### With Connection String
+
+```java
+import com.azure.messaging.webpubsub.WebPubSubServiceClient;
+import com.azure.messaging.webpubsub.WebPubSubServiceClientBuilder;
+
+WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
+    .connectionString(System.getenv("WEB_PUBSUB_CONNECTION_STRING"))
+    .hub("chat")
+    .buildClient();
+```
+
+### With DefaultAzureCredential
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint(System.getenv("WEB_PUBSUB_ENDPOINT"))
+    .hub("chat")
+    .buildClient();
+```
+
+### With Access Key
+
+```java
+import com.azure.core.credential.AzureKeyCredential;
+
+WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
+    .credential(new AzureKeyCredential("<access-key>"))
+    .endpoint("<endpoint>")
+    .hub("chat")
+    .buildClient();
+```
+
+### Async Client
+
+```java
+import com.azure.messaging.webpubsub.WebPubSubServiceAsyncClient;
+
+WebPubSubServiceAsyncClient asyncClient = new WebPubSubServiceClientBuilder()
+    .connectionString(connectionString)
+    .hub("chat")
+    .buildAsyncClient();
+```
+
+## Send Messages
+
+### Send to All Connections
+
+```java
+import com.azure.messaging.webpubsub.models.WebPubSubContentType;
+
+// Send text message
+client.sendToAll("Hello everyone!", WebPubSubContentType.TEXT_PLAIN);
+
+// Send JSON
+String jsonMessage = "{\"type\": \"notification\", \"message\": \"New update!\"}";
+client.sendToAll(jsonMessage, WebPubSubContentType.APPLICATION_JSON);
+```
+
+### Send to All with Filter
+
+```java
+import com.azure.core.http.rest.RequestOptions;
+import com.azure.core.util.BinaryData;
+
+BinaryData message = BinaryData.fromString("Hello filtered users!");
+
+// Filter by userId
+client.sendToAllWithResponse(
+    message,
+    WebPubSubContentType.TEXT_PLAIN,
+    message.getLength(),
+    new RequestOptions().addQueryParam("filter", "userId ne 'user1'"));
+
+// Filter by groups
+client.sendToAllWithResponse(
+    message,
+    WebPubSubContentType.TEXT_PLAIN,
+    message.getLength(),
+    new RequestOptions().addQueryParam("filter", "'GroupA' in groups and not('GroupB' in groups)"));
+```
+
+### Send to Group
+
+```java
+client.sendToGroup("developers", "Hello developers!", WebPubSubContentType.TEXT_PLAIN);
+
+String json = "{\"event\": \"update\", \"version\": \"2.0\"}";
+client.sendToGroup("subscribers", json, WebPubSubContentType.APPLICATION_JSON);
+```
+
+### Send to User
+
+```java
+client.sendToUser("user123", "Personal message", WebPubSubContentType.TEXT_PLAIN);
+```
+
+### Send to Connection
+
+```java
+client.sendToConnection("connectionId123", "Direct message", WebPubSubContentType.TEXT_PLAIN);
+```
+
+## Group Management
+
+### Add/Remove Connections
+
+```java
+// Add connection to group
+client.addConnectionToGroup("premium-users", "connectionId123");
+
+// Remove connection from group
+client.removeConnectionFromGroup("premium-users", "connectionId123");
+```
+
+### Add/Remove Users
+
+```java
+// Add user to group (all their connections)
+client.addUserToGroup("admin-group", "userId456");
+
+// Remove user from group
+client.removeUserFromGroup("admin-group", "userId456");
+
+// Check if user is in group
+boolean exists = client.userExistsInGroup("admin-group", "userId456");
+```
+
+## Connection Management
+
+### Check Connection/User Status
+
+```java
+// Check if connection exists
+boolean connected = client.connectionExists("connectionId123");
+
+// Check if user exists (has any connections)
+boolean userOnline = client.userExists("userId456");
+```
+
+### Close Connections
+
+```java
+// Close a connection
+client.closeConnection("connectionId123");
+
+// Close with reason
+client.closeConnection("connectionId123", "Session expired");
+
+// Close all connections for a user
+client.closeUserConnections("userId456");
+
+// Close all connections in a group
+client.closeGroupConnections("inactive-group");
+```
+
+## Client Access Tokens
+
+### Generate Basic Token
+
+```java
+import com.azure.messaging.webpubsub.models.GetClientAccessTokenOptions;
+import com.azure.messaging.webpubsub.models.WebPubSubClientAccessToken;
+
+WebPubSubClientAccessToken token = client.getClientAccessToken(
+    new GetClientAccessTokenOptions());
+System.out.println("WebSocket URL: " + token.getUrl());
+```
+
+### Token with User ID
+
+```java
+WebPubSubClientAccessToken token = client.getClientAccessToken(
+    new GetClientAccessTokenOptions().setUserId("user123"));
+```
+
+### Token with Roles
+
+```java
+WebPubSubClientAccessToken token = client.getClientAccessToken(
+    new GetClientAccessTokenOptions()
+        .setUserId("user123")
+        .addRole("webpubsub.joinLeaveGroup")
+        .addRole("webpubsub.sendToGroup"));
+```
+
+### Token with Initial Groups
+
+```java
+WebPubSubClientAccessToken token = client.getClientAccessToken(
+    new GetClientAccessTokenOptions()
+        .setUserId("user123")
+        .addGroup("announcements")
+        .addGroup("updates"));
+```
+
+### Token with Custom Expiration
+
+```java
+import java.time.Duration;
+
+WebPubSubClientAccessToken token = client.getClientAccessToken(
+    new GetClientAccessTokenOptions()
+        .setUserId("user123")
+        .setExpiresAfter(Duration.ofHours(2)));
+```
+
+## Permissions
+
+### Grant/Revoke Permissions
+
+```java
+import com.azure.messaging.webpubsub.models.WebPubSubPermission;
+
+// Grant permission
+client.grantPermission(
+    WebPubSubPermission.SEND_TO_GROUP,
+    "connectionId123",
+    new RequestOptions().addQueryParam("targetName", "chat-room"));
+
+// Revoke permission
+client.revokePermission(
+    WebPubSubPermission.SEND_TO_GROUP,
+    "connectionId123",
+    new RequestOptions().addQueryParam("targetName", "chat-room"));
+
+// Check permission
+boolean hasPermission = client.checkPermission(
+    WebPubSubPermission.SEND_TO_GROUP,
+    "connectionId123",
+    new RequestOptions().addQueryParam("targetName", "chat-room"));
+```
+
+## Async Operations
+
+```java
+WebPubSubServiceAsyncClient asyncClient = new WebPubSubServiceClientBuilder()
+    .connectionString(connectionString)
+    .hub("chat")
+    .buildAsyncClient();
+
+asyncClient.sendToAll("Async message!", WebPubSubContentType.TEXT_PLAIN)
+    .subscribe(
+        unused -> System.out.println("Message sent"),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+
+asyncClient.sendToGroup("developers", "Group message", WebPubSubContentType.TEXT_PLAIN)
+    .doOnSuccess(v -> System.out.println("Sent to group"))
+    .doOnError(e -> System.err.println("Failed: " + e))
+    .subscribe();
+```
+
+## Complete Application Example
+
+### Real-Time Chat Service
+
+```java
+import com.azure.messaging.webpubsub.*;
+import com.azure.messaging.webpubsub.models.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ChatService {
+    private final WebPubSubServiceClient client;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Map<String, Set<String>> userRooms = new ConcurrentHashMap<>();
+    
+    public ChatService(String connectionString) {
+        this.client = new WebPubSubServiceClientBuilder()
+            .connectionString(connectionString)
+            .hub("chat")
+            .buildClient();
+    }
+    
+    public WebPubSubClientAccessToken connectUser(String userId, List<String> initialRooms) {
+        GetClientAccessTokenOptions options = new GetClientAccessTokenOptions()
+            .setUserId(userId)
+            .addRole("webpubsub.joinLeaveGroup")
+            .addRole("webpubsub.sendToGroup")
+            .setExpiresAfter(Duration.ofHours(24));
+        
+        // Add initial rooms
+        for (String room : initialRooms) {
+            options.addGroup(room);
+        }
+        
+        userRooms.put(userId, new HashSet<>(initialRooms));
+        
+        return client.getClientAccessToken(options);
+    }
+    
+    public void joinRoom(String userId, String roomId) {
+        client.addUserToGroup(roomId, userId);
+        userRooms.computeIfAbsent(userId, k -> new HashSet<>()).add(roomId);
+        
+        broadcastToRoom(roomId, new ChatEvent("user_joined", userId, roomId, null));
+    }
+    
+    public void leaveRoom(String userId, String roomId) {
+        client.removeUserFromGroup(roomId, userId);
+        
+        Set<String> rooms = userRooms.get(userId);
+        if (rooms != null) {
+            rooms.remove(roomId);
+        }
+        
+        broadcastToRoom(roomId, new ChatEvent("user_left", userId, roomId, null));
+    }
+    
+    public void sendMessage(String userId, String roomId, String message) {
+        ChatEvent event = new ChatEvent("message", userId, roomId, message);
+        broadcastToRoom(roomId, event);
+    }
+    
+    public void sendDirectMessage(String fromUserId, String toUserId, String message) {
+        ChatEvent event = new ChatEvent("direct_message", fromUserId, null, message);
+        try {
+            String json = objectMapper.writeValueAsString(event);
+            client.sendToUser(toUserId, json, WebPubSubContentType.APPLICATION_JSON);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to send direct message", e);
+        }
+    }
+    
+    public void broadcastSystemMessage(String message) {
+        ChatEvent event = new ChatEvent("system", "system", null, message);
+        try {
+            String json = objectMapper.writeValueAsString(event);
+            client.sendToAll(json, WebPubSubContentType.APPLICATION_JSON);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to broadcast", e);
+        }
+    }
+    
+    public boolean isUserOnline(String userId) {
+        return client.userExists(userId);
+    }
+    
+    public void disconnectUser(String userId) {
+        client.closeUserConnections(userId);
+        userRooms.remove(userId);
+    }
+    
+    private void broadcastToRoom(String roomId, ChatEvent event) {
+        try {
+            String json = objectMapper.writeValueAsString(event);
+            client.sendToGroup(roomId, json, WebPubSubContentType.APPLICATION_JSON);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to broadcast to room", e);
+        }
+    }
+    
+    static class ChatEvent {
+        public String type;
+        public String userId;
+        public String roomId;
+        public String message;
+        public long timestamp;
+        
+        ChatEvent(String type, String userId, String roomId, String message) {
+            this.type = type;
+            this.userId = userId;
+            this.roomId = roomId;
+            this.message = message;
+            this.timestamp = System.currentTimeMillis();
+        }
+    }
+}
+```
+
+### Usage
+
+```java
+public class Main {
+    public static void main(String[] args) {
+        String connectionString = System.getenv("WEB_PUBSUB_CONNECTION_STRING");
+        ChatService chatService = new ChatService(connectionString);
+        
+        // Connect a user
+        WebPubSubClientAccessToken token = chatService.connectUser(
+            "user1", 
+            Arrays.asList("general", "support")
+        );
+        System.out.println("WebSocket URL: " + token.getUrl());
+        
+        // Send a message
+        chatService.sendMessage("user1", "general", "Hello everyone!");
+        
+        // Send direct message
+        chatService.sendDirectMessage("user1", "user2", "Hey, private message!");
+        
+        // Broadcast system message
+        chatService.broadcastSystemMessage("Server maintenance in 10 minutes");
+    }
+}
+```
+
+## Environment Variables
+
+```bash
+WEB_PUBSUB_CONNECTION_STRING=Endpoint=https://<resource>.webpubsub.azure.com;AccessKey=...
+WEB_PUBSUB_ENDPOINT=https://<resource>.webpubsub.azure.com
+WEB_PUBSUB_ACCESS_KEY=<your-access-key>
+```
+
+## Client Roles Reference
+
+| Role | Permission |
+|------|------------|
+| `webpubsub.joinLeaveGroup` | Join/leave any group |
+| `webpubsub.sendToGroup` | Send to any group |
+| `webpubsub.joinLeaveGroup.<group>` | Join/leave specific group |
+| `webpubsub.sendToGroup.<group>` | Send to specific group |
+
+## Best Practices
+
+1. **Use Groups** - Organize connections into groups for targeted messaging
+2. **User IDs** - Associate connections with user IDs for user-level messaging
+3. **Token Expiration** - Set appropriate token expiration for security
+4. **Roles** - Grant minimal required permissions via roles
+5. **Hub Isolation** - Use separate hubs for different application features
+6. **Connection Management** - Clean up inactive connections
+7. **Error Handling** - Handle connection failures gracefully

--- a/skills/java/monitoring/ingestion/SKILL.md
+++ b/skills/java/monitoring/ingestion/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: azure-monitor-ingestion-java
+description: |
+  Azure Monitor Ingestion SDK for Java. Send custom logs to Azure Monitor via Data Collection Rules (DCR) and Data Collection Endpoints (DCE).
+  Triggers: "LogsIngestionClient java", "azure monitor ingestion java", "custom logs java", "DCR java", "data collection rule java".
+---
+
+# Azure Monitor Ingestion SDK for Java
+
+Client library for sending custom logs to Azure Monitor using the Logs Ingestion API via Data Collection Rules.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-ingestion</artifactId>
+    <version>1.2.11</version>
+</dependency>
+```
+
+Or use Azure SDK BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-monitor-ingestion</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## Prerequisites
+
+- Data Collection Endpoint (DCE)
+- Data Collection Rule (DCR)
+- Log Analytics workspace
+- Target table (custom or built-in: CommonSecurityLog, SecurityEvents, Syslog, WindowsEvents)
+
+## Environment Variables
+
+```bash
+DATA_COLLECTION_ENDPOINT=https://<dce-name>.<region>.ingest.monitor.azure.com
+DATA_COLLECTION_RULE_ID=dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+STREAM_NAME=Custom-MyTable_CL
+```
+
+## Client Creation
+
+### Synchronous Client
+
+```java
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.monitor.ingestion.LogsIngestionClient;
+import com.azure.monitor.ingestion.LogsIngestionClientBuilder;
+
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+
+LogsIngestionClient client = new LogsIngestionClientBuilder()
+    .endpoint("<data-collection-endpoint>")
+    .credential(credential)
+    .buildClient();
+```
+
+### Asynchronous Client
+
+```java
+import com.azure.monitor.ingestion.LogsIngestionAsyncClient;
+
+LogsIngestionAsyncClient asyncClient = new LogsIngestionClientBuilder()
+    .endpoint("<data-collection-endpoint>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Data Collection Endpoint (DCE) | Ingestion endpoint URL for your region |
+| Data Collection Rule (DCR) | Defines data transformation and routing to tables |
+| Stream Name | Target stream in the DCR (e.g., `Custom-MyTable_CL`) |
+| Log Analytics Workspace | Destination for ingested logs |
+
+## Core Operations
+
+### Upload Custom Logs
+
+```java
+import java.util.List;
+import java.util.ArrayList;
+
+List<Object> logs = new ArrayList<>();
+logs.add(new MyLogEntry("2024-01-15T10:30:00Z", "INFO", "Application started"));
+logs.add(new MyLogEntry("2024-01-15T10:30:05Z", "DEBUG", "Processing request"));
+
+client.upload("<data-collection-rule-id>", "<stream-name>", logs);
+System.out.println("Logs uploaded successfully");
+```
+
+### Upload with Concurrency
+
+For large log collections, enable concurrent uploads:
+
+```java
+import com.azure.monitor.ingestion.models.LogsUploadOptions;
+import com.azure.core.util.Context;
+
+List<Object> logs = getLargeLogs(); // Large collection
+
+LogsUploadOptions options = new LogsUploadOptions()
+    .setMaxConcurrency(3);
+
+client.upload("<data-collection-rule-id>", "<stream-name>", logs, options, Context.NONE);
+```
+
+### Upload with Error Handling
+
+Handle partial upload failures gracefully:
+
+```java
+LogsUploadOptions options = new LogsUploadOptions()
+    .setLogsUploadErrorConsumer(uploadError -> {
+        System.err.println("Upload error: " + uploadError.getResponseException().getMessage());
+        System.err.println("Failed logs count: " + uploadError.getFailedLogs().size());
+        
+        // Option 1: Log and continue
+        // Option 2: Throw to abort remaining uploads
+        // throw uploadError.getResponseException();
+    });
+
+client.upload("<data-collection-rule-id>", "<stream-name>", logs, options, Context.NONE);
+```
+
+### Async Upload with Reactor
+
+```java
+import reactor.core.publisher.Mono;
+
+List<Object> logs = getLogs();
+
+asyncClient.upload("<data-collection-rule-id>", "<stream-name>", logs)
+    .doOnSuccess(v -> System.out.println("Upload completed"))
+    .doOnError(e -> System.err.println("Upload failed: " + e.getMessage()))
+    .subscribe();
+```
+
+## Log Entry Model Example
+
+```java
+public class MyLogEntry {
+    private String timeGenerated;
+    private String level;
+    private String message;
+    
+    public MyLogEntry(String timeGenerated, String level, String message) {
+        this.timeGenerated = timeGenerated;
+        this.level = level;
+        this.message = message;
+    }
+    
+    // Getters required for JSON serialization
+    public String getTimeGenerated() { return timeGenerated; }
+    public String getLevel() { return level; }
+    public String getMessage() { return message; }
+}
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+
+try {
+    client.upload(ruleId, streamName, logs);
+} catch (HttpResponseException e) {
+    System.err.println("HTTP Status: " + e.getResponse().getStatusCode());
+    System.err.println("Error: " + e.getMessage());
+    
+    if (e.getResponse().getStatusCode() == 403) {
+        System.err.println("Check DCR permissions and managed identity");
+    } else if (e.getResponse().getStatusCode() == 404) {
+        System.err.println("Verify DCE endpoint and DCR ID");
+    }
+}
+```
+
+## Best Practices
+
+1. **Batch logs** — Upload in batches rather than one at a time
+2. **Use concurrency** — Set `maxConcurrency` for large uploads
+3. **Handle partial failures** — Use error consumer to log failed entries
+4. **Match DCR schema** — Log entry fields must match DCR transformation expectations
+5. **Include TimeGenerated** — Most tables require a timestamp field
+6. **Reuse client** — Create once, reuse throughout application
+7. **Use async for high throughput** — `LogsIngestionAsyncClient` for reactive patterns
+
+## Querying Uploaded Logs
+
+Use [azure-monitor-query](../query/SKILL.md) to query ingested logs:
+
+```java
+// See azure-monitor-query skill for LogsQueryClient usage
+String query = "MyTable_CL | where TimeGenerated > ago(1h) | limit 10";
+```
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Maven Package | https://central.sonatype.com/artifact/com.azure/azure-monitor-ingestion |
+| GitHub | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/monitor/azure-monitor-ingestion |
+| Product Docs | https://learn.microsoft.com/azure/azure-monitor/logs/logs-ingestion-api-overview |
+| DCE Overview | https://learn.microsoft.com/azure/azure-monitor/essentials/data-collection-endpoint-overview |
+| DCR Overview | https://learn.microsoft.com/azure/azure-monitor/essentials/data-collection-rule-overview |
+| Troubleshooting | https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-ingestion/TROUBLESHOOTING.md |

--- a/skills/java/monitoring/ingestion/references/examples.md
+++ b/skills/java/monitoring/ingestion/references/examples.md
@@ -1,0 +1,282 @@
+# Azure Monitor Ingestion SDK for Java - Examples
+
+Comprehensive code examples for the Azure Monitor Ingestion SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Uploading Logs](#uploading-logs)
+- [Batching with Concurrency](#batching-with-concurrency)
+- [Error Handling](#error-handling)
+- [Async Client Patterns](#async-client-patterns)
+
+## Maven Dependency
+
+```xml
+<!-- Using Azure SDK BOM (recommended) -->
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>1.2.29</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-monitor-ingestion</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-identity</artifactId>
+    </dependency>
+</dependencies>
+
+<!-- Or direct dependencies -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-ingestion</artifactId>
+    <version>1.2.14</version>
+</dependency>
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.15.3</version>
+</dependency>
+```
+
+## Client Creation
+
+### Synchronous Client
+
+```java
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.monitor.ingestion.LogsIngestionClient;
+import com.azure.monitor.ingestion.LogsIngestionClientBuilder;
+
+DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+
+LogsIngestionClient client = new LogsIngestionClientBuilder()
+    .endpoint("<data-collection-endpoint>")  // e.g., "https://my-dce.eastus-1.ingest.monitor.azure.com"
+    .credential(credential)
+    .buildClient();
+```
+
+### Asynchronous Client
+
+```java
+import com.azure.monitor.ingestion.LogsIngestionAsyncClient;
+
+LogsIngestionAsyncClient asyncClient = new LogsIngestionClientBuilder()
+    .endpoint("<data-collection-endpoint>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+## Uploading Logs
+
+### Basic Upload
+
+```java
+import com.azure.monitor.ingestion.LogsIngestionClient;
+import com.azure.monitor.ingestion.models.LogsUploadException;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+List<Object> logs = Arrays.asList(
+    new Object() {
+        OffsetDateTime time = OffsetDateTime.now();
+        String computer = "Computer1";
+        String message = "Application started";
+        int level = 1;
+    },
+    new Object() {
+        OffsetDateTime time = OffsetDateTime.now();
+        String computer = "Computer2";
+        String message = "Connection established";
+        int level = 2;
+    }
+);
+
+try {
+    client.upload(
+        "dcr-00000000000000000000000000000000",  // DCR immutable ID
+        "Custom-MyTableRawData",                  // Stream name from DCR
+        logs
+    );
+    System.out.println("Logs uploaded successfully");
+} catch (LogsUploadException e) {
+    System.out.println("Failed to upload logs");
+    e.getLogsUploadErrors().forEach(error -> 
+        System.out.println(error.getMessage()));
+}
+```
+
+### Using POJO Classes
+
+```java
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+// Define log entry class
+class CustomLogEntry {
+    private OffsetDateTime timeGenerated;
+    private String computer;
+    private String message;
+    private int severity;
+
+    public CustomLogEntry(OffsetDateTime timeGenerated, String computer, 
+                          String message, int severity) {
+        this.timeGenerated = timeGenerated;
+        this.computer = computer;
+        this.message = message;
+        this.severity = severity;
+    }
+
+    // Getters required for JSON serialization
+    public OffsetDateTime getTimeGenerated() { return timeGenerated; }
+    public String getComputer() { return computer; }
+    public String getMessage() { return message; }
+    public int getSeverity() { return severity; }
+}
+
+// Create and upload logs
+List<Object> logs = new ArrayList<>();
+logs.add(new CustomLogEntry(OffsetDateTime.now(), "Server1", "Started", 1));
+logs.add(new CustomLogEntry(OffsetDateTime.now(), "Server2", "Connected", 2));
+
+client.upload("<dcr-id>", "<stream-name>", logs);
+```
+
+## Batching with Concurrency
+
+When uploading large collections, the SDK automatically splits them into batches:
+
+```java
+import com.azure.core.util.Context;
+import com.azure.monitor.ingestion.models.LogsUploadOptions;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+// Generate large batch
+List<Object> logs = new ArrayList<>();
+for (int i = 0; i < 100000; i++) {
+    final int index = i;
+    logs.add(new Object() {
+        OffsetDateTime time = OffsetDateTime.now();
+        String computer = "Computer" + (index % 10);
+        String message = "Log entry " + index;
+        int level = index % 5;
+    });
+}
+
+// Configure concurrency
+LogsUploadOptions options = new LogsUploadOptions()
+    .setMaxConcurrency(3);  // Up to 3 concurrent batch uploads
+
+client.upload("<dcr-id>", "<stream-name>", logs, options, Context.NONE);
+```
+
+## Error Handling
+
+### Error Consumer for Partial Failures
+
+```java
+import com.azure.core.util.Context;
+import com.azure.monitor.ingestion.models.LogsUploadOptions;
+
+LogsUploadOptions options = new LogsUploadOptions()
+    .setLogsUploadErrorConsumer(error -> {
+        // Log error details
+        System.out.println("Error: " + error.getResponseException().getMessage());
+        System.out.println("Failed logs: " + error.getFailedLogs().size());
+        
+        // Access failed logs for retry
+        error.getFailedLogs().forEach(log -> 
+            System.out.println("Failed: " + log));
+
+        // Option 1: Continue with remaining logs (default)
+        // Just return
+
+        // Option 2: Abort remaining uploads
+        // throw error.getResponseException();
+    });
+
+client.upload("<dcr-id>", "<stream-name>", logs, options, Context.NONE);
+```
+
+### Catching LogsUploadException
+
+```java
+import com.azure.monitor.ingestion.models.LogsUploadException;
+
+try {
+    client.upload("<dcr-id>", "<stream-name>", logs);
+    System.out.println("All logs uploaded");
+} catch (LogsUploadException e) {
+    System.out.println("Some logs failed");
+    e.getLogsUploadErrors().forEach(error -> {
+        System.out.println("Error: " + error.getMessage());
+        System.out.println("Status: " + 
+            error.getResponseException().getResponse().getStatusCode());
+    });
+}
+```
+
+## Async Client Patterns
+
+### Basic Async Upload
+
+```java
+import java.util.concurrent.CountDownLatch;
+
+CountDownLatch latch = new CountDownLatch(1);
+
+asyncClient.upload("<dcr-id>", "<stream-name>", logs)
+    .doOnSuccess(unused -> System.out.println("Uploaded successfully"))
+    .doOnError(error -> System.err.println("Failed: " + error.getMessage()))
+    .doFinally(signal -> latch.countDown())
+    .subscribe();
+
+latch.await();
+```
+
+### Async with Options
+
+```java
+import com.azure.monitor.ingestion.models.LogsUploadOptions;
+
+LogsUploadOptions options = new LogsUploadOptions()
+    .setMaxConcurrency(3)
+    .setLogsUploadErrorConsumer(error -> {
+        System.out.println("Partial failure: " + error.getFailedLogs().size());
+    });
+
+asyncClient.upload("<dcr-id>", "<stream-name>", logs, options)
+    .subscribe(
+        unused -> System.out.println("Success"),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Completed")
+    );
+```
+
+### Chaining Operations
+
+```java
+import reactor.core.publisher.Mono;
+
+Mono.just(generateLogs())
+    .flatMap(logs -> asyncClient.upload("<dcr-id>", "<stream-name>", logs))
+    .doOnSuccess(unused -> System.out.println("Upload complete"))
+    .doOnError(error -> System.err.println("Upload failed: " + error))
+    .subscribe();
+```

--- a/skills/java/monitoring/opentelemetry-exporter/SKILL.md
+++ b/skills/java/monitoring/opentelemetry-exporter/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: azure-monitor-opentelemetry-exporter-java
+description: |
+  Azure Monitor OpenTelemetry Exporter for Java. Export OpenTelemetry traces, metrics, and logs to Azure Monitor/Application Insights.
+  Triggers: "AzureMonitorExporter java", "opentelemetry azure java", "application insights java otel", "azure monitor tracing java".
+  Note: This package is DEPRECATED. Migrate to azure-monitor-opentelemetry-autoconfigure.
+---
+
+# Azure Monitor OpenTelemetry Exporter for Java
+
+> **⚠️ DEPRECATION NOTICE**: This package is deprecated. Migrate to `azure-monitor-opentelemetry-autoconfigure`.
+>
+> See [Migration Guide](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/MIGRATION.md) for detailed instructions.
+
+Export OpenTelemetry telemetry data to Azure Monitor / Application Insights.
+
+## Installation (Deprecated)
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-opentelemetry-exporter</artifactId>
+    <version>1.0.0-beta.x</version>
+</dependency>
+```
+
+## Recommended: Use Autoconfigure Instead
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-opentelemetry-autoconfigure</artifactId>
+    <version>LATEST</version>
+</dependency>
+```
+
+## Environment Variables
+
+```bash
+APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/
+```
+
+## Basic Setup with Autoconfigure (Recommended)
+
+### Using Environment Variable
+
+```java
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import io.opentelemetry.api.OpenTelemetry;
+import com.azure.monitor.opentelemetry.exporter.AzureMonitorExporter;
+
+// Connection string from APPLICATIONINSIGHTS_CONNECTION_STRING env var
+AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
+AzureMonitorExporter.customize(sdkBuilder);
+OpenTelemetry openTelemetry = sdkBuilder.build().getOpenTelemetrySdk();
+```
+
+### With Explicit Connection String
+
+```java
+AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
+AzureMonitorExporter.customize(sdkBuilder, "{connection-string}");
+OpenTelemetry openTelemetry = sdkBuilder.build().getOpenTelemetrySdk();
+```
+
+## Creating Spans
+
+```java
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
+// Get tracer
+Tracer tracer = openTelemetry.getTracer("com.example.myapp");
+
+// Create span
+Span span = tracer.spanBuilder("myOperation").startSpan();
+
+try (Scope scope = span.makeCurrent()) {
+    // Your application logic
+    doWork();
+} catch (Throwable t) {
+    span.recordException(t);
+    throw t;
+} finally {
+    span.end();
+}
+```
+
+## Adding Span Attributes
+
+```java
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+
+Span span = tracer.spanBuilder("processOrder")
+    .setAttribute("order.id", "12345")
+    .setAttribute("customer.tier", "premium")
+    .startSpan();
+
+try (Scope scope = span.makeCurrent()) {
+    // Add attributes during execution
+    span.setAttribute("items.count", 3);
+    span.setAttribute("total.amount", 99.99);
+    
+    processOrder();
+} finally {
+    span.end();
+}
+```
+
+## Custom Span Processor
+
+```java
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.context.Context;
+
+private static final AttributeKey<String> CUSTOM_ATTR = AttributeKey.stringKey("custom.attribute");
+
+SpanProcessor customProcessor = new SpanProcessor() {
+    @Override
+    public void onStart(Context context, ReadWriteSpan span) {
+        // Add custom attribute to every span
+        span.setAttribute(CUSTOM_ATTR, "customValue");
+    }
+
+    @Override
+    public boolean isStartRequired() {
+        return true;
+    }
+
+    @Override
+    public void onEnd(ReadableSpan span) {
+        // Post-processing if needed
+    }
+
+    @Override
+    public boolean isEndRequired() {
+        return false;
+    }
+};
+
+// Register processor
+AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
+AzureMonitorExporter.customize(sdkBuilder);
+
+sdkBuilder.addTracerProviderCustomizer(
+    (sdkTracerProviderBuilder, configProperties) -> 
+        sdkTracerProviderBuilder.addSpanProcessor(customProcessor)
+);
+
+OpenTelemetry openTelemetry = sdkBuilder.build().getOpenTelemetrySdk();
+```
+
+## Nested Spans
+
+```java
+public void parentOperation() {
+    Span parentSpan = tracer.spanBuilder("parentOperation").startSpan();
+    try (Scope scope = parentSpan.makeCurrent()) {
+        childOperation();
+    } finally {
+        parentSpan.end();
+    }
+}
+
+public void childOperation() {
+    // Automatically links to parent via Context
+    Span childSpan = tracer.spanBuilder("childOperation").startSpan();
+    try (Scope scope = childSpan.makeCurrent()) {
+        // Child work
+    } finally {
+        childSpan.end();
+    }
+}
+```
+
+## Recording Exceptions
+
+```java
+Span span = tracer.spanBuilder("riskyOperation").startSpan();
+try (Scope scope = span.makeCurrent()) {
+    performRiskyWork();
+} catch (Exception e) {
+    span.recordException(e);
+    span.setStatus(StatusCode.ERROR, e.getMessage());
+    throw e;
+} finally {
+    span.end();
+}
+```
+
+## Metrics (via OpenTelemetry)
+
+```java
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+
+Meter meter = openTelemetry.getMeter("com.example.myapp");
+
+// Counter
+LongCounter requestCounter = meter.counterBuilder("http.requests")
+    .setDescription("Total HTTP requests")
+    .setUnit("requests")
+    .build();
+
+requestCounter.add(1, Attributes.of(
+    AttributeKey.stringKey("http.method"), "GET",
+    AttributeKey.longKey("http.status_code"), 200L
+));
+
+// Histogram
+LongHistogram latencyHistogram = meter.histogramBuilder("http.latency")
+    .setDescription("Request latency")
+    .setUnit("ms")
+    .ofLongs()
+    .build();
+
+latencyHistogram.record(150, Attributes.of(
+    AttributeKey.stringKey("http.route"), "/api/users"
+));
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Connection String | Application Insights connection string with instrumentation key |
+| Tracer | Creates spans for distributed tracing |
+| Span | Represents a unit of work with timing and attributes |
+| SpanProcessor | Intercepts span lifecycle for customization |
+| Exporter | Sends telemetry to Azure Monitor |
+
+## Migration to Autoconfigure
+
+The `azure-monitor-opentelemetry-autoconfigure` package provides:
+- Automatic instrumentation of common libraries
+- Simplified configuration
+- Better integration with OpenTelemetry SDK
+
+### Migration Steps
+
+1. Replace dependency:
+   ```xml
+   <!-- Remove -->
+   <dependency>
+       <groupId>com.azure</groupId>
+       <artifactId>azure-monitor-opentelemetry-exporter</artifactId>
+   </dependency>
+   
+   <!-- Add -->
+   <dependency>
+       <groupId>com.azure</groupId>
+       <artifactId>azure-monitor-opentelemetry-autoconfigure</artifactId>
+   </dependency>
+   ```
+
+2. Update initialization code per [Migration Guide](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/MIGRATION.md)
+
+## Best Practices
+
+1. **Use autoconfigure** — Migrate to `azure-monitor-opentelemetry-autoconfigure`
+2. **Set meaningful span names** — Use descriptive operation names
+3. **Add relevant attributes** — Include contextual data for debugging
+4. **Handle exceptions** — Always record exceptions on spans
+5. **Use semantic conventions** — Follow OpenTelemetry semantic conventions
+6. **End spans in finally** — Ensure spans are always ended
+7. **Use try-with-resources** — Scope management with try-with-resources pattern
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Maven Package | https://central.sonatype.com/artifact/com.azure/azure-monitor-opentelemetry-exporter |
+| GitHub | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter |
+| Migration Guide | https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/MIGRATION.md |
+| Autoconfigure Package | https://central.sonatype.com/artifact/com.azure/azure-monitor-opentelemetry-autoconfigure |
+| OpenTelemetry Java | https://opentelemetry.io/docs/languages/java/ |
+| Application Insights | https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview |

--- a/skills/java/monitoring/opentelemetry-exporter/references/examples.md
+++ b/skills/java/monitoring/opentelemetry-exporter/references/examples.md
@@ -1,0 +1,178 @@
+# Azure Monitor OpenTelemetry Exporter Java - Migration Guide
+
+> **⚠️ DEPRECATION NOTICE**: This package (`azure-monitor-opentelemetry-exporter`) is deprecated.
+>
+> **Migrate to `azure-monitor-opentelemetry-autoconfigure`** for automatic instrumentation and simplified configuration.
+
+## Migration Overview
+
+| Old Package | New Package |
+|-------------|-------------|
+| `azure-monitor-opentelemetry-exporter` | `azure-monitor-opentelemetry-autoconfigure` |
+
+## Maven Dependency
+
+### Remove (Deprecated)
+
+```xml
+<!-- REMOVE THIS -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-opentelemetry-exporter</artifactId>
+    <version>1.0.0-beta.x</version>
+</dependency>
+```
+
+### Add (Recommended)
+
+```xml
+<!-- ADD THIS -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-opentelemetry-autoconfigure</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+## Environment Variables
+
+```bash
+APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/
+```
+
+## Basic Setup with Autoconfigure
+
+### Using Environment Variable (Simplest)
+
+```java
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import io.opentelemetry.api.OpenTelemetry;
+import com.azure.monitor.opentelemetry.exporter.AzureMonitorExporter;
+
+// Connection string from APPLICATIONINSIGHTS_CONNECTION_STRING env var
+AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
+AzureMonitorExporter.customize(sdkBuilder);
+OpenTelemetry openTelemetry = sdkBuilder.build().getOpenTelemetrySdk();
+```
+
+### With Explicit Connection String
+
+```java
+String connectionString = System.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING");
+
+AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
+AzureMonitorExporter.customize(sdkBuilder, connectionString);
+OpenTelemetry openTelemetry = sdkBuilder.build().getOpenTelemetrySdk();
+```
+
+## Creating Traces
+
+```java
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
+// Get tracer
+Tracer tracer = openTelemetry.getTracer("com.example.myapp");
+
+// Create span
+Span span = tracer.spanBuilder("processOrder").startSpan();
+
+try (Scope scope = span.makeCurrent()) {
+    // Your application logic
+    span.setAttribute("order.id", "12345");
+    span.setAttribute("customer.tier", "premium");
+    
+    processOrder();
+} catch (Throwable t) {
+    span.recordException(t);
+    throw t;
+} finally {
+    span.end();
+}
+```
+
+## Creating Metrics
+
+```java
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributeKey;
+
+Meter meter = openTelemetry.getMeter("com.example.myapp");
+
+// Counter
+LongCounter requestCounter = meter.counterBuilder("http.requests")
+    .setDescription("Total HTTP requests")
+    .setUnit("requests")
+    .build();
+
+requestCounter.add(1, Attributes.of(
+    AttributeKey.stringKey("http.method"), "GET",
+    AttributeKey.longKey("http.status_code"), 200L
+));
+```
+
+## Custom Span Processor
+
+```java
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.context.Context;
+
+SpanProcessor customProcessor = new SpanProcessor() {
+    @Override
+    public void onStart(Context context, ReadWriteSpan span) {
+        span.setAttribute("custom.attribute", "value");
+    }
+
+    @Override
+    public boolean isStartRequired() { return true; }
+
+    @Override
+    public void onEnd(ReadableSpan span) { }
+
+    @Override
+    public boolean isEndRequired() { return false; }
+};
+
+AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
+AzureMonitorExporter.customize(sdkBuilder);
+
+sdkBuilder.addTracerProviderCustomizer(
+    (sdkTracerProviderBuilder, configProperties) -> 
+        sdkTracerProviderBuilder.addSpanProcessor(customProcessor)
+);
+
+OpenTelemetry openTelemetry = sdkBuilder.build().getOpenTelemetrySdk();
+```
+
+## Why Migrate?
+
+The `azure-monitor-opentelemetry-autoconfigure` package provides:
+
+1. **Automatic instrumentation** — Common libraries instrumented automatically
+2. **Simplified configuration** — Less boilerplate code
+3. **Better integration** — Native OpenTelemetry SDK integration
+4. **Active maintenance** — Ongoing updates and improvements
+5. **Production ready** — GA (Generally Available) status
+
+## Migration Steps Summary
+
+1. Update Maven/Gradle dependency
+2. Replace manual exporter setup with `AzureMonitorExporter.customize()`
+3. Use `AutoConfiguredOpenTelemetrySdk.builder()` for SDK initialization
+4. Remove manual span processor registration (unless custom processors needed)
+5. Set `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Migration Guide | https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/MIGRATION.md |
+| Autoconfigure Package | https://central.sonatype.com/artifact/com.azure/azure-monitor-opentelemetry-autoconfigure |
+| OpenTelemetry Java | https://opentelemetry.io/docs/languages/java/ |
+| Application Insights | https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview |

--- a/skills/java/monitoring/query/SKILL.md
+++ b/skills/java/monitoring/query/SKILL.md
@@ -1,0 +1,416 @@
+---
+name: azure-monitor-query-java
+description: |
+  Azure Monitor Query SDK for Java. Execute Kusto queries against Log Analytics workspaces and query metrics from Azure resources.
+  Triggers: "LogsQueryClient java", "MetricsQueryClient java", "kusto query java", "log analytics java", "azure monitor query java".
+  Note: This package is deprecated. Migrate to azure-monitor-query-logs and azure-monitor-query-metrics.
+---
+
+# Azure Monitor Query SDK for Java
+
+> **DEPRECATION NOTICE**: This package is deprecated in favor of:
+> - `azure-monitor-query-logs` — For Log Analytics queries
+> - `azure-monitor-query-metrics` — For metrics queries
+>
+> See migration guides: [Logs Migration](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-query-logs/migration-guide.md) | [Metrics Migration](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-query-metrics/migration-guide.md)
+
+Client library for querying Azure Monitor Logs and Metrics.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-query</artifactId>
+    <version>1.5.9</version>
+</dependency>
+```
+
+Or use Azure SDK BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-monitor-query</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## Prerequisites
+
+- Log Analytics workspace (for logs queries)
+- Azure resource (for metrics queries)
+- TokenCredential with appropriate permissions
+
+## Environment Variables
+
+```bash
+LOG_ANALYTICS_WORKSPACE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+AZURE_RESOURCE_ID=/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{resource}
+```
+
+## Client Creation
+
+### LogsQueryClient (Sync)
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.monitor.query.LogsQueryClient;
+import com.azure.monitor.query.LogsQueryClientBuilder;
+
+LogsQueryClient logsClient = new LogsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### LogsQueryAsyncClient
+
+```java
+import com.azure.monitor.query.LogsQueryAsyncClient;
+
+LogsQueryAsyncClient logsAsyncClient = new LogsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+### MetricsQueryClient (Sync)
+
+```java
+import com.azure.monitor.query.MetricsQueryClient;
+import com.azure.monitor.query.MetricsQueryClientBuilder;
+
+MetricsQueryClient metricsClient = new MetricsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### MetricsQueryAsyncClient
+
+```java
+import com.azure.monitor.query.MetricsQueryAsyncClient;
+
+MetricsQueryAsyncClient metricsAsyncClient = new MetricsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+### Sovereign Cloud Configuration
+
+```java
+// Azure China Cloud - Logs
+LogsQueryClient logsClient = new LogsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint("https://api.loganalytics.azure.cn/v1")
+    .buildClient();
+
+// Azure China Cloud - Metrics
+MetricsQueryClient metricsClient = new MetricsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint("https://management.chinacloudapi.cn")
+    .buildClient();
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Logs | Log and performance data from Azure resources via Kusto Query Language |
+| Metrics | Numeric time-series data collected at regular intervals |
+| Workspace ID | Log Analytics workspace identifier |
+| Resource ID | Azure resource URI for metrics queries |
+| QueryTimeInterval | Time range for the query |
+
+## Logs Query Operations
+
+### Basic Query
+
+```java
+import com.azure.monitor.query.models.LogsQueryResult;
+import com.azure.monitor.query.models.LogsTableRow;
+import com.azure.monitor.query.models.QueryTimeInterval;
+import java.time.Duration;
+
+LogsQueryResult result = logsClient.queryWorkspace(
+    "{workspace-id}",
+    "AzureActivity | summarize count() by ResourceGroup | top 10 by count_",
+    new QueryTimeInterval(Duration.ofDays(7))
+);
+
+for (LogsTableRow row : result.getTable().getRows()) {
+    System.out.println(row.getColumnValue("ResourceGroup") + ": " + row.getColumnValue("count_"));
+}
+```
+
+### Query by Resource ID
+
+```java
+LogsQueryResult result = logsClient.queryResource(
+    "{resource-id}",
+    "AzureMetrics | where TimeGenerated > ago(1h)",
+    new QueryTimeInterval(Duration.ofDays(1))
+);
+
+for (LogsTableRow row : result.getTable().getRows()) {
+    System.out.println(row.getColumnValue("MetricName") + " " + row.getColumnValue("Average"));
+}
+```
+
+### Map Results to Custom Model
+
+```java
+// Define model class
+public class ActivityLog {
+    private String resourceGroup;
+    private String operationName;
+    
+    public String getResourceGroup() { return resourceGroup; }
+    public String getOperationName() { return operationName; }
+}
+
+// Query with model mapping
+List<ActivityLog> logs = logsClient.queryWorkspace(
+    "{workspace-id}",
+    "AzureActivity | project ResourceGroup, OperationName | take 100",
+    new QueryTimeInterval(Duration.ofDays(2)),
+    ActivityLog.class
+);
+
+for (ActivityLog log : logs) {
+    System.out.println(log.getOperationName() + " - " + log.getResourceGroup());
+}
+```
+
+### Batch Query
+
+```java
+import com.azure.monitor.query.models.LogsBatchQuery;
+import com.azure.monitor.query.models.LogsBatchQueryResult;
+import com.azure.monitor.query.models.LogsBatchQueryResultCollection;
+import com.azure.core.util.Context;
+
+LogsBatchQuery batchQuery = new LogsBatchQuery();
+String q1 = batchQuery.addWorkspaceQuery("{workspace-id}", "AzureActivity | count", new QueryTimeInterval(Duration.ofDays(1)));
+String q2 = batchQuery.addWorkspaceQuery("{workspace-id}", "Heartbeat | count", new QueryTimeInterval(Duration.ofDays(1)));
+String q3 = batchQuery.addWorkspaceQuery("{workspace-id}", "Perf | count", new QueryTimeInterval(Duration.ofDays(1)));
+
+LogsBatchQueryResultCollection results = logsClient
+    .queryBatchWithResponse(batchQuery, Context.NONE)
+    .getValue();
+
+LogsBatchQueryResult result1 = results.getResult(q1);
+LogsBatchQueryResult result2 = results.getResult(q2);
+LogsBatchQueryResult result3 = results.getResult(q3);
+
+// Check for failures
+if (result3.getQueryResultStatus() == LogsQueryResultStatus.FAILURE) {
+    System.err.println("Query failed: " + result3.getError().getMessage());
+}
+```
+
+### Query with Options
+
+```java
+import com.azure.monitor.query.models.LogsQueryOptions;
+import com.azure.core.http.rest.Response;
+
+LogsQueryOptions options = new LogsQueryOptions()
+    .setServerTimeout(Duration.ofMinutes(10))
+    .setIncludeStatistics(true)
+    .setIncludeVisualization(true);
+
+Response<LogsQueryResult> response = logsClient.queryWorkspaceWithResponse(
+    "{workspace-id}",
+    "AzureActivity | summarize count() by bin(TimeGenerated, 1h)",
+    new QueryTimeInterval(Duration.ofDays(7)),
+    options,
+    Context.NONE
+);
+
+LogsQueryResult result = response.getValue();
+
+// Access statistics
+BinaryData statistics = result.getStatistics();
+// Access visualization data
+BinaryData visualization = result.getVisualization();
+```
+
+### Query Multiple Workspaces
+
+```java
+import java.util.Arrays;
+
+LogsQueryOptions options = new LogsQueryOptions()
+    .setAdditionalWorkspaces(Arrays.asList("{workspace-id-2}", "{workspace-id-3}"));
+
+Response<LogsQueryResult> response = logsClient.queryWorkspaceWithResponse(
+    "{workspace-id-1}",
+    "AzureActivity | summarize count() by TenantId",
+    new QueryTimeInterval(Duration.ofDays(1)),
+    options,
+    Context.NONE
+);
+```
+
+## Metrics Query Operations
+
+### Basic Metrics Query
+
+```java
+import com.azure.monitor.query.models.MetricsQueryResult;
+import com.azure.monitor.query.models.MetricResult;
+import com.azure.monitor.query.models.TimeSeriesElement;
+import com.azure.monitor.query.models.MetricValue;
+import java.util.Arrays;
+
+MetricsQueryResult result = metricsClient.queryResource(
+    "{resource-uri}",
+    Arrays.asList("SuccessfulCalls", "TotalCalls")
+);
+
+for (MetricResult metric : result.getMetrics()) {
+    System.out.println("Metric: " + metric.getMetricName());
+    for (TimeSeriesElement ts : metric.getTimeSeries()) {
+        System.out.println("  Dimensions: " + ts.getMetadata());
+        for (MetricValue value : ts.getValues()) {
+            System.out.println("    " + value.getTimeStamp() + ": " + value.getTotal());
+        }
+    }
+}
+```
+
+### Metrics with Aggregations
+
+```java
+import com.azure.monitor.query.models.MetricsQueryOptions;
+import com.azure.monitor.query.models.AggregationType;
+
+Response<MetricsQueryResult> response = metricsClient.queryResourceWithResponse(
+    "{resource-id}",
+    Arrays.asList("SuccessfulCalls", "TotalCalls"),
+    new MetricsQueryOptions()
+        .setGranularity(Duration.ofHours(1))
+        .setAggregations(Arrays.asList(AggregationType.AVERAGE, AggregationType.COUNT)),
+    Context.NONE
+);
+
+MetricsQueryResult result = response.getValue();
+```
+
+### Query Multiple Resources (MetricsClient)
+
+```java
+import com.azure.monitor.query.MetricsClient;
+import com.azure.monitor.query.MetricsClientBuilder;
+import com.azure.monitor.query.models.MetricsQueryResourcesResult;
+
+MetricsClient metricsClient = new MetricsClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint("{endpoint}")
+    .buildClient();
+
+MetricsQueryResourcesResult result = metricsClient.queryResources(
+    Arrays.asList("{resourceId1}", "{resourceId2}"),
+    Arrays.asList("{metric1}", "{metric2}"),
+    "{metricNamespace}"
+);
+
+for (MetricsQueryResult queryResult : result.getMetricsQueryResults()) {
+    for (MetricResult metric : queryResult.getMetrics()) {
+        System.out.println(metric.getMetricName());
+        metric.getTimeSeries().stream()
+            .flatMap(ts -> ts.getValues().stream())
+            .forEach(mv -> System.out.println(
+                mv.getTimeStamp() + " Count=" + mv.getCount() + " Avg=" + mv.getAverage()));
+    }
+}
+```
+
+## Response Structure
+
+### Logs Response Hierarchy
+
+```
+LogsQueryResult
+├── statistics (BinaryData)
+├── visualization (BinaryData)
+├── error
+└── tables (List<LogsTable>)
+    ├── name
+    ├── columns (List<LogsTableColumn>)
+    │   ├── name
+    │   └── type
+    └── rows (List<LogsTableRow>)
+        ├── rowIndex
+        └── rowCells (List<LogsTableCell>)
+```
+
+### Metrics Response Hierarchy
+
+```
+MetricsQueryResult
+├── granularity
+├── timeInterval
+├── namespace
+├── resourceRegion
+└── metrics (List<MetricResult>)
+    ├── id, name, type, unit
+    └── timeSeries (List<TimeSeriesElement>)
+        ├── metadata (dimensions)
+        └── values (List<MetricValue>)
+            ├── timeStamp
+            ├── count, average, total
+            ├── maximum, minimum
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.monitor.query.models.LogsQueryResultStatus;
+
+try {
+    LogsQueryResult result = logsClient.queryWorkspace(workspaceId, query, timeInterval);
+    
+    // Check partial failure
+    if (result.getStatus() == LogsQueryResultStatus.PARTIAL_FAILURE) {
+        System.err.println("Partial failure: " + result.getError().getMessage());
+    }
+} catch (HttpResponseException e) {
+    System.err.println("Query failed: " + e.getMessage());
+    System.err.println("Status: " + e.getResponse().getStatusCode());
+}
+```
+
+## Best Practices
+
+1. **Use batch queries** — Combine multiple queries into a single request
+2. **Set appropriate timeouts** — Long queries may need extended server timeout
+3. **Limit result size** — Use `top` or `take` in Kusto queries
+4. **Use projections** — Select only needed columns with `project`
+5. **Check query status** — Handle PARTIAL_FAILURE results gracefully
+6. **Cache results** — Metrics don't change frequently; cache when appropriate
+7. **Migrate to new packages** — Plan migration to `azure-monitor-query-logs` and `azure-monitor-query-metrics`
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| Maven Package | https://central.sonatype.com/artifact/com.azure/azure-monitor-query |
+| GitHub | https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/monitor/azure-monitor-query |
+| API Reference | https://learn.microsoft.com/java/api/com.azure.monitor.query |
+| Kusto Query Language | https://learn.microsoft.com/azure/data-explorer/kusto/query/ |
+| Log Analytics Limits | https://learn.microsoft.com/azure/azure-monitor/service-limits#la-query-api |
+| Troubleshooting | https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/azure-monitor-query/TROUBLESHOOTING.md |

--- a/skills/java/monitoring/query/references/examples.md
+++ b/skills/java/monitoring/query/references/examples.md
@@ -1,0 +1,413 @@
+# Azure Monitor Query SDK for Java - Examples
+
+Comprehensive code examples for the Azure Monitor Query SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Querying Log Analytics](#querying-log-analytics)
+- [Querying Metrics](#querying-metrics)
+- [Batch Queries](#batch-queries)
+- [Handling Query Results](#handling-query-results)
+- [Time Ranges](#time-ranges)
+- [Async Client Patterns](#async-client-patterns)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<!-- Using Azure SDK BOM (recommended) -->
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>{bom_version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-monitor-query</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-identity</artifactId>
+    </dependency>
+</dependencies>
+
+<!-- Or direct dependencies -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-monitor-query</artifactId>
+    <version>1.5.9</version>
+</dependency>
+```
+
+## Client Creation
+
+### LogsQueryClient
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.monitor.query.LogsQueryClient;
+import com.azure.monitor.query.LogsQueryClientBuilder;
+
+LogsQueryClient logsQueryClient = new LogsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### MetricsQueryClient
+
+```java
+import com.azure.monitor.query.MetricsQueryClient;
+import com.azure.monitor.query.MetricsQueryClientBuilder;
+
+MetricsQueryClient metricsQueryClient = new MetricsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### For Sovereign Clouds
+
+```java
+LogsQueryClient logsQueryClient = new LogsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .endpoint("https://api.loganalytics.azure.cn/v1")
+    .buildClient();
+```
+
+## Querying Log Analytics
+
+### Query Workspace
+
+```java
+import com.azure.monitor.query.models.LogsQueryResult;
+import com.azure.monitor.query.models.LogsTableRow;
+import com.azure.monitor.query.models.QueryTimeInterval;
+import java.time.Duration;
+
+LogsQueryResult result = logsQueryClient.queryWorkspace(
+    "{workspace-id}",
+    "AzureActivity | top 10 by TimeGenerated",
+    new QueryTimeInterval(Duration.ofDays(2))
+);
+
+for (LogsTableRow row : result.getTable().getRows()) {
+    System.out.println(
+        row.getColumnValue("OperationName") + " " + 
+        row.getColumnValue("ResourceGroup")
+    );
+}
+```
+
+### Query by Resource ID
+
+```java
+LogsQueryResult result = logsQueryClient.queryResource(
+    "{resource-id}",  // Full Azure resource ID
+    "AzureActivity | top 10 by TimeGenerated",
+    new QueryTimeInterval(Duration.ofDays(2))
+);
+```
+
+### Query with Options
+
+```java
+import com.azure.monitor.query.models.LogsQueryOptions;
+
+LogsQueryResult result = logsQueryClient.queryWorkspace(
+    "{workspace-id}",
+    "AzureActivity | top 10 by TimeGenerated",
+    new QueryTimeInterval(Duration.ofDays(2)),
+    new LogsQueryOptions()
+        .setServerTimeout(Duration.ofMinutes(2))
+        .setIncludeStatistics(true)
+        .setIncludeVisualization(true)
+);
+```
+
+## Querying Metrics
+
+### Basic Metrics Query
+
+```java
+import com.azure.monitor.query.models.MetricResult;
+import com.azure.monitor.query.models.MetricValue;
+import com.azure.monitor.query.models.MetricsQueryResult;
+import com.azure.monitor.query.models.TimeSeriesElement;
+import java.util.Arrays;
+
+MetricsQueryResult result = metricsQueryClient.queryResource(
+    "{resource-uri}",
+    Arrays.asList("SuccessfulCalls", "TotalCalls")
+);
+
+for (MetricResult metric : result.getMetrics()) {
+    System.out.println("Metric: " + metric.getMetricName());
+    for (TimeSeriesElement ts : metric.getTimeSeries()) {
+        System.out.println("Dimensions: " + ts.getMetadata());
+        for (MetricValue value : ts.getValues()) {
+            System.out.println(value.getTimeStamp() + ": " + value.getTotal());
+        }
+    }
+}
+```
+
+### With Aggregations and Granularity
+
+```java
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+import com.azure.monitor.query.models.AggregationType;
+import com.azure.monitor.query.models.MetricsQueryOptions;
+
+Response<MetricsQueryResult> response = metricsQueryClient.queryResourceWithResponse(
+    "{resource-id}",
+    Arrays.asList("SuccessfulCalls", "TotalCalls"),
+    new MetricsQueryOptions()
+        .setGranularity(Duration.ofHours(1))
+        .setAggregations(Arrays.asList(
+            AggregationType.AVERAGE, 
+            AggregationType.COUNT
+        )),
+    Context.NONE
+);
+
+MetricsQueryResult result = response.getValue();
+```
+
+## Batch Queries
+
+```java
+import com.azure.monitor.query.models.LogsBatchQuery;
+import com.azure.monitor.query.models.LogsBatchQueryResult;
+import com.azure.monitor.query.models.LogsBatchQueryResultCollection;
+import com.azure.monitor.query.models.LogsQueryResultStatus;
+
+LogsBatchQuery batchQuery = new LogsBatchQuery();
+String q1 = batchQuery.addWorkspaceQuery("{workspace-id}", "{query-1}", 
+    new QueryTimeInterval(Duration.ofDays(2)));
+String q2 = batchQuery.addWorkspaceQuery("{workspace-id}", "{query-2}", 
+    new QueryTimeInterval(Duration.ofDays(30)));
+String q3 = batchQuery.addWorkspaceQuery("{workspace-id}", "{query-3}", 
+    new QueryTimeInterval(Duration.ofDays(10)));
+
+LogsBatchQueryResultCollection results = logsQueryClient
+    .queryBatchWithResponse(batchQuery, Context.NONE).getValue();
+
+// Process query 1 - iterate rows
+LogsBatchQueryResult result1 = results.getResult(q1);
+for (LogsTableRow row : result1.getTable().getRows()) {
+    System.out.println(row.getColumnValue("OperationName"));
+}
+
+// Process query 2 - map to model
+List<CustomModel> models = results.getResult(q2, CustomModel.class);
+
+// Check query 3 for failures
+LogsBatchQueryResult result3 = results.getResult(q3);
+if (result3.getQueryResultStatus() == LogsQueryResultStatus.FAILURE) {
+    System.out.println("Error: " + result3.getError().getMessage());
+}
+```
+
+## Handling Query Results
+
+### Response Structure
+
+```
+LogsQueryResult
+├── statistics
+├── visualization
+├── error
+└── tables (List<LogsTable>)
+    └── LogsTable
+        ├── name
+        ├── columns (List<LogsTableColumn>)
+        │   ├── name
+        │   └── type
+        └── rows (List<LogsTableRow>)
+            └── LogsTableRow
+                └── getColumnValue(name)
+```
+
+### Iterate Tables and Rows
+
+```java
+import com.azure.monitor.query.models.LogsTable;
+import com.azure.monitor.query.models.LogsTableColumn;
+import com.azure.monitor.query.models.LogsTableRow;
+
+LogsQueryResult result = logsQueryClient.queryWorkspace(...);
+LogsTable table = result.getTable();
+
+// Print columns
+System.out.println("Columns:");
+for (LogsTableColumn col : table.getColumns()) {
+    System.out.println("  " + col.getName() + " (" + col.getType() + ")");
+}
+
+// Print rows
+System.out.println("Rows:");
+for (LogsTableRow row : table.getRows()) {
+    Object operationName = row.getColumnValue("OperationName");
+    Object resourceGroup = row.getColumnValue("ResourceGroup");
+    System.out.println(operationName + " - " + resourceGroup);
+}
+```
+
+### Map to Custom Model
+
+```java
+// Define model
+public class CustomLogModel {
+    private String resourceGroup;
+    private String operationName;
+
+    public String getResourceGroup() { return resourceGroup; }
+    public String getOperationName() { return operationName; }
+}
+
+// Query and map
+List<CustomLogModel> models = logsQueryClient.queryWorkspace(
+    "{workspace-id}",
+    "{kusto-query}",
+    new QueryTimeInterval(Duration.ofDays(2)),
+    CustomLogModel.class
+);
+
+for (CustomLogModel model : models) {
+    System.out.println(model.getOperationName());
+}
+```
+
+## Time Ranges
+
+### Using Duration
+
+```java
+QueryTimeInterval last2Days = new QueryTimeInterval(Duration.ofDays(2));
+QueryTimeInterval last1Hour = new QueryTimeInterval(Duration.ofHours(1));
+QueryTimeInterval last30Min = new QueryTimeInterval(Duration.ofMinutes(30));
+```
+
+### Predefined Constants
+
+```java
+QueryTimeInterval lastHour = QueryTimeInterval.LAST_1_HOUR;
+QueryTimeInterval last7Days = QueryTimeInterval.LAST_7_DAYS;
+```
+
+### Absolute Time Range
+
+```java
+import java.time.OffsetDateTime;
+
+OffsetDateTime start = OffsetDateTime.now().minusDays(7);
+OffsetDateTime end = OffsetDateTime.now();
+QueryTimeInterval absolute = new QueryTimeInterval(start, end);
+```
+
+## Async Client Patterns
+
+### Create Async Clients
+
+```java
+import com.azure.monitor.query.LogsQueryAsyncClient;
+import com.azure.monitor.query.MetricsQueryAsyncClient;
+
+LogsQueryAsyncClient asyncLogsClient = new LogsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+
+MetricsQueryAsyncClient asyncMetricsClient = new MetricsQueryClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+### Async Logs Query
+
+```java
+asyncLogsClient.queryWorkspace(
+    "{workspace-id}",
+    "AzureActivity | top 10 by TimeGenerated",
+    new QueryTimeInterval(Duration.ofDays(2))
+)
+.subscribe(
+    result -> {
+        for (LogsTableRow row : result.getTable().getRows()) {
+            System.out.println(row.getColumnValue("OperationName"));
+        }
+    },
+    error -> System.err.println("Error: " + error.getMessage())
+);
+```
+
+### Async Metrics Query
+
+```java
+asyncMetricsClient.queryResource(
+    "{resource-id}",
+    Arrays.asList("SuccessfulCalls")
+)
+.subscribe(
+    result -> {
+        for (MetricResult metric : result.getMetrics()) {
+            System.out.println("Metric: " + metric.getMetricName());
+        }
+    },
+    error -> System.err.println("Error: " + error.getMessage())
+);
+```
+
+## Error Handling
+
+### Sync Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.monitor.query.models.LogsQueryResultStatus;
+
+try {
+    LogsQueryResult result = logsQueryClient.queryWorkspace(...);
+    
+    // Check for partial errors
+    if (result.getQueryResultStatus() == LogsQueryResultStatus.PARTIAL_FAILURE) {
+        System.out.println("Warning: " + result.getError().getMessage());
+    }
+} catch (HttpResponseException e) {
+    System.err.println("HTTP error: " + e.getResponse().getStatusCode());
+    System.err.println("Message: " + e.getMessage());
+} catch (Exception e) {
+    System.err.println("Error: " + e.getMessage());
+}
+```
+
+### Async Error Handling
+
+```java
+asyncLogsClient.queryWorkspace(...)
+    .subscribe(
+        result -> {
+            if (result.getQueryResultStatus() == LogsQueryResultStatus.FAILURE) {
+                System.err.println("Query failed: " + result.getError().getMessage());
+            } else {
+                // Process results
+            }
+        },
+        error -> {
+            if (error instanceof HttpResponseException) {
+                HttpResponseException httpError = (HttpResponseException) error;
+                System.err.println("HTTP: " + httpError.getResponse().getStatusCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        }
+    );
+```

--- a/skills/java/security/keyvault-keys/SKILL.md
+++ b/skills/java/security/keyvault-keys/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: azure-keyvault-keys-java
+description: Azure Key Vault Keys Java SDK for cryptographic key management. Use when creating, managing, or using RSA/EC keys, performing encrypt/decrypt/sign/verify operations, or working with HSM-backed keys.
+---
+
+# Azure Key Vault Keys (Java)
+
+Manage cryptographic keys and perform cryptographic operations in Azure Key Vault and Managed HSM.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-security-keyvault-keys</artifactId>
+    <version>4.9.0</version>
+</dependency>
+```
+
+## Client Creation
+
+```java
+import com.azure.security.keyvault.keys.KeyClient;
+import com.azure.security.keyvault.keys.KeyClientBuilder;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClient;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// Key management client
+KeyClient keyClient = new KeyClientBuilder()
+    .vaultUrl("https://<vault-name>.vault.azure.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+// Async client
+KeyAsyncClient keyAsyncClient = new KeyClientBuilder()
+    .vaultUrl("https://<vault-name>.vault.azure.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+
+// Cryptography client (for encrypt/decrypt/sign/verify)
+CryptographyClient cryptoClient = new CryptographyClientBuilder()
+    .keyIdentifier("https://<vault-name>.vault.azure.net/keys/<key-name>/<key-version>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+## Key Types
+
+| Type | Description |
+|------|-------------|
+| `RSA` | RSA key (2048, 3072, 4096 bits) |
+| `RSA_HSM` | RSA key in HSM |
+| `EC` | Elliptic Curve key |
+| `EC_HSM` | Elliptic Curve key in HSM |
+| `OCT` | Symmetric key (Managed HSM only) |
+| `OCT_HSM` | Symmetric key in HSM |
+
+## Create Keys
+
+### Create RSA Key
+
+```java
+import com.azure.security.keyvault.keys.models.*;
+
+// Simple RSA key
+KeyVaultKey rsaKey = keyClient.createRsaKey(new CreateRsaKeyOptions("my-rsa-key")
+    .setKeySize(2048));
+
+System.out.println("Key name: " + rsaKey.getName());
+System.out.println("Key ID: " + rsaKey.getId());
+System.out.println("Key type: " + rsaKey.getKeyType());
+
+// RSA key with options
+KeyVaultKey rsaKeyWithOptions = keyClient.createRsaKey(new CreateRsaKeyOptions("my-rsa-key-2")
+    .setKeySize(4096)
+    .setExpiresOn(OffsetDateTime.now().plusYears(1))
+    .setNotBefore(OffsetDateTime.now())
+    .setEnabled(true)
+    .setKeyOperations(KeyOperation.ENCRYPT, KeyOperation.DECRYPT, 
+                       KeyOperation.WRAP_KEY, KeyOperation.UNWRAP_KEY)
+    .setTags(Map.of("environment", "production")));
+
+// HSM-backed RSA key
+KeyVaultKey hsmKey = keyClient.createRsaKey(new CreateRsaKeyOptions("my-hsm-key")
+    .setKeySize(2048)
+    .setHardwareProtected(true));
+```
+
+### Create EC Key
+
+```java
+// EC key with P-256 curve
+KeyVaultKey ecKey = keyClient.createEcKey(new CreateEcKeyOptions("my-ec-key")
+    .setCurveName(KeyCurveName.P_256));
+
+// EC key with other curves
+KeyVaultKey ecKey384 = keyClient.createEcKey(new CreateEcKeyOptions("my-ec-key-384")
+    .setCurveName(KeyCurveName.P_384));
+
+KeyVaultKey ecKey521 = keyClient.createEcKey(new CreateEcKeyOptions("my-ec-key-521")
+    .setCurveName(KeyCurveName.P_521));
+
+// HSM-backed EC key
+KeyVaultKey ecHsmKey = keyClient.createEcKey(new CreateEcKeyOptions("my-ec-hsm-key")
+    .setCurveName(KeyCurveName.P_256)
+    .setHardwareProtected(true));
+```
+
+### Create Symmetric Key (Managed HSM only)
+
+```java
+KeyVaultKey octKey = keyClient.createOctKey(new CreateOctKeyOptions("my-symmetric-key")
+    .setKeySize(256)
+    .setHardwareProtected(true));
+```
+
+## Get Key
+
+```java
+// Get latest version
+KeyVaultKey key = keyClient.getKey("my-key");
+
+// Get specific version
+KeyVaultKey keyVersion = keyClient.getKey("my-key", "<version-id>");
+
+// Get only key properties (no key material)
+KeyProperties keyProps = keyClient.getKey("my-key").getProperties();
+```
+
+## Update Key Properties
+
+```java
+KeyVaultKey key = keyClient.getKey("my-key");
+
+// Update properties
+key.getProperties()
+    .setEnabled(false)
+    .setExpiresOn(OffsetDateTime.now().plusMonths(6))
+    .setTags(Map.of("status", "archived"));
+
+KeyVaultKey updatedKey = keyClient.updateKeyProperties(key.getProperties(),
+    KeyOperation.ENCRYPT, KeyOperation.DECRYPT);
+```
+
+## List Keys
+
+```java
+import com.azure.core.util.paging.PagedIterable;
+
+// List all keys
+for (KeyProperties keyProps : keyClient.listPropertiesOfKeys()) {
+    System.out.println("Key: " + keyProps.getName());
+    System.out.println("  Enabled: " + keyProps.isEnabled());
+    System.out.println("  Created: " + keyProps.getCreatedOn());
+}
+
+// List key versions
+for (KeyProperties version : keyClient.listPropertiesOfKeyVersions("my-key")) {
+    System.out.println("Version: " + version.getVersion());
+    System.out.println("Created: " + version.getCreatedOn());
+}
+```
+
+## Delete Key
+
+```java
+import com.azure.core.util.polling.SyncPoller;
+
+// Begin delete (soft-delete enabled vaults)
+SyncPoller<DeletedKey, Void> deletePoller = keyClient.beginDeleteKey("my-key");
+
+// Wait for deletion
+DeletedKey deletedKey = deletePoller.poll().getValue();
+System.out.println("Deleted: " + deletedKey.getDeletedOn());
+
+deletePoller.waitForCompletion();
+
+// Purge deleted key (permanent deletion)
+keyClient.purgeDeletedKey("my-key");
+
+// Recover deleted key
+SyncPoller<KeyVaultKey, Void> recoverPoller = keyClient.beginRecoverDeletedKey("my-key");
+recoverPoller.waitForCompletion();
+```
+
+## Cryptographic Operations
+
+### Encrypt/Decrypt
+
+```java
+import com.azure.security.keyvault.keys.cryptography.models.*;
+
+CryptographyClient cryptoClient = new CryptographyClientBuilder()
+    .keyIdentifier("https://<vault>.vault.azure.net/keys/<key-name>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+byte[] plaintext = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+
+// Encrypt
+EncryptResult encryptResult = cryptoClient.encrypt(EncryptionAlgorithm.RSA_OAEP, plaintext);
+byte[] ciphertext = encryptResult.getCipherText();
+System.out.println("Ciphertext length: " + ciphertext.length);
+
+// Decrypt
+DecryptResult decryptResult = cryptoClient.decrypt(EncryptionAlgorithm.RSA_OAEP, ciphertext);
+String decrypted = new String(decryptResult.getPlainText(), StandardCharsets.UTF_8);
+System.out.println("Decrypted: " + decrypted);
+```
+
+### Sign/Verify
+
+```java
+import java.security.MessageDigest;
+
+// Create digest of data
+byte[] data = "Data to sign".getBytes(StandardCharsets.UTF_8);
+MessageDigest md = MessageDigest.getInstance("SHA-256");
+byte[] digest = md.digest(data);
+
+// Sign
+SignResult signResult = cryptoClient.sign(SignatureAlgorithm.RS256, digest);
+byte[] signature = signResult.getSignature();
+
+// Verify
+VerifyResult verifyResult = cryptoClient.verify(SignatureAlgorithm.RS256, digest, signature);
+System.out.println("Valid signature: " + verifyResult.isValid());
+```
+
+### Wrap/Unwrap Key
+
+```java
+// Key to wrap (e.g., AES key)
+byte[] keyToWrap = new byte[32];  // 256-bit key
+new SecureRandom().nextBytes(keyToWrap);
+
+// Wrap
+WrapResult wrapResult = cryptoClient.wrapKey(KeyWrapAlgorithm.RSA_OAEP, keyToWrap);
+byte[] wrappedKey = wrapResult.getEncryptedKey();
+
+// Unwrap
+UnwrapResult unwrapResult = cryptoClient.unwrapKey(KeyWrapAlgorithm.RSA_OAEP, wrappedKey);
+byte[] unwrappedKey = unwrapResult.getKey();
+```
+
+## Backup and Restore
+
+```java
+// Backup
+byte[] backup = keyClient.backupKey("my-key");
+
+// Save backup to file
+Files.write(Paths.get("key-backup.blob"), backup);
+
+// Restore
+byte[] backupData = Files.readAllBytes(Paths.get("key-backup.blob"));
+KeyVaultKey restoredKey = keyClient.restoreKeyBackup(backupData);
+```
+
+## Key Rotation
+
+```java
+// Rotate to new version
+KeyVaultKey rotatedKey = keyClient.rotateKey("my-key");
+System.out.println("New version: " + rotatedKey.getProperties().getVersion());
+
+// Set rotation policy
+KeyRotationPolicy policy = new KeyRotationPolicy()
+    .setExpiresIn("P90D")  // Expire after 90 days
+    .setLifetimeActions(Arrays.asList(
+        new KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE)
+            .setTimeBeforeExpiry("P30D")));  // Rotate 30 days before expiry
+
+keyClient.updateKeyRotationPolicy("my-key", policy);
+
+// Get rotation policy
+KeyRotationPolicy currentPolicy = keyClient.getKeyRotationPolicy("my-key");
+```
+
+## Import Key
+
+```java
+import com.azure.security.keyvault.keys.models.ImportKeyOptions;
+import com.azure.security.keyvault.keys.models.JsonWebKey;
+
+// Import existing key material
+JsonWebKey jsonWebKey = new JsonWebKey()
+    .setKeyType(KeyType.RSA)
+    .setN(modulus)
+    .setE(exponent)
+    .setD(privateExponent)
+    // ... other RSA components
+    ;
+
+ImportKeyOptions importOptions = new ImportKeyOptions("imported-key", jsonWebKey)
+    .setHardwareProtected(false);
+
+KeyVaultKey importedKey = keyClient.importKey(importOptions);
+```
+
+## Encryption Algorithms
+
+| Algorithm | Key Type | Description |
+|-----------|----------|-------------|
+| `RSA1_5` | RSA | RSAES-PKCS1-v1_5 |
+| `RSA_OAEP` | RSA | RSAES with OAEP (recommended) |
+| `RSA_OAEP_256` | RSA | RSAES with OAEP using SHA-256 |
+| `A128GCM` | OCT | AES-GCM 128-bit |
+| `A256GCM` | OCT | AES-GCM 256-bit |
+| `A128CBC` | OCT | AES-CBC 128-bit |
+| `A256CBC` | OCT | AES-CBC 256-bit |
+
+## Signature Algorithms
+
+| Algorithm | Key Type | Hash |
+|-----------|----------|------|
+| `RS256` | RSA | SHA-256 |
+| `RS384` | RSA | SHA-384 |
+| `RS512` | RSA | SHA-512 |
+| `PS256` | RSA | SHA-256 (PSS) |
+| `ES256` | EC P-256 | SHA-256 |
+| `ES384` | EC P-384 | SHA-384 |
+| `ES512` | EC P-521 | SHA-512 |
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.exception.ResourceNotFoundException;
+
+try {
+    KeyVaultKey key = keyClient.getKey("non-existent-key");
+} catch (ResourceNotFoundException e) {
+    System.out.println("Key not found: " + e.getMessage());
+} catch (HttpResponseException e) {
+    System.out.println("HTTP error " + e.getResponse().getStatusCode());
+    System.out.println("Message: " + e.getMessage());
+}
+```
+
+## Environment Variables
+
+```bash
+AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net
+```
+
+## Best Practices
+
+1. **Use HSM Keys for Production** - Set `setHardwareProtected(true)` for sensitive keys
+2. **Enable Soft Delete** - Protects against accidental deletion
+3. **Key Rotation** - Set up automatic rotation policies
+4. **Least Privilege** - Use separate keys for different operations
+5. **Local Crypto When Possible** - Use `CryptographyClient` with local key material to reduce round-trips
+
+## Trigger Phrases
+
+- "Key Vault keys Java", "cryptographic keys Java"
+- "encrypt decrypt Java", "sign verify Java"
+- "RSA key", "EC key", "HSM key"
+- "key rotation", "wrap unwrap key"

--- a/skills/java/security/keyvault-keys/references/examples.md
+++ b/skills/java/security/keyvault-keys/references/examples.md
@@ -1,0 +1,514 @@
+# Azure Key Vault Keys SDK for Java - Examples
+
+Comprehensive code examples for the Azure Key Vault Keys SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Creating Keys](#creating-keys)
+- [Getting and Listing Keys](#getting-and-listing-keys)
+- [Updating Key Properties](#updating-key-properties)
+- [Deleting and Recovering Keys](#deleting-and-recovering-keys)
+- [Key Rotation](#key-rotation)
+- [Cryptographic Operations](#cryptographic-operations)
+- [Async Client Patterns](#async-client-patterns)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-security-keyvault-keys</artifactId>
+    <version>4.9.0</version>
+</dependency>
+
+<!-- Required for authentication -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.14.0</version>
+</dependency>
+```
+
+## Client Creation
+
+### Sync KeyClient
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.keys.KeyClient;
+import com.azure.security.keyvault.keys.KeyClientBuilder;
+
+KeyClient keyClient = new KeyClientBuilder()
+    .vaultUrl("<your-key-vault-url>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### Async KeyClient
+
+```java
+import com.azure.security.keyvault.keys.KeyAsyncClient;
+
+KeyAsyncClient keyAsyncClient = new KeyClientBuilder()
+    .vaultUrl("<your-key-vault-url>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+### Sync CryptographyClient
+
+```java
+import com.azure.security.keyvault.keys.cryptography.CryptographyClient;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
+
+CryptographyClient cryptographyClient = new CryptographyClientBuilder()
+    .keyIdentifier("<your-key-id>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+```
+
+### Async CryptographyClient
+
+```java
+import com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient;
+
+CryptographyAsyncClient cryptographyAsyncClient = new CryptographyClientBuilder()
+    .keyIdentifier("<your-key-id>")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+### CryptographyClient with Local JsonWebKey
+
+```java
+import com.azure.security.keyvault.keys.models.JsonWebKey;
+
+// For local cryptographic operations without Key Vault call
+JsonWebKey jsonWebKey = new JsonWebKey().setId("SampleJsonWebKey");
+CryptographyClient cryptographyClient = new CryptographyClientBuilder()
+    .jsonWebKey(jsonWebKey)
+    .buildClient();
+```
+
+## Creating Keys
+
+### Create RSA Key
+
+```java
+import com.azure.security.keyvault.keys.models.CreateRsaKeyOptions;
+import com.azure.security.keyvault.keys.models.KeyVaultKey;
+import java.time.OffsetDateTime;
+
+// Simple RSA key
+CreateRsaKeyOptions createRsaKeyOptions = new CreateRsaKeyOptions("myRsaKey")
+    .setKeySize(2048)
+    .setNotBefore(OffsetDateTime.now().plusDays(1))
+    .setExpiresOn(OffsetDateTime.now().plusYears(1));
+
+KeyVaultKey rsaKey = keyClient.createRsaKey(createRsaKeyOptions);
+System.out.printf("Created key: %s, ID: %s%n", rsaKey.getName(), rsaKey.getId());
+
+// RSA key with 4096-bit size
+keyClient.createRsaKey(new CreateRsaKeyOptions("CloudRsaKey")
+    .setExpiresOn(OffsetDateTime.now().plusYears(1))
+    .setKeySize(4096));
+```
+
+### Create EC (Elliptic Curve) Key
+
+```java
+import com.azure.security.keyvault.keys.models.CreateEcKeyOptions;
+import com.azure.security.keyvault.keys.models.KeyCurveName;
+
+CreateEcKeyOptions createEcKeyOptions = new CreateEcKeyOptions("myEcKey")
+    .setCurveName(KeyCurveName.P_384)
+    .setNotBefore(OffsetDateTime.now().plusDays(1))
+    .setExpiresOn(OffsetDateTime.now().plusYears(1));
+
+KeyVaultKey ecKey = keyClient.createEcKey(createEcKeyOptions);
+System.out.printf("Created EC key: %s%n", ecKey.getName());
+```
+
+### Create Symmetric (OCT) Key
+
+```java
+import com.azure.security.keyvault.keys.models.CreateOctKeyOptions;
+
+CreateOctKeyOptions createOctKeyOptions = new CreateOctKeyOptions("myOctKey")
+    .setNotBefore(OffsetDateTime.now().plusDays(1))
+    .setExpiresOn(OffsetDateTime.now().plusYears(1));
+
+KeyVaultKey octKey = keyClient.createOctKey(createOctKeyOptions);
+System.out.printf("Created OCT key: %s%n", octKey.getName());
+```
+
+### Create Key by Type
+
+```java
+import com.azure.security.keyvault.keys.models.CreateKeyOptions;
+import com.azure.security.keyvault.keys.models.KeyType;
+
+// Simple key creation
+KeyVaultKey key = keyClient.createKey("myKey", KeyType.EC);
+
+// With options
+CreateKeyOptions createKeyOptions = new CreateKeyOptions("myKey", KeyType.RSA)
+    .setNotBefore(OffsetDateTime.now().plusDays(1))
+    .setExpiresOn(OffsetDateTime.now().plusYears(1));
+
+KeyVaultKey optionsKey = keyClient.createKey(createKeyOptions);
+```
+
+## Getting and Listing Keys
+
+### Get a Key
+
+```java
+// Get latest version
+KeyVaultKey key = keyClient.getKey("myKey");
+System.out.printf("Key name: %s, ID: %s%n", key.getName(), key.getId());
+
+// Get specific version
+String keyVersion = "<key-version>";
+KeyVaultKey keyWithVersion = keyClient.getKey("myKey", keyVersion);
+```
+
+### Get Key with Response
+
+```java
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+
+Response<KeyVaultKey> getKeyResponse = keyClient.getKeyWithResponse(
+    "myKey", 
+    keyVersion, 
+    new Context("key1", "value1")
+);
+
+System.out.printf("Status code: %d%n", getKeyResponse.getStatusCode());
+System.out.printf("Key: %s%n", getKeyResponse.getValue().getName());
+```
+
+### List All Keys
+
+```java
+import com.azure.security.keyvault.keys.models.KeyProperties;
+
+// Simple iteration
+for (KeyProperties keyProperties : keyClient.listPropertiesOfKeys()) {
+    KeyVaultKey key = keyClient.getKey(keyProperties.getName(), keyProperties.getVersion());
+    System.out.printf("Key: %s, Type: %s%n", key.getName(), key.getKeyType());
+}
+
+// With pagination
+keyClient.listPropertiesOfKeys().iterableByPage().forEach(pagedResponse -> {
+    System.out.printf("Page status: %d%n", pagedResponse.getStatusCode());
+    pagedResponse.getElements().forEach(keyProperties -> {
+        System.out.printf("Key: %s%n", keyProperties.getName());
+    });
+});
+```
+
+### List Key Versions
+
+```java
+for (KeyProperties keyProperties : keyClient.listPropertiesOfKeyVersions("myKey")) {
+    KeyVaultKey key = keyClient.getKey(keyProperties.getName(), keyProperties.getVersion());
+    System.out.printf("Version: %s, Created: %s%n", 
+        key.getProperties().getVersion(), 
+        key.getProperties().getCreatedOn());
+}
+```
+
+## Updating Key Properties
+
+```java
+import com.azure.security.keyvault.keys.models.KeyOperation;
+
+// Get key first
+KeyVaultKey key = keyClient.getKey("myKey");
+
+// Update expiry time
+key.getProperties().setExpiresOn(OffsetDateTime.now().plusDays(60));
+
+// Update with allowed operations
+KeyVaultKey updatedKey = keyClient.updateKeyProperties(
+    key.getProperties(), 
+    KeyOperation.ENCRYPT, 
+    KeyOperation.DECRYPT
+);
+
+System.out.printf("Updated key: %s%n", updatedKey.getName());
+```
+
+### Update with Response
+
+```java
+Response<KeyVaultKey> updateKeyResponse = keyClient.updateKeyPropertiesWithResponse(
+    key.getProperties(), 
+    new Context("key1", "value1"),
+    KeyOperation.ENCRYPT, 
+    KeyOperation.DECRYPT
+);
+
+System.out.printf("Update status: %d%n", updateKeyResponse.getStatusCode());
+```
+
+## Deleting and Recovering Keys
+
+### Delete a Key
+
+```java
+import com.azure.core.util.polling.PollResponse;
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.security.keyvault.keys.models.DeletedKey;
+
+// Begin delete (long-running operation)
+SyncPoller<DeletedKey, Void> deleteKeyPoller = keyClient.beginDeleteKey("myKey");
+PollResponse<DeletedKey> deleteKeyPollResponse = deleteKeyPoller.poll();
+
+// Get deleted key info
+DeletedKey deletedKey = deleteKeyPollResponse.getValue();
+System.out.printf("Delete date: %s%n", deletedKey.getDeletedOn());
+System.out.printf("Recovery ID: %s%n", deletedKey.getRecoveryId());
+
+// Wait for deletion to complete
+deleteKeyPoller.waitForCompletion();
+```
+
+### Get Deleted Key
+
+```java
+DeletedKey deletedKey = keyClient.getDeletedKey("myKey");
+System.out.printf("Recovery ID: %s%n", deletedKey.getRecoveryId());
+```
+
+### List Deleted Keys
+
+```java
+for (DeletedKey deletedKey : keyClient.listDeletedKeys()) {
+    System.out.printf("Deleted key: %s, Recovery ID: %s%n", 
+        deletedKey.getName(), 
+        deletedKey.getRecoveryId());
+}
+```
+
+### Recover Deleted Key
+
+```java
+SyncPoller<KeyVaultKey, Void> recoverKeyPoller = keyClient.beginRecoverDeletedKey("myKey");
+PollResponse<KeyVaultKey> recoverKeyPollResponse = recoverKeyPoller.poll();
+
+KeyVaultKey recoveredKey = recoverKeyPollResponse.getValue();
+System.out.printf("Recovered key: %s%n", recoveredKey.getName());
+
+recoverKeyPoller.waitForCompletion();
+```
+
+### Purge Deleted Key
+
+```java
+// Permanently delete (cannot be recovered)
+keyClient.purgeDeletedKey("myKey");
+System.out.println("Key purged permanently");
+```
+
+## Key Rotation
+
+### Rotate Key
+
+```java
+// Create new version of the key
+KeyVaultKey rotatedKey = keyClient.rotateKey("myKey");
+System.out.printf("New key version: %s%n", rotatedKey.getProperties().getVersion());
+```
+
+### Get Key Rotation Policy
+
+```java
+import com.azure.security.keyvault.keys.models.KeyRotationPolicy;
+
+KeyRotationPolicy policy = keyClient.getKeyRotationPolicy("myKey");
+System.out.printf("Policy ID: %s%n", policy.getId());
+```
+
+### Update Key Rotation Policy
+
+```java
+import com.azure.security.keyvault.keys.models.KeyRotationLifetimeAction;
+import com.azure.security.keyvault.keys.models.KeyRotationPolicyAction;
+
+KeyRotationPolicy policy = new KeyRotationPolicy()
+    .setExpiresIn("P90D")  // Key expires in 90 days
+    .setLifetimeActions(Arrays.asList(
+        new KeyRotationLifetimeAction(KeyRotationPolicyAction.ROTATE)
+            .setTimeBeforeExpiry("P30D")  // Rotate 30 days before expiry
+    ));
+
+KeyRotationPolicy updatedPolicy = keyClient.updateKeyRotationPolicy("myKey", policy);
+```
+
+## Cryptographic Operations
+
+### Encrypt and Decrypt
+
+```java
+import com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm;
+import com.azure.security.keyvault.keys.cryptography.models.EncryptResult;
+import com.azure.security.keyvault.keys.cryptography.models.DecryptResult;
+
+byte[] plaintext = "Hello, World!".getBytes();
+
+// Encrypt
+EncryptResult encryptResult = cryptographyClient.encrypt(
+    EncryptionAlgorithm.RSA_OAEP, 
+    plaintext
+);
+byte[] ciphertext = encryptResult.getCipherText();
+System.out.printf("Encrypted: %d bytes%n", ciphertext.length);
+
+// Decrypt
+DecryptResult decryptResult = cryptographyClient.decrypt(
+    EncryptionAlgorithm.RSA_OAEP, 
+    ciphertext
+);
+String decryptedText = new String(decryptResult.getPlainText());
+System.out.printf("Decrypted: %s%n", decryptedText);
+```
+
+### Sign and Verify
+
+```java
+import com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm;
+import com.azure.security.keyvault.keys.cryptography.models.SignResult;
+import com.azure.security.keyvault.keys.cryptography.models.VerifyResult;
+import java.security.MessageDigest;
+
+byte[] data = "Data to sign".getBytes();
+MessageDigest md = MessageDigest.getInstance("SHA-256");
+byte[] digest = md.digest(data);
+
+// Sign
+SignResult signResult = cryptographyClient.sign(
+    SignatureAlgorithm.RS256, 
+    digest
+);
+byte[] signature = signResult.getSignature();
+System.out.printf("Signature: %d bytes%n", signature.length);
+
+// Verify
+VerifyResult verifyResult = cryptographyClient.verify(
+    SignatureAlgorithm.RS256, 
+    digest, 
+    signature
+);
+System.out.printf("Signature valid: %s%n", verifyResult.isValid());
+```
+
+### Wrap and Unwrap Key
+
+```java
+import com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm;
+import com.azure.security.keyvault.keys.cryptography.models.WrapResult;
+import com.azure.security.keyvault.keys.cryptography.models.UnwrapResult;
+
+byte[] keyToWrap = new byte[32];  // 256-bit key
+new java.security.SecureRandom().nextBytes(keyToWrap);
+
+// Wrap
+WrapResult wrapResult = cryptographyClient.wrapKey(
+    KeyWrapAlgorithm.RSA_OAEP, 
+    keyToWrap
+);
+byte[] wrappedKey = wrapResult.getEncryptedKey();
+System.out.printf("Wrapped key: %d bytes%n", wrappedKey.length);
+
+// Unwrap
+UnwrapResult unwrapResult = cryptographyClient.unwrapKey(
+    KeyWrapAlgorithm.RSA_OAEP, 
+    wrappedKey
+);
+byte[] unwrappedKey = unwrapResult.getKey();
+System.out.printf("Unwrapped key: %d bytes%n", unwrappedKey.length);
+```
+
+## Async Client Patterns
+
+### Create Key Async
+
+```java
+keyAsyncClient.createRsaKey(new CreateRsaKeyOptions("asyncKey").setKeySize(2048))
+    .subscribe(
+        key -> System.out.printf("Created key: %s%n", key.getName()),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Create completed")
+    );
+```
+
+### List Keys Async
+
+```java
+keyAsyncClient.listPropertiesOfKeys()
+    .subscribe(keyProperties -> {
+        System.out.printf("Key: %s%n", keyProperties.getName());
+    });
+```
+
+### Encrypt/Decrypt Async
+
+```java
+byte[] plaintext = "Hello, async!".getBytes();
+
+cryptographyAsyncClient.encrypt(EncryptionAlgorithm.RSA_OAEP, plaintext)
+    .flatMap(encryptResult -> {
+        System.out.printf("Encrypted: %d bytes%n", encryptResult.getCipherText().length);
+        return cryptographyAsyncClient.decrypt(
+            EncryptionAlgorithm.RSA_OAEP, 
+            encryptResult.getCipherText()
+        );
+    })
+    .subscribe(
+        decryptResult -> System.out.printf("Decrypted: %s%n", 
+            new String(decryptResult.getPlainText())),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.exception.ResourceNotFoundException;
+
+try {
+    KeyVaultKey key = keyClient.getKey("nonexistent-key");
+} catch (ResourceNotFoundException e) {
+    System.err.println("Key not found: " + e.getMessage());
+} catch (HttpResponseException e) {
+    System.err.println("HTTP error: " + e.getResponse().getStatusCode());
+    System.err.println("Message: " + e.getMessage());
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+### Async Error Handling
+
+```java
+keyAsyncClient.getKey("nonexistent-key")
+    .subscribe(
+        key -> System.out.println("Key: " + key.getName()),
+        error -> {
+            if (error instanceof ResourceNotFoundException) {
+                System.err.println("Key not found");
+            } else if (error instanceof HttpResponseException) {
+                HttpResponseException httpError = (HttpResponseException) error;
+                System.err.println("HTTP error: " + httpError.getResponse().getStatusCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        }
+    );
+```

--- a/skills/java/security/keyvault-secrets/SKILL.md
+++ b/skills/java/security/keyvault-secrets/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: azure-keyvault-secrets-java
+description: Azure Key Vault Secrets Java SDK for secret management. Use when storing, retrieving, or managing passwords, API keys, connection strings, or other sensitive configuration data.
+---
+
+# Azure Key Vault Secrets (Java)
+
+Securely store and manage secrets like passwords, API keys, and connection strings.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-security-keyvault-secrets</artifactId>
+    <version>4.9.0</version>
+</dependency>
+```
+
+## Client Creation
+
+```java
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// Sync client
+SecretClient secretClient = new SecretClientBuilder()
+    .vaultUrl("https://<vault-name>.vault.azure.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+// Async client
+SecretAsyncClient secretAsyncClient = new SecretClientBuilder()
+    .vaultUrl("https://<vault-name>.vault.azure.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+```
+
+## Create/Set Secret
+
+```java
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+
+// Simple secret
+KeyVaultSecret secret = secretClient.setSecret("database-password", "P@ssw0rd123!");
+System.out.println("Secret name: " + secret.getName());
+System.out.println("Secret ID: " + secret.getId());
+
+// Secret with options
+KeyVaultSecret secretWithOptions = secretClient.setSecret(
+    new KeyVaultSecret("api-key", "sk_live_abc123xyz")
+        .setProperties(new SecretProperties()
+            .setContentType("application/json")
+            .setExpiresOn(OffsetDateTime.now().plusYears(1))
+            .setNotBefore(OffsetDateTime.now())
+            .setEnabled(true)
+            .setTags(Map.of(
+                "environment", "production",
+                "service", "payment-api"
+            ))
+        )
+);
+```
+
+## Get Secret
+
+```java
+// Get latest version
+KeyVaultSecret secret = secretClient.getSecret("database-password");
+String value = secret.getValue();
+System.out.println("Secret value: " + value);
+
+// Get specific version
+KeyVaultSecret specificVersion = secretClient.getSecret("database-password", "<version-id>");
+
+// Get only properties (no value)
+SecretProperties props = secretClient.getSecret("database-password").getProperties();
+System.out.println("Enabled: " + props.isEnabled());
+System.out.println("Created: " + props.getCreatedOn());
+```
+
+## Update Secret Properties
+
+```java
+// Get secret
+KeyVaultSecret secret = secretClient.getSecret("api-key");
+
+// Update properties (cannot update value - create new version instead)
+secret.getProperties()
+    .setEnabled(false)
+    .setExpiresOn(OffsetDateTime.now().plusMonths(6))
+    .setTags(Map.of("status", "rotating"));
+
+SecretProperties updated = secretClient.updateSecretProperties(secret.getProperties());
+System.out.println("Updated: " + updated.getUpdatedOn());
+```
+
+## List Secrets
+
+```java
+import com.azure.core.util.paging.PagedIterable;
+import com.azure.security.keyvault.secrets.models.SecretProperties;
+
+// List all secrets (properties only, no values)
+for (SecretProperties secretProps : secretClient.listPropertiesOfSecrets()) {
+    System.out.println("Secret: " + secretProps.getName());
+    System.out.println("  Enabled: " + secretProps.isEnabled());
+    System.out.println("  Created: " + secretProps.getCreatedOn());
+    System.out.println("  Content-Type: " + secretProps.getContentType());
+    
+    // Get value if needed
+    if (secretProps.isEnabled()) {
+        KeyVaultSecret fullSecret = secretClient.getSecret(secretProps.getName());
+        System.out.println("  Value: " + fullSecret.getValue().substring(0, 5) + "...");
+    }
+}
+
+// List versions of a secret
+for (SecretProperties version : secretClient.listPropertiesOfSecretVersions("database-password")) {
+    System.out.println("Version: " + version.getVersion());
+    System.out.println("Created: " + version.getCreatedOn());
+    System.out.println("Enabled: " + version.isEnabled());
+}
+```
+
+## Delete Secret
+
+```java
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.security.keyvault.secrets.models.DeletedSecret;
+
+// Begin delete (returns poller for soft-delete enabled vaults)
+SyncPoller<DeletedSecret, Void> deletePoller = secretClient.beginDeleteSecret("old-secret");
+
+// Wait for deletion
+DeletedSecret deletedSecret = deletePoller.poll().getValue();
+System.out.println("Deleted on: " + deletedSecret.getDeletedOn());
+System.out.println("Scheduled purge: " + deletedSecret.getScheduledPurgeDate());
+
+deletePoller.waitForCompletion();
+```
+
+## Recover Deleted Secret
+
+```java
+// List deleted secrets
+for (DeletedSecret deleted : secretClient.listDeletedSecrets()) {
+    System.out.println("Deleted: " + deleted.getName());
+    System.out.println("Deletion date: " + deleted.getDeletedOn());
+}
+
+// Recover deleted secret
+SyncPoller<KeyVaultSecret, Void> recoverPoller = secretClient.beginRecoverDeletedSecret("old-secret");
+recoverPoller.waitForCompletion();
+
+KeyVaultSecret recovered = recoverPoller.getFinalResult();
+System.out.println("Recovered: " + recovered.getName());
+```
+
+## Purge Deleted Secret
+
+```java
+// Permanently delete (cannot be recovered)
+secretClient.purgeDeletedSecret("old-secret");
+
+// Get deleted secret info first
+DeletedSecret deleted = secretClient.getDeletedSecret("old-secret");
+System.out.println("Will purge: " + deleted.getName());
+secretClient.purgeDeletedSecret("old-secret");
+```
+
+## Backup and Restore
+
+```java
+// Backup secret (all versions)
+byte[] backup = secretClient.backupSecret("important-secret");
+
+// Save to file
+Files.write(Paths.get("secret-backup.blob"), backup);
+
+// Restore from backup
+byte[] backupData = Files.readAllBytes(Paths.get("secret-backup.blob"));
+KeyVaultSecret restored = secretClient.restoreSecretBackup(backupData);
+System.out.println("Restored: " + restored.getName());
+```
+
+## Async Operations
+
+```java
+SecretAsyncClient asyncClient = new SecretClientBuilder()
+    .vaultUrl("https://<vault>.vault.azure.net")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildAsyncClient();
+
+// Set secret async
+asyncClient.setSecret("async-secret", "async-value")
+    .subscribe(
+        secret -> System.out.println("Created: " + secret.getName()),
+        error -> System.out.println("Error: " + error.getMessage())
+    );
+
+// Get secret async
+asyncClient.getSecret("async-secret")
+    .subscribe(secret -> System.out.println("Value: " + secret.getValue()));
+
+// List secrets async
+asyncClient.listPropertiesOfSecrets()
+    .doOnNext(props -> System.out.println("Found: " + props.getName()))
+    .subscribe();
+```
+
+## Configuration Patterns
+
+### Load Multiple Secrets
+
+```java
+public class ConfigLoader {
+    private final SecretClient client;
+    
+    public ConfigLoader(String vaultUrl) {
+        this.client = new SecretClientBuilder()
+            .vaultUrl(vaultUrl)
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+    }
+    
+    public Map<String, String> loadSecrets(List<String> secretNames) {
+        Map<String, String> secrets = new HashMap<>();
+        for (String name : secretNames) {
+            try {
+                KeyVaultSecret secret = client.getSecret(name);
+                secrets.put(name, secret.getValue());
+            } catch (ResourceNotFoundException e) {
+                System.out.println("Secret not found: " + name);
+            }
+        }
+        return secrets;
+    }
+}
+
+// Usage
+ConfigLoader loader = new ConfigLoader("https://my-vault.vault.azure.net");
+Map<String, String> config = loader.loadSecrets(
+    Arrays.asList("db-connection-string", "api-key", "jwt-secret")
+);
+```
+
+### Secret Rotation Pattern
+
+```java
+public void rotateSecret(String secretName, String newValue) {
+    // Get current secret
+    KeyVaultSecret current = secretClient.getSecret(secretName);
+    
+    // Disable old version
+    current.getProperties().setEnabled(false);
+    secretClient.updateSecretProperties(current.getProperties());
+    
+    // Create new version with new value
+    KeyVaultSecret newSecret = secretClient.setSecret(secretName, newValue);
+    System.out.println("Rotated to version: " + newSecret.getProperties().getVersion());
+}
+```
+
+## Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.exception.ResourceNotFoundException;
+
+try {
+    KeyVaultSecret secret = secretClient.getSecret("my-secret");
+    System.out.println("Value: " + secret.getValue());
+} catch (ResourceNotFoundException e) {
+    System.out.println("Secret not found");
+} catch (HttpResponseException e) {
+    int status = e.getResponse().getStatusCode();
+    if (status == 403) {
+        System.out.println("Access denied - check permissions");
+    } else if (status == 429) {
+        System.out.println("Rate limited - retry later");
+    } else {
+        System.out.println("HTTP error: " + status);
+    }
+}
+```
+
+## Secret Properties
+
+| Property | Description |
+|----------|-------------|
+| `name` | Secret name |
+| `value` | Secret value (string) |
+| `id` | Full identifier URL |
+| `contentType` | MIME type hint |
+| `enabled` | Whether secret can be retrieved |
+| `notBefore` | Activation time |
+| `expiresOn` | Expiration time |
+| `createdOn` | Creation timestamp |
+| `updatedOn` | Last update timestamp |
+| `recoveryLevel` | Soft-delete recovery level |
+| `tags` | User-defined metadata |
+
+## Environment Variables
+
+```bash
+AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net
+```
+
+## Best Practices
+
+1. **Enable Soft Delete** - Protects against accidental deletion
+2. **Use Tags** - Tag secrets with environment, service, owner
+3. **Set Expiration** - Use `setExpiresOn()` for credentials that should rotate
+4. **Content Type** - Set `contentType` to indicate format (e.g., `application/json`)
+5. **Version Management** - Don't delete old versions immediately during rotation
+6. **Access Logging** - Enable diagnostic logging on Key Vault
+7. **Least Privilege** - Use separate vaults for different environments
+
+## Common Secret Types
+
+```java
+// Database connection string
+secretClient.setSecret(new KeyVaultSecret("db-connection", 
+    "Server=myserver.database.windows.net;Database=mydb;...")
+    .setProperties(new SecretProperties()
+        .setContentType("text/plain")
+        .setTags(Map.of("type", "connection-string"))));
+
+// API key
+secretClient.setSecret(new KeyVaultSecret("stripe-api-key", "sk_live_...")
+    .setProperties(new SecretProperties()
+        .setContentType("text/plain")
+        .setExpiresOn(OffsetDateTime.now().plusYears(1))));
+
+// JSON configuration
+secretClient.setSecret(new KeyVaultSecret("app-config", 
+    "{\"endpoint\":\"https://...\",\"key\":\"...\"}")
+    .setProperties(new SecretProperties()
+        .setContentType("application/json")));
+
+// Certificate password
+secretClient.setSecret(new KeyVaultSecret("cert-password", "CertP@ss!")
+    .setProperties(new SecretProperties()
+        .setContentType("text/plain")
+        .setTags(Map.of("certificate", "my-cert"))));
+```
+
+## Trigger Phrases
+
+- "Key Vault secrets Java", "secret management Java"
+- "store password", "store API key", "connection string"
+- "retrieve secret", "rotate secret"
+- "Azure secrets", "vault secrets"

--- a/skills/java/security/keyvault-secrets/references/examples.md
+++ b/skills/java/security/keyvault-secrets/references/examples.md
@@ -1,0 +1,395 @@
+# Azure Key Vault Secrets SDK for Java - Examples
+
+Comprehensive code examples for the Azure Key Vault Secrets SDK for Java.
+
+## Table of Contents
+- [Maven Dependency](#maven-dependency)
+- [Client Creation](#client-creation)
+- [Setting Secrets](#setting-secrets)
+- [Getting Secrets](#getting-secrets)
+- [Listing Secrets](#listing-secrets)
+- [Updating Secret Properties](#updating-secret-properties)
+- [Deleting and Recovering Secrets](#deleting-and-recovering-secrets)
+- [Purging Deleted Secrets](#purging-deleted-secrets)
+- [Backup and Restore](#backup-and-restore)
+- [Async Client Patterns](#async-client-patterns)
+- [Error Handling](#error-handling)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-security-keyvault-secrets</artifactId>
+    <version>4.11.0-beta.1</version>
+</dependency>
+
+<!-- Required for authentication -->
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-identity</artifactId>
+    <version>1.18.2</version>
+</dependency>
+```
+
+## Client Creation
+
+### Sync SecretClient
+
+```java
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+
+SecretClient secretClient = new SecretClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .vaultUrl("<your-key-vault-url>")
+    .buildClient();
+```
+
+### Async SecretClient
+
+```java
+import com.azure.security.keyvault.secrets.SecretAsyncClient;
+
+SecretAsyncClient secretAsyncClient = new SecretClientBuilder()
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .vaultUrl("<your-key-vault-url>")
+    .buildAsyncClient();
+```
+
+## Setting Secrets
+
+### Simple Secret
+
+```java
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+
+KeyVaultSecret secret = secretClient.setSecret("<secret-name>", "<secret-value>");
+System.out.printf("Secret created with name \"%s\" and value \"%s\"%n", 
+    secret.getName(), secret.getValue());
+```
+
+### Secret with Properties (Expiration)
+
+```java
+import com.azure.security.keyvault.secrets.models.SecretProperties;
+import java.time.OffsetDateTime;
+
+KeyVaultSecret newSecret = new KeyVaultSecret("secretName", "secretValue")
+    .setProperties(new SecretProperties().setExpiresOn(OffsetDateTime.now().plusDays(60)));
+
+KeyVaultSecret returnedSecret = secretClient.setSecret(newSecret);
+System.out.printf("Secret created with name %s and value %s%n", 
+    returnedSecret.getName(), returnedSecret.getValue());
+```
+
+### With Response (includes HTTP metadata)
+
+```java
+import com.azure.core.util.Context;
+
+KeyVaultSecret newSecret = new KeyVaultSecret("secretName", "secretValue")
+    .setProperties(new SecretProperties().setExpiresOn(OffsetDateTime.now().plusDays(60)));
+
+KeyVaultSecret secret = secretClient.setSecretWithResponse(newSecret, new Context("key1", "value1"))
+    .getValue();
+System.out.printf("Secret created with name %s%n", secret.getName());
+```
+
+## Getting Secrets
+
+### Get Current Version
+
+```java
+KeyVaultSecret secret = secretClient.getSecret("secretName");
+System.out.printf("Secret returned with name %s and value %s%n",
+    secret.getName(), secret.getValue());
+```
+
+### Get Specific Version
+
+```java
+String secretVersion = "6A385B124DEF4096AF1361A85B16C204";
+KeyVaultSecret secretWithVersion = secretClient.getSecret("secretName", secretVersion);
+System.out.printf("Secret returned with name %s and value %s%n",
+    secretWithVersion.getName(), secretWithVersion.getValue());
+```
+
+### Get with Response
+
+```java
+import com.azure.core.util.Context;
+
+String secretVersion = "6A385B124DEF4096AF1361A85B16C204";
+KeyVaultSecret secret = secretClient.getSecretWithResponse(
+    "secretName", 
+    secretVersion,
+    new Context("key1", "value1")
+).getValue();
+System.out.printf("Secret returned with name %s%n", secret.getName());
+```
+
+## Listing Secrets
+
+### List All Secrets
+
+```java
+import com.azure.security.keyvault.secrets.models.SecretProperties;
+
+// Note: List operations don't return secret values - call getSecret for each
+for (SecretProperties secretProps : secretClient.listPropertiesOfSecrets()) {
+    KeyVaultSecret secretWithValue = secretClient.getSecret(
+        secretProps.getName(), 
+        secretProps.getVersion()
+    );
+    System.out.printf("Secret: %s = %s%n", 
+        secretWithValue.getName(), 
+        secretWithValue.getValue());
+}
+```
+
+### List with Pagination
+
+```java
+secretClient.listPropertiesOfSecrets().iterableByPage().forEach(page -> {
+    System.out.printf("Status code: %d, URL: %s%n", 
+        page.getStatusCode(), 
+        page.getRequest().getUrl());
+    
+    page.getItems().forEach(secretProps -> {
+        KeyVaultSecret secret = secretClient.getSecret(
+            secretProps.getName(), 
+            secretProps.getVersion()
+        );
+        System.out.printf("Secret: %s%n", secret.getName());
+    });
+});
+```
+
+### List Secret Versions
+
+```java
+for (SecretProperties secretProps : secretClient.listPropertiesOfSecretVersions("secretName")) {
+    KeyVaultSecret secret = secretClient.getSecret(
+        secretProps.getName(), 
+        secretProps.getVersion()
+    );
+    System.out.printf("Version: %s, Value: %s%n", 
+        secretProps.getVersion(), 
+        secret.getValue());
+}
+```
+
+## Updating Secret Properties
+
+```java
+// Get the secret first
+SecretProperties secretProperties = secretClient.getSecret("secretName").getProperties();
+
+// Update the expiry time
+secretProperties.setExpiresOn(OffsetDateTime.now().plusDays(60));
+SecretProperties updatedProperties = secretClient.updateSecretProperties(secretProperties);
+
+// Get the updated secret
+KeyVaultSecret updatedSecret = secretClient.getSecret(updatedProperties.getName());
+System.out.printf("Updated secret expires: %s%n", 
+    updatedSecret.getProperties().getExpiresOn());
+```
+
+**Note**: `updateSecretProperties()` cannot change the secret value - only metadata like expiration, enabled status, tags, etc. To change the value, call `setSecret()` which creates a new version.
+
+## Deleting and Recovering Secrets
+
+### Delete Secret (with Polling)
+
+```java
+import com.azure.core.util.polling.PollResponse;
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.security.keyvault.secrets.models.DeletedSecret;
+
+SyncPoller<DeletedSecret, Void> deleteSecretPoller = secretClient.beginDeleteSecret("secretName");
+
+// Deleted Secret is accessible as soon as polling begins
+PollResponse<DeletedSecret> pollResponse = deleteSecretPoller.poll();
+
+// Deletion date only works for SoftDelete-enabled Key Vault
+System.out.printf("Deleted Date: %s%n", pollResponse.getValue().getDeletedOn());
+System.out.printf("Recovery Id: %s%n", pollResponse.getValue().getRecoveryId());
+
+// Wait for deletion to complete on server
+deleteSecretPoller.waitForCompletion();
+```
+
+### Get Deleted Secret
+
+```java
+DeletedSecret deletedSecret = secretClient.getDeletedSecret("secretName");
+System.out.printf("Recovery Id: %s%n", deletedSecret.getRecoveryId());
+```
+
+### List Deleted Secrets
+
+```java
+for (DeletedSecret deletedSecret : secretClient.listDeletedSecrets()) {
+    System.out.printf("Deleted secret: %s, Recovery Id: %s%n", 
+        deletedSecret.getName(),
+        deletedSecret.getRecoveryId());
+}
+```
+
+### Recover Deleted Secret
+
+```java
+SyncPoller<KeyVaultSecret, Void> recoverPoller = 
+    secretClient.beginRecoverDeletedSecret("deletedSecretName");
+
+// Recovered secret accessible as soon as polling begins
+PollResponse<KeyVaultSecret> pollResponse = recoverPoller.poll();
+System.out.printf("Recovered secret: %s%n", pollResponse.getValue().getName());
+
+// Wait for recovery to complete on server
+recoverPoller.waitForCompletion();
+```
+
+## Purging Deleted Secrets
+
+```java
+// Permanently delete (cannot be recovered after this)
+secretClient.purgeDeletedSecret("secretName");
+System.out.println("Secret purged permanently");
+```
+
+## Backup and Restore
+
+### Backup Secret
+
+```java
+byte[] secretBackup = secretClient.backupSecret("secretName");
+System.out.printf("Secret backup size: %d bytes%n", secretBackup.length);
+
+// Store the backup securely (e.g., to a file or blob storage)
+```
+
+### Restore Secret
+
+```java
+// Restore from backup bytes
+KeyVaultSecret restoredSecret = secretClient.restoreSecretBackup(secretBackup);
+System.out.printf("Restored secret: %s%n", restoredSecret.getName());
+```
+
+## Async Client Patterns
+
+### Set Secret Async
+
+```java
+secretAsyncClient.setSecret("asyncSecretName", "asyncSecretValue")
+    .subscribe(
+        secret -> System.out.printf("Created secret: %s%n", secret.getName()),
+        error -> System.err.println("Error: " + error.getMessage()),
+        () -> System.out.println("Operation completed")
+    );
+```
+
+### Get Secret Async
+
+```java
+secretAsyncClient.getSecret("secretName")
+    .subscribe(
+        secret -> System.out.printf("Secret value: %s%n", secret.getValue()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### List Secrets Async
+
+```java
+secretAsyncClient.listPropertiesOfSecrets()
+    .flatMap(secretProps -> secretAsyncClient.getSecret(
+        secretProps.getName(), 
+        secretProps.getVersion()
+    ))
+    .subscribe(
+        secret -> System.out.printf("Secret: %s%n", secret.getName()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+### Delete Secret Async
+
+```java
+secretAsyncClient.beginDeleteSecret("secretName")
+    .subscribe(pollResponse -> {
+        System.out.printf("Delete status: %s%n", pollResponse.getStatus());
+        System.out.printf("Deleted secret: %s%n", pollResponse.getValue().getName());
+    });
+```
+
+### Chain Operations
+
+```java
+secretAsyncClient.setSecret("mySecret", "myValue")
+    .flatMap(created -> {
+        System.out.printf("Created: %s%n", created.getName());
+        return secretAsyncClient.getSecret(created.getName());
+    })
+    .flatMap(retrieved -> {
+        System.out.printf("Retrieved: %s%n", retrieved.getValue());
+        retrieved.getProperties().setExpiresOn(OffsetDateTime.now().plusDays(30));
+        return secretAsyncClient.updateSecretProperties(retrieved.getProperties());
+    })
+    .subscribe(
+        updated -> System.out.printf("Updated, expires: %s%n", updated.getExpiresOn()),
+        error -> System.err.println("Error: " + error.getMessage())
+    );
+```
+
+## Error Handling
+
+### Sync Error Handling
+
+```java
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.exception.ResourceNotFoundException;
+
+try {
+    KeyVaultSecret secret = secretClient.getSecret("nonexistent-secret");
+} catch (ResourceNotFoundException e) {
+    System.err.println("Secret not found: " + e.getMessage());
+} catch (HttpResponseException e) {
+    System.err.println("HTTP error: " + e.getResponse().getStatusCode());
+    System.err.println("Message: " + e.getMessage());
+} catch (Exception e) {
+    System.err.println("Unexpected error: " + e.getMessage());
+}
+```
+
+### Async Error Handling
+
+```java
+secretAsyncClient.getSecret("nonexistent-secret")
+    .subscribe(
+        secret -> System.out.println("Secret: " + secret.getName()),
+        error -> {
+            if (error instanceof ResourceNotFoundException) {
+                System.err.println("Secret not found");
+            } else if (error instanceof HttpResponseException) {
+                HttpResponseException httpError = (HttpResponseException) error;
+                System.err.println("HTTP error: " + httpError.getResponse().getStatusCode());
+            } else {
+                System.err.println("Error: " + error.getMessage());
+            }
+        }
+    );
+```
+
+### Common Error Scenarios
+
+| Status Code | Exception | Cause |
+|-------------|-----------|-------|
+| 401 | ClientAuthenticationException | Invalid credentials |
+| 403 | HttpResponseException | Access denied (missing permissions) |
+| 404 | ResourceNotFoundException | Secret not found |
+| 409 | HttpResponseException | Conflict (secret already exists/deleted) |
+| 429 | HttpResponseException | Rate limited |

--- a/skills/typescript/ai/inference/SKILL.md
+++ b/skills/typescript/ai/inference/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: azure-ai-inference-typescript
+description: Azure AI Inference REST client for chat completions, embeddings, and image analysis (@azure-rest/ai-inference). Use when building chat applications, generating embeddings, or calling models with function tools.
+---
+
+# Azure AI Inference REST SDK for TypeScript
+
+REST client for chat completions, embeddings, and model inference.
+
+## Installation
+
+```bash
+npm install @azure-rest/ai-inference @azure/identity @azure/core-auth @azure/core-sse
+```
+
+## Environment Variables
+
+```bash
+AZURE_INFERENCE_ENDPOINT=https://<resource>.services.ai.azure.com/models
+AZURE_INFERENCE_CREDENTIAL=<api-key>  # For API key auth
+```
+
+## Authentication
+
+**Important**: This is a REST client. `ModelClient` is a **function**, not a class.
+
+### DefaultAzureCredential
+
+```typescript
+import ModelClient from "@azure-rest/ai-inference";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = ModelClient(
+  process.env.AZURE_INFERENCE_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+```
+
+### API Key
+
+```typescript
+import ModelClient from "@azure-rest/ai-inference";
+import { AzureKeyCredential } from "@azure/core-auth";
+
+const client = ModelClient(
+  process.env.AZURE_INFERENCE_ENDPOINT!,
+  new AzureKeyCredential(process.env.AZURE_INFERENCE_CREDENTIAL!)
+);
+```
+
+## Chat Completions
+
+### Basic Request
+
+```typescript
+import ModelClient, { isUnexpected } from "@azure-rest/ai-inference";
+
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "What is the capital of France?" }
+    ],
+    max_tokens: 128,
+    temperature: 0.7
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+console.log(response.body.choices[0].message.content);
+```
+
+### Streaming
+
+```typescript
+import ModelClient from "@azure-rest/ai-inference";
+import { createSseStream } from "@azure/core-sse";
+import { IncomingMessage } from "node:http";
+
+const response = await client
+  .path("/chat/completions")
+  .post({
+    body: {
+      messages: [{ role: "user", content: "Tell me a story" }],
+      stream: true,
+      max_tokens: 500
+    }
+  })
+  .asNodeStream();
+
+if (response.status !== "200") {
+  throw new Error("Stream failed");
+}
+
+const sses = createSseStream(response.body as IncomingMessage);
+
+for await (const event of sses) {
+  if (event.data === "[DONE]") break;
+  
+  const chunk = JSON.parse(event.data);
+  const content = chunk.choices[0]?.delta?.content;
+  if (content) {
+    process.stdout.write(content);
+  }
+}
+```
+
+## Text Embeddings
+
+```typescript
+import ModelClient, { isUnexpected } from "@azure-rest/ai-inference";
+
+const response = await client.path("/embeddings").post({
+  body: {
+    input: ["First sentence", "Second sentence", "Third sentence"],
+    // Optional:
+    // dimensions: 1024,
+    // encoding_format: "float",
+    // input_type: "query"
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+for (const item of response.body.data) {
+  console.log(`Embedding length: ${item.embedding.length}`);
+}
+```
+
+## Image Embeddings
+
+```typescript
+import { readFileSync } from "node:fs";
+
+function getImageDataUrl(path: string, format: string): string {
+  const buffer = readFileSync(path);
+  return `data:image/${format};base64,${buffer.toString("base64")}`;
+}
+
+const response = await client.path("/images/embeddings").post({
+  body: {
+    input: [{ image: getImageDataUrl("./image.png", "png") }]
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+```
+
+## Chat with Images (Vision)
+
+```typescript
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image_url: {
+              url: "https://example.com/image.jpg",
+              detail: "auto"  // "auto" | "low" | "high"
+            }
+          },
+          { type: "text", text: "What's in this image?" }
+        ]
+      }
+    ]
+  }
+});
+```
+
+## Function/Tool Calling
+
+```typescript
+const tools = [
+  {
+    type: "function" as const,
+    function: {
+      name: "get_weather",
+      description: "Get current weather for a location",
+      parameters: {
+        type: "object",
+        properties: {
+          location: { type: "string", description: "City name" },
+          unit: { type: "string", enum: ["celsius", "fahrenheit"] }
+        },
+        required: ["location"]
+      }
+    }
+  }
+];
+
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [{ role: "user", content: "What's the weather in Paris?" }],
+    tools,
+    tool_choice: "auto"
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+const choice = response.body.choices[0];
+if (choice.message.tool_calls) {
+  for (const call of choice.message.tool_calls) {
+    const args = JSON.parse(call.function.arguments);
+    console.log(`Call ${call.function.name} with:`, args);
+    // Execute function and continue conversation with tool message
+  }
+}
+```
+
+## JSON Mode / Structured Output
+
+### JSON Object Mode
+
+```typescript
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [{ role: "user", content: "Return a JSON with name and age" }],
+    response_format: { type: "json_object" }
+  }
+});
+```
+
+### JSON Schema (Structured Output)
+
+```typescript
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [{ role: "user", content: "Extract person info from: John is 30 years old" }],
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: "person_info",
+        schema: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            age: { type: "number" }
+          },
+          required: ["name", "age"]
+        },
+        strict: true
+      }
+    }
+  }
+});
+```
+
+## API Routes
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/chat/completions` | POST | Chat completions |
+| `/embeddings` | POST | Text embeddings |
+| `/images/embeddings` | POST | Image embeddings |
+| `/info` | GET | Model information |
+
+## Key Types
+
+```typescript
+import ModelClient, {
+  isUnexpected,
+  // Request types
+  GetChatCompletionsBodyParam,
+  GetEmbeddingsBodyParam,
+  // Response types
+  ChatCompletionsOutput,
+  EmbeddingsResultOutput,
+  // Message types
+  ChatRequestMessage,
+  ChatRequestSystemMessage,
+  ChatRequestUserMessage,
+  ChatRequestAssistantMessage,
+  ChatRequestToolMessage
+} from "@azure-rest/ai-inference";
+```
+
+## Error Handling
+
+```typescript
+import ModelClient, { isUnexpected } from "@azure-rest/ai-inference";
+
+const response = await client.path("/chat/completions").post({ body: {...} });
+
+// Type guard narrows response type
+if (isUnexpected(response)) {
+  // Error response
+  console.error("Error:", response.body.error);
+  throw new Error(response.body.error.message);
+}
+
+// Success response - TypeScript knows this is 200
+console.log(response.body.choices[0].message.content);
+```
+
+## Best Practices
+
+1. **Always use isUnexpected()** - Type guard for proper error handling
+2. **Use streaming for long responses** - Better UX with `asNodeStream()` + `createSseStream()`
+3. **Set max_tokens** - Prevent runaway token usage
+4. **Handle tool calls** - Check for tool_calls in response and continue conversation
+5. **Use structured output** - `json_schema` for predictable parsing

--- a/skills/typescript/ai/inference/references/chat-completions.md
+++ b/skills/typescript/ai/inference/references/chat-completions.md
@@ -1,0 +1,686 @@
+# Chat Completions Reference
+
+Chat completions, streaming, tool calling, and structured output using @azure-rest/ai-inference SDK.
+
+## Overview
+
+The Azure AI Inference REST client provides chat completions for Azure OpenAI and Azure AI model deployments. This reference covers:
+- Basic and streaming chat completions
+- Tool/function calling patterns
+- JSON mode and structured output
+- Vision (image) inputs
+
+## Core Types
+
+```typescript
+import ModelClient, {
+  isUnexpected,
+  // Request types
+  ChatCompletionsOutput,
+  ChatRequestMessage,
+  ChatRequestSystemMessage,
+  ChatRequestUserMessage,
+  ChatRequestAssistantMessage,
+  ChatRequestToolMessage,
+  // Tool types
+  ChatCompletionsToolDefinition,
+  ChatCompletionsFunctionToolDefinition,
+  ChatCompletionsToolCall,
+  // Response format
+  ChatCompletionsResponseFormat,
+  ChatCompletionsJsonSchemaResponseFormat
+} from "@azure-rest/ai-inference";
+
+import { createSseStream } from "@azure/core-sse";
+```
+
+## Client Initialization
+
+```typescript
+import ModelClient from "@azure-rest/ai-inference";
+import { DefaultAzureCredential } from "@azure/identity";
+import { AzureKeyCredential } from "@azure/core-auth";
+
+// With DefaultAzureCredential (recommended)
+const client = ModelClient(
+  process.env.AZURE_INFERENCE_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+
+// With API key
+const clientWithKey = ModelClient(
+  process.env.AZURE_INFERENCE_ENDPOINT!,
+  new AzureKeyCredential(process.env.AZURE_INFERENCE_CREDENTIAL!)
+);
+```
+
+## Basic Chat Completion
+
+```typescript
+import ModelClient, { isUnexpected } from "@azure-rest/ai-inference";
+
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "What is TypeScript?" }
+    ]
+  }
+});
+
+if (isUnexpected(response)) {
+  throw new Error(response.body.error.message);
+}
+
+const content = response.body.choices[0].message.content;
+console.log(content);
+```
+
+## Request Parameters
+
+```typescript
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [...],
+    
+    // Token limits
+    max_tokens: 1000,           // Maximum tokens in response
+    
+    // Sampling parameters
+    temperature: 0.7,           // 0-2, higher = more random
+    top_p: 0.95,                // Nucleus sampling threshold
+    
+    // Repetition control
+    frequency_penalty: 0,       // -2 to 2, penalize frequent tokens
+    presence_penalty: 0,        // -2 to 2, penalize repeated topics
+    
+    // Output control
+    n: 1,                       // Number of completions to generate
+    stop: ["\n\n", "END"],      // Stop sequences
+    
+    // Reproducibility
+    seed: 42,                   // For deterministic outputs
+    
+    // Model selection (for multi-model endpoints)
+    model: "gpt-4o"             // Optional model override
+  }
+});
+```
+
+## Streaming
+
+### Node.js Streaming Pattern
+
+```typescript
+import ModelClient from "@azure-rest/ai-inference";
+import { createSseStream } from "@azure/core-sse";
+import { IncomingMessage } from "node:http";
+
+const response = await client
+  .path("/chat/completions")
+  .post({
+    body: {
+      messages: [{ role: "user", content: "Write a short poem about coding" }],
+      stream: true,
+      max_tokens: 500
+    }
+  })
+  .asNodeStream();
+
+if (response.status !== "200") {
+  throw new Error(`Stream failed with status ${response.status}`);
+}
+
+const sses = createSseStream(response.body as IncomingMessage);
+
+for await (const event of sses) {
+  // Check for stream end
+  if (event.data === "[DONE]") {
+    console.log("\n--- Stream complete ---");
+    break;
+  }
+  
+  const chunk = JSON.parse(event.data);
+  const delta = chunk.choices[0]?.delta;
+  
+  // Handle content
+  if (delta?.content) {
+    process.stdout.write(delta.content);
+  }
+  
+  // Handle tool calls (in streaming)
+  if (delta?.tool_calls) {
+    for (const toolCall of delta.tool_calls) {
+      console.log(`Tool call: ${toolCall.function?.name}`);
+    }
+  }
+  
+  // Check finish reason
+  const finishReason = chunk.choices[0]?.finish_reason;
+  if (finishReason) {
+    console.log(`\nFinish reason: ${finishReason}`);
+  }
+}
+```
+
+### Streaming Chunk Structure
+
+```typescript
+interface StreamingChatCompletionChunk {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: "assistant";
+      content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function?: {
+          name?: string;
+          arguments?: string;  // Partial JSON, accumulate across chunks
+        };
+      }>;
+    };
+    finish_reason: "stop" | "length" | "tool_calls" | "content_filter" | null;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+```
+
+### Accumulating Streamed Content
+
+```typescript
+let fullContent = "";
+let toolCalls: Map<number, { id: string; name: string; arguments: string }> = new Map();
+
+for await (const event of sses) {
+  if (event.data === "[DONE]") break;
+  
+  const chunk = JSON.parse(event.data);
+  const delta = chunk.choices[0]?.delta;
+  
+  // Accumulate content
+  if (delta?.content) {
+    fullContent += delta.content;
+  }
+  
+  // Accumulate tool calls (arguments come in chunks)
+  if (delta?.tool_calls) {
+    for (const tc of delta.tool_calls) {
+      const existing = toolCalls.get(tc.index);
+      if (existing) {
+        existing.arguments += tc.function?.arguments || "";
+      } else {
+        toolCalls.set(tc.index, {
+          id: tc.id || "",
+          name: tc.function?.name || "",
+          arguments: tc.function?.arguments || ""
+        });
+      }
+    }
+  }
+}
+
+console.log("Full content:", fullContent);
+console.log("Tool calls:", Array.from(toolCalls.values()));
+```
+
+## Tool Calling (Function Calling)
+
+### Define Tools
+
+```typescript
+const tools: ChatCompletionsToolDefinition[] = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get current weather for a location",
+      parameters: {
+        type: "object",
+        properties: {
+          location: {
+            type: "string",
+            description: "City name, e.g., 'San Francisco, CA'"
+          },
+          unit: {
+            type: "string",
+            enum: ["celsius", "fahrenheit"],
+            description: "Temperature unit"
+          }
+        },
+        required: ["location"]
+      }
+    }
+  },
+  {
+    type: "function",
+    function: {
+      name: "search_database",
+      description: "Search the product database",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query" },
+          limit: { type: "number", description: "Max results (default 10)" },
+          category: {
+            type: "string",
+            enum: ["electronics", "clothing", "books"]
+          }
+        },
+        required: ["query"]
+      }
+    }
+  }
+];
+```
+
+### Request with Tools
+
+```typescript
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      { role: "user", content: "What's the weather in Tokyo?" }
+    ],
+    tools,
+    tool_choice: "auto"  // "auto" | "none" | { type: "function", function: { name: "..." } }
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+const message = response.body.choices[0].message;
+
+// Check if model wants to call tools
+if (message.tool_calls && message.tool_calls.length > 0) {
+  console.log("Tool calls requested:");
+  for (const toolCall of message.tool_calls) {
+    console.log(`  ${toolCall.function.name}(${toolCall.function.arguments})`);
+  }
+}
+```
+
+### Execute Tools and Continue
+
+```typescript
+// Tool implementations
+function getWeather(location: string, unit: string = "celsius"): string {
+  // Real implementation would call weather API
+  return JSON.stringify({ location, temperature: 22, unit, condition: "sunny" });
+}
+
+function searchDatabase(query: string, limit: number = 10, category?: string): string {
+  // Real implementation would query database
+  return JSON.stringify({ results: [{ id: 1, name: "Product A" }], total: 1 });
+}
+
+// Process tool calls
+const messages: ChatRequestMessage[] = [
+  { role: "user", content: "What's the weather in Tokyo?" }
+];
+
+const response1 = await client.path("/chat/completions").post({
+  body: { messages, tools, tool_choice: "auto" }
+});
+
+if (isUnexpected(response1)) throw response1.body.error;
+
+const assistantMessage = response1.body.choices[0].message;
+
+if (assistantMessage.tool_calls) {
+  // Add assistant message with tool calls
+  messages.push({
+    role: "assistant",
+    content: assistantMessage.content || "",
+    tool_calls: assistantMessage.tool_calls
+  });
+  
+  // Execute each tool and add results
+  for (const toolCall of assistantMessage.tool_calls) {
+    const args = JSON.parse(toolCall.function.arguments);
+    let result: string;
+    
+    switch (toolCall.function.name) {
+      case "get_weather":
+        result = getWeather(args.location, args.unit);
+        break;
+      case "search_database":
+        result = searchDatabase(args.query, args.limit, args.category);
+        break;
+      default:
+        result = JSON.stringify({ error: "Unknown function" });
+    }
+    
+    // Add tool result message
+    messages.push({
+      role: "tool",
+      tool_call_id: toolCall.id,
+      content: result
+    });
+  }
+  
+  // Get final response with tool results
+  const response2 = await client.path("/chat/completions").post({
+    body: { messages, tools }
+  });
+  
+  if (isUnexpected(response2)) throw response2.body.error;
+  
+  console.log("Final response:", response2.body.choices[0].message.content);
+}
+```
+
+### Parallel Tool Calls
+
+```typescript
+// Model may request multiple tools in parallel
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      { role: "user", content: "Get weather for Tokyo and New York" }
+    ],
+    tools,
+    parallel_tool_calls: true  // Allow parallel calls (default true)
+  }
+});
+
+// message.tool_calls may contain multiple calls
+// Execute all in parallel:
+const toolResults = await Promise.all(
+  message.tool_calls!.map(async (tc) => {
+    const args = JSON.parse(tc.function.arguments);
+    const result = await executeToolAsync(tc.function.name, args);
+    return {
+      role: "tool" as const,
+      tool_call_id: tc.id,
+      content: result
+    };
+  })
+);
+```
+
+## JSON Mode and Structured Output
+
+### JSON Object Mode
+
+```typescript
+// Request JSON output (model decides structure)
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      { role: "system", content: "Return responses as JSON objects." },
+      { role: "user", content: "List 3 programming languages with their main use case" }
+    ],
+    response_format: { type: "json_object" }
+  }
+});
+
+const json = JSON.parse(response.body.choices[0].message.content!);
+```
+
+### Structured Output (JSON Schema)
+
+```typescript
+// Request output conforming to specific schema
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      { role: "user", content: "Extract person info: John Smith is a 35-year-old software engineer living in Seattle." }
+    ],
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: "person_info",
+        description: "Information about a person",
+        schema: {
+          type: "object",
+          properties: {
+            name: { type: "string", description: "Full name" },
+            age: { type: "number", description: "Age in years" },
+            occupation: { type: "string", description: "Job title" },
+            location: { type: "string", description: "City of residence" }
+          },
+          required: ["name", "age", "occupation", "location"],
+          additionalProperties: false
+        },
+        strict: true  // Enforce exact schema conformance
+      }
+    }
+  }
+});
+
+interface PersonInfo {
+  name: string;
+  age: number;
+  occupation: string;
+  location: string;
+}
+
+const person: PersonInfo = JSON.parse(response.body.choices[0].message.content!);
+console.log(`${person.name}, ${person.age}, ${person.occupation} in ${person.location}`);
+```
+
+### Complex Schema Example
+
+```typescript
+const orderSchema = {
+  type: "json_schema" as const,
+  json_schema: {
+    name: "order_extraction",
+    schema: {
+      type: "object",
+      properties: {
+        order_id: { type: "string" },
+        customer: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            email: { type: "string" }
+          },
+          required: ["name"]
+        },
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              product: { type: "string" },
+              quantity: { type: "number" },
+              price: { type: "number" }
+            },
+            required: ["product", "quantity", "price"]
+          }
+        },
+        total: { type: "number" },
+        status: {
+          type: "string",
+          enum: ["pending", "shipped", "delivered", "cancelled"]
+        }
+      },
+      required: ["order_id", "customer", "items", "total", "status"],
+      additionalProperties: false
+    },
+    strict: true
+  }
+};
+```
+
+## Vision (Image Input)
+
+### Image URL
+
+```typescript
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image_url: {
+              url: "https://example.com/image.jpg",
+              detail: "auto"  // "auto" | "low" | "high"
+            }
+          },
+          { type: "text", text: "What's in this image?" }
+        ]
+      }
+    ],
+    max_tokens: 300
+  }
+});
+```
+
+### Base64 Image
+
+```typescript
+import { readFileSync } from "node:fs";
+
+function imageToDataUrl(path: string, mimeType: string): string {
+  const buffer = readFileSync(path);
+  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+}
+
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image_url: {
+              url: imageToDataUrl("./photo.png", "image/png")
+            }
+          },
+          { type: "text", text: "Describe this image in detail" }
+        ]
+      }
+    ]
+  }
+});
+```
+
+### Multiple Images
+
+```typescript
+const response = await client.path("/chat/completions").post({
+  body: {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/image1.jpg" }
+          },
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/image2.jpg" }
+          },
+          { type: "text", text: "Compare these two images" }
+        ]
+      }
+    ]
+  }
+});
+```
+
+## Error Handling
+
+```typescript
+import ModelClient, { isUnexpected } from "@azure-rest/ai-inference";
+
+const response = await client.path("/chat/completions").post({
+  body: { messages: [...] }
+});
+
+if (isUnexpected(response)) {
+  const error = response.body.error;
+  
+  switch (response.status) {
+    case "400":
+      console.error("Bad request:", error.message);
+      break;
+    case "401":
+      console.error("Authentication failed");
+      break;
+    case "403":
+      console.error("Access denied");
+      break;
+    case "404":
+      console.error("Model not found");
+      break;
+    case "429":
+      console.error("Rate limited, retry after:", response.headers["retry-after"]);
+      break;
+    case "500":
+      console.error("Server error");
+      break;
+    default:
+      console.error(`Error ${response.status}:`, error.message);
+  }
+  
+  throw new Error(error.message);
+}
+```
+
+## Response Structure
+
+```typescript
+interface ChatCompletionsOutput {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: "assistant";
+      content: string | null;
+      tool_calls?: Array<{
+        id: string;
+        type: "function";
+        function: {
+          name: string;
+          arguments: string;
+        };
+      }>;
+    };
+    finish_reason: "stop" | "length" | "tool_calls" | "content_filter";
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+```
+
+## Best Practices
+
+1. **Always use isUnexpected()** - Type guard ensures proper error handling
+2. **Stream long responses** - Better UX for lengthy completions
+3. **Set max_tokens** - Prevent runaway token usage and costs
+4. **Handle tool calls in a loop** - Models may request tools multiple times
+5. **Use structured output** - `json_schema` ensures parseable responses
+6. **Accumulate streaming content** - Don't process partial chunks
+7. **Check finish_reason** - Handle "length" (truncated) and "content_filter" cases
+8. **Retry on 429** - Implement exponential backoff for rate limits
+
+## See Also
+
+- [embeddings.md](./embeddings.md) - Text and image embeddings

--- a/skills/typescript/ai/inference/references/embeddings.md
+++ b/skills/typescript/ai/inference/references/embeddings.md
@@ -1,0 +1,584 @@
+# Embeddings Reference
+
+Text and image embeddings using @azure-rest/ai-inference SDK.
+
+## Overview
+
+The Azure AI Inference REST client provides embedding generation for:
+- **Text embeddings** - Semantic representations of text for search, similarity, clustering
+- **Image embeddings** - Visual representations for image search and similarity
+
+## Core Types
+
+```typescript
+import ModelClient, {
+  isUnexpected,
+  EmbeddingsResultOutput,
+  EmbeddingItem
+} from "@azure-rest/ai-inference";
+```
+
+## Client Initialization
+
+```typescript
+import ModelClient from "@azure-rest/ai-inference";
+import { DefaultAzureCredential } from "@azure/identity";
+import { AzureKeyCredential } from "@azure/core-auth";
+
+// With DefaultAzureCredential (recommended)
+const client = ModelClient(
+  process.env.AZURE_INFERENCE_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+
+// With API key
+const clientWithKey = ModelClient(
+  process.env.AZURE_INFERENCE_ENDPOINT!,
+  new AzureKeyCredential(process.env.AZURE_INFERENCE_CREDENTIAL!)
+);
+```
+
+## Text Embeddings
+
+### Basic Text Embedding
+
+```typescript
+import ModelClient, { isUnexpected } from "@azure-rest/ai-inference";
+
+const response = await client.path("/embeddings").post({
+  body: {
+    input: ["Hello, world!"]
+  }
+});
+
+if (isUnexpected(response)) {
+  throw new Error(response.body.error.message);
+}
+
+const embedding = response.body.data[0].embedding;
+console.log(`Embedding dimension: ${embedding.length}`);
+console.log(`First 5 values: ${embedding.slice(0, 5)}`);
+```
+
+### Multiple Text Inputs (Batch)
+
+```typescript
+const response = await client.path("/embeddings").post({
+  body: {
+    input: [
+      "First document about machine learning",
+      "Second document about web development",
+      "Third document about cloud computing",
+      "Fourth document about TypeScript"
+    ]
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+// Each input gets its own embedding at corresponding index
+for (const item of response.body.data) {
+  console.log(`Index ${item.index}: ${item.embedding.length} dimensions`);
+}
+
+// Access by index
+const firstEmbedding = response.body.data[0].embedding;
+const secondEmbedding = response.body.data[1].embedding;
+```
+
+### Request Parameters
+
+```typescript
+const response = await client.path("/embeddings").post({
+  body: {
+    input: ["Text to embed"],
+    
+    // Reduce dimensions (model-dependent)
+    dimensions: 1024,
+    
+    // Output format
+    encoding_format: "float",  // "float" | "base64"
+    
+    // Input type hint (model-dependent)
+    input_type: "query",  // "query" | "document"
+    
+    // Model override (for multi-model endpoints)
+    model: "text-embedding-3-small"
+  }
+});
+```
+
+### Input Types
+
+| Type | Use Case |
+|------|----------|
+| `query` | Search queries (shorter, question-like text) |
+| `document` | Documents to be indexed/searched |
+
+```typescript
+// For search: embed query with input_type "query"
+const queryEmbedding = await client.path("/embeddings").post({
+  body: {
+    input: ["What is machine learning?"],
+    input_type: "query"
+  }
+});
+
+// For indexing: embed documents with input_type "document"
+const docEmbeddings = await client.path("/embeddings").post({
+  body: {
+    input: [
+      "Machine learning is a subset of artificial intelligence...",
+      "Deep learning uses neural networks..."
+    ],
+    input_type: "document"
+  }
+});
+```
+
+### Encoding Formats
+
+```typescript
+// Float format (default) - array of numbers
+const floatResponse = await client.path("/embeddings").post({
+  body: {
+    input: ["Hello"],
+    encoding_format: "float"
+  }
+});
+// embedding: [0.123, -0.456, 0.789, ...]
+
+// Base64 format - compact binary representation
+const base64Response = await client.path("/embeddings").post({
+  body: {
+    input: ["Hello"],
+    encoding_format: "base64"
+  }
+});
+// embedding: "SGVsbG8gV29ybGQ..." (base64 string of float32 array)
+
+// Decode base64 to float array
+function decodeBase64Embedding(base64: string): number[] {
+  const buffer = Buffer.from(base64, "base64");
+  const floats: number[] = [];
+  for (let i = 0; i < buffer.length; i += 4) {
+    floats.push(buffer.readFloatLE(i));
+  }
+  return floats;
+}
+```
+
+## Image Embeddings
+
+### Basic Image Embedding (URL)
+
+```typescript
+const response = await client.path("/images/embeddings").post({
+  body: {
+    input: [
+      { image: "https://example.com/image.jpg" }
+    ]
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+const imageEmbedding = response.body.data[0].embedding;
+console.log(`Image embedding: ${imageEmbedding.length} dimensions`);
+```
+
+### Image Embedding (Base64 Data URL)
+
+```typescript
+import { readFileSync } from "node:fs";
+import { extname } from "node:path";
+
+function imageToDataUrl(filePath: string): string {
+  const buffer = readFileSync(filePath);
+  const ext = extname(filePath).slice(1).toLowerCase();
+  const mimeType = ext === "jpg" ? "jpeg" : ext;
+  return `data:image/${mimeType};base64,${buffer.toString("base64")}`;
+}
+
+const response = await client.path("/images/embeddings").post({
+  body: {
+    input: [
+      { image: imageToDataUrl("./photo.png") }
+    ]
+  }
+});
+```
+
+### Multiple Image Embeddings
+
+```typescript
+const response = await client.path("/images/embeddings").post({
+  body: {
+    input: [
+      { image: "https://example.com/cat.jpg" },
+      { image: "https://example.com/dog.jpg" },
+      { image: imageToDataUrl("./bird.png") }
+    ]
+  }
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+// Process each image embedding
+for (const item of response.body.data) {
+  console.log(`Image ${item.index}: ${item.embedding.length} dimensions`);
+}
+```
+
+## Response Structure
+
+```typescript
+interface EmbeddingsResultOutput {
+  data: Array<{
+    index: number;           // Position in input array
+    embedding: number[];     // Vector representation
+    object: "embedding";
+  }>;
+  model: string;             // Model used
+  object: "list";
+  usage: {
+    prompt_tokens: number;   // Input tokens consumed
+    total_tokens: number;    // Total tokens used
+  };
+}
+```
+
+## Batch Processing
+
+### Chunked Batch Processing
+
+```typescript
+async function embedInBatches(
+  client: ReturnType<typeof ModelClient>,
+  texts: string[],
+  batchSize: number = 100
+): Promise<number[][]> {
+  const allEmbeddings: number[][] = [];
+  
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    
+    const response = await client.path("/embeddings").post({
+      body: { input: batch }
+    });
+    
+    if (isUnexpected(response)) {
+      throw new Error(`Batch ${i / batchSize} failed: ${response.body.error.message}`);
+    }
+    
+    // Ensure correct order
+    const sortedData = response.body.data.sort((a, b) => a.index - b.index);
+    allEmbeddings.push(...sortedData.map(d => d.embedding));
+    
+    console.log(`Processed batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(texts.length / batchSize)}`);
+  }
+  
+  return allEmbeddings;
+}
+
+// Usage
+const documents = ["doc1", "doc2", ..., "doc1000"];
+const embeddings = await embedInBatches(client, documents, 100);
+```
+
+### Parallel Batch Processing
+
+```typescript
+async function embedInParallel(
+  client: ReturnType<typeof ModelClient>,
+  texts: string[],
+  batchSize: number = 100,
+  concurrency: number = 3
+): Promise<number[][]> {
+  const batches: string[][] = [];
+  for (let i = 0; i < texts.length; i += batchSize) {
+    batches.push(texts.slice(i, i + batchSize));
+  }
+  
+  const results: Map<number, number[][]> = new Map();
+  
+  // Process in parallel with concurrency limit
+  for (let i = 0; i < batches.length; i += concurrency) {
+    const batchPromises = batches
+      .slice(i, i + concurrency)
+      .map(async (batch, offset) => {
+        const batchIndex = i + offset;
+        const response = await client.path("/embeddings").post({
+          body: { input: batch }
+        });
+        
+        if (isUnexpected(response)) {
+          throw new Error(`Batch ${batchIndex} failed`);
+        }
+        
+        const sorted = response.body.data.sort((a, b) => a.index - b.index);
+        results.set(batchIndex, sorted.map(d => d.embedding));
+      });
+    
+    await Promise.all(batchPromises);
+  }
+  
+  // Reassemble in order
+  const allEmbeddings: number[][] = [];
+  for (let i = 0; i < batches.length; i++) {
+    allEmbeddings.push(...results.get(i)!);
+  }
+  
+  return allEmbeddings;
+}
+```
+
+## Vector Similarity
+
+### Cosine Similarity
+
+```typescript
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error("Vectors must have same length");
+  }
+  
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+  
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  
+  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+// Usage
+const similarity = cosineSimilarity(embedding1, embedding2);
+console.log(`Similarity: ${similarity.toFixed(4)}`);  // 0-1, higher = more similar
+```
+
+### Dot Product (for Normalized Vectors)
+
+```typescript
+function dotProduct(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < a.length; i++) {
+    sum += a[i] * b[i];
+  }
+  return sum;
+}
+
+// Normalize vector
+function normalize(v: number[]): number[] {
+  const magnitude = Math.sqrt(v.reduce((sum, x) => sum + x * x, 0));
+  return v.map(x => x / magnitude);
+}
+```
+
+### Euclidean Distance
+
+```typescript
+function euclideanDistance(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < a.length; i++) {
+    sum += (a[i] - b[i]) ** 2;
+  }
+  return Math.sqrt(sum);
+}
+// Lower = more similar
+```
+
+## Semantic Search Pattern
+
+```typescript
+interface Document {
+  id: string;
+  text: string;
+  embedding?: number[];
+}
+
+class SimpleVectorStore {
+  private documents: Document[] = [];
+  private client: ReturnType<typeof ModelClient>;
+  
+  constructor(client: ReturnType<typeof ModelClient>) {
+    this.client = client;
+  }
+  
+  async addDocuments(docs: Document[]): Promise<void> {
+    const texts = docs.map(d => d.text);
+    
+    const response = await this.client.path("/embeddings").post({
+      body: { input: texts, input_type: "document" }
+    });
+    
+    if (isUnexpected(response)) {
+      throw response.body.error;
+    }
+    
+    for (const item of response.body.data) {
+      docs[item.index].embedding = item.embedding;
+    }
+    
+    this.documents.push(...docs);
+  }
+  
+  async search(query: string, topK: number = 5): Promise<Array<Document & { score: number }>> {
+    // Embed query
+    const response = await this.client.path("/embeddings").post({
+      body: { input: [query], input_type: "query" }
+    });
+    
+    if (isUnexpected(response)) {
+      throw response.body.error;
+    }
+    
+    const queryEmbedding = response.body.data[0].embedding;
+    
+    // Calculate similarity scores
+    const scored = this.documents.map(doc => ({
+      ...doc,
+      score: cosineSimilarity(queryEmbedding, doc.embedding!)
+    }));
+    
+    // Return top K
+    return scored
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK);
+  }
+}
+
+// Usage
+const store = new SimpleVectorStore(client);
+
+await store.addDocuments([
+  { id: "1", text: "TypeScript is a typed superset of JavaScript" },
+  { id: "2", text: "Python is great for machine learning" },
+  { id: "3", text: "JavaScript runs in web browsers" }
+]);
+
+const results = await store.search("What language is good for ML?");
+// Returns doc 2 with highest score
+```
+
+## Error Handling
+
+```typescript
+import ModelClient, { isUnexpected } from "@azure-rest/ai-inference";
+
+async function getEmbeddingSafe(text: string): Promise<number[] | null> {
+  try {
+    const response = await client.path("/embeddings").post({
+      body: { input: [text] }
+    });
+    
+    if (isUnexpected(response)) {
+      console.error(`API Error: ${response.body.error.message}`);
+      return null;
+    }
+    
+    return response.body.data[0].embedding;
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Network error: ${error.message}`);
+    }
+    return null;
+  }
+}
+```
+
+### Common Error Codes
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Invalid input (empty text, too long, invalid format) |
+| 401 | Authentication failed |
+| 403 | Access denied |
+| 404 | Model/endpoint not found |
+| 429 | Rate limited |
+| 500 | Server error |
+
+### Rate Limit Handling
+
+```typescript
+async function embedWithRetry(
+  client: ReturnType<typeof ModelClient>,
+  input: string[],
+  maxRetries: number = 3
+): Promise<number[][]> {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const response = await client.path("/embeddings").post({
+      body: { input }
+    });
+    
+    if (response.status === "429") {
+      const retryAfter = parseInt(response.headers["retry-after"] || "5");
+      console.log(`Rate limited, waiting ${retryAfter}s...`);
+      await new Promise(r => setTimeout(r, retryAfter * 1000));
+      continue;
+    }
+    
+    if (isUnexpected(response)) {
+      throw response.body.error;
+    }
+    
+    return response.body.data
+      .sort((a, b) => a.index - b.index)
+      .map(d => d.embedding);
+  }
+  
+  throw new Error("Max retries exceeded");
+}
+```
+
+## Token Counting
+
+```typescript
+// Approximate token count (rough estimate)
+function estimateTokens(text: string): number {
+  // ~4 characters per token for English text
+  return Math.ceil(text.length / 4);
+}
+
+// Check token usage from response
+const response = await client.path("/embeddings").post({
+  body: { input: texts }
+});
+
+if (!isUnexpected(response)) {
+  console.log(`Tokens used: ${response.body.usage.total_tokens}`);
+}
+```
+
+## Best Practices
+
+1. **Batch inputs** - Send multiple texts per request (up to model limit, typically 100-2048)
+2. **Use input_type** - "query" for searches, "document" for indexing (improves retrieval)
+3. **Reduce dimensions** - Use `dimensions` parameter if model supports it for storage savings
+4. **Handle rate limits** - Implement exponential backoff for 429 responses
+5. **Normalize vectors** - Pre-normalize if using dot product similarity
+6. **Cache embeddings** - Store embeddings to avoid recomputing for unchanged content
+7. **Monitor usage** - Track token consumption via `usage` in responses
+8. **Choose right model** - Smaller models (text-embedding-3-small) for cost, larger for quality
+
+## Supported Models
+
+| Model | Dimensions | Max Input | Best For |
+|-------|------------|-----------|----------|
+| text-embedding-3-small | 1536 | 8191 tokens | Cost-effective general use |
+| text-embedding-3-large | 3072 | 8191 tokens | High-quality retrieval |
+| text-embedding-ada-002 | 1536 | 8191 tokens | Legacy compatibility |
+
+## See Also
+
+- [chat-completions.md](./chat-completions.md) - Chat completions and streaming

--- a/skills/typescript/ai/translation/SKILL.md
+++ b/skills/typescript/ai/translation/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: azure-translation-typescript
+description: Build translation applications using Azure Translation SDKs for JavaScript (@azure-rest/ai-translation-text, @azure-rest/ai-translation-document). Use when implementing text translation, transliteration, language detection, or batch document translation.
+---
+
+# Azure Translation SDKs for TypeScript
+
+Text and document translation with REST-style clients.
+
+## Installation
+
+```bash
+# Text translation
+npm install @azure-rest/ai-translation-text @azure/identity
+
+# Document translation
+npm install @azure-rest/ai-translation-document @azure/identity
+```
+
+## Environment Variables
+
+```bash
+TRANSLATOR_ENDPOINT=https://api.cognitive.microsofttranslator.com
+TRANSLATOR_SUBSCRIPTION_KEY=<your-api-key>
+TRANSLATOR_REGION=<your-region>  # e.g., westus, eastus
+```
+
+## Text Translation Client
+
+### Authentication
+
+```typescript
+import TextTranslationClient, { TranslatorCredential } from "@azure-rest/ai-translation-text";
+
+// API Key + Region
+const credential: TranslatorCredential = {
+  key: process.env.TRANSLATOR_SUBSCRIPTION_KEY!,
+  region: process.env.TRANSLATOR_REGION!,
+};
+const client = TextTranslationClient(process.env.TRANSLATOR_ENDPOINT!, credential);
+
+// Or just credential (uses global endpoint)
+const client2 = TextTranslationClient(credential);
+```
+
+### Translate Text
+
+```typescript
+import TextTranslationClient, { isUnexpected } from "@azure-rest/ai-translation-text";
+
+const response = await client.path("/translate").post({
+  body: {
+    inputs: [
+      {
+        text: "Hello, how are you?",
+        language: "en",  // source (optional, auto-detect)
+        targets: [
+          { language: "es" },
+          { language: "fr" },
+        ],
+      },
+    ],
+  },
+});
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+for (const result of response.body.value) {
+  for (const translation of result.translations) {
+    console.log(`${translation.language}: ${translation.text}`);
+  }
+}
+```
+
+### Translate with Options
+
+```typescript
+const response = await client.path("/translate").post({
+  body: {
+    inputs: [
+      {
+        text: "Hello world",
+        language: "en",
+        textType: "Plain",  // or "Html"
+        targets: [
+          {
+            language: "de",
+            profanityAction: "NoAction",  // "Marked" | "Deleted"
+            tone: "formal",  // LLM-specific
+          },
+        ],
+      },
+    ],
+  },
+});
+```
+
+### Get Supported Languages
+
+```typescript
+const response = await client.path("/languages").get();
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+// Translation languages
+for (const [code, lang] of Object.entries(response.body.translation || {})) {
+  console.log(`${code}: ${lang.name} (${lang.nativeName})`);
+}
+```
+
+### Transliterate
+
+```typescript
+const response = await client.path("/transliterate").post({
+  body: { inputs: [{ text: "这是个测试" }] },
+  queryParameters: {
+    language: "zh-Hans",
+    fromScript: "Hans",
+    toScript: "Latn",
+  },
+});
+
+if (!isUnexpected(response)) {
+  for (const t of response.body.value) {
+    console.log(`${t.script}: ${t.text}`);  // Latn: zhè shì gè cè shì
+  }
+}
+```
+
+### Detect Language
+
+```typescript
+const response = await client.path("/detect").post({
+  body: { inputs: [{ text: "Bonjour le monde" }] },
+});
+
+if (!isUnexpected(response)) {
+  for (const result of response.body.value) {
+    console.log(`Language: ${result.language}, Score: ${result.score}`);
+  }
+}
+```
+
+## Document Translation Client
+
+### Authentication
+
+```typescript
+import DocumentTranslationClient from "@azure-rest/ai-translation-document";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const endpoint = "https://<translator>.cognitiveservices.azure.com";
+
+// TokenCredential
+const client = DocumentTranslationClient(endpoint, new DefaultAzureCredential());
+
+// API Key
+const client2 = DocumentTranslationClient(endpoint, { key: "<api-key>" });
+```
+
+### Single Document Translation
+
+```typescript
+import DocumentTranslationClient from "@azure-rest/ai-translation-document";
+import { writeFile } from "node:fs/promises";
+
+const response = await client.path("/document:translate").post({
+  queryParameters: {
+    targetLanguage: "es",
+    sourceLanguage: "en",  // optional
+  },
+  contentType: "multipart/form-data",
+  body: [
+    {
+      name: "document",
+      body: "Hello, this is a test document.",
+      filename: "test.txt",
+      contentType: "text/plain",
+    },
+  ],
+}).asNodeStream();
+
+if (response.status === "200") {
+  await writeFile("translated.txt", response.body);
+}
+```
+
+### Batch Document Translation
+
+```typescript
+import { ContainerSASPermissions, BlobServiceClient } from "@azure/storage-blob";
+
+// Generate SAS URLs for source and target containers
+const sourceSas = await sourceContainer.generateSasUrl({
+  permissions: ContainerSASPermissions.parse("rl"),
+  expiresOn: new Date(Date.now() + 24 * 60 * 60 * 1000),
+});
+
+const targetSas = await targetContainer.generateSasUrl({
+  permissions: ContainerSASPermissions.parse("rwl"),
+  expiresOn: new Date(Date.now() + 24 * 60 * 60 * 1000),
+});
+
+// Start batch translation
+const response = await client.path("/document/batches").post({
+  body: {
+    inputs: [
+      {
+        source: { sourceUrl: sourceSas },
+        targets: [
+          { targetUrl: targetSas, language: "fr" },
+        ],
+      },
+    ],
+  },
+});
+
+// Get operation ID from header
+const operationId = new URL(response.headers["operation-location"])
+  .pathname.split("/").pop();
+```
+
+### Get Translation Status
+
+```typescript
+import { isUnexpected, paginate } from "@azure-rest/ai-translation-document";
+
+const statusResponse = await client.path("/document/batches/{id}", operationId).get();
+
+if (!isUnexpected(statusResponse)) {
+  const status = statusResponse.body;
+  console.log(`Status: ${status.status}`);
+  console.log(`Total: ${status.summary.total}`);
+  console.log(`Success: ${status.summary.success}`);
+}
+
+// List documents with pagination
+const docsResponse = await client.path("/document/batches/{id}/documents", operationId).get();
+const documents = paginate(client, docsResponse);
+
+for await (const doc of documents) {
+  console.log(`${doc.id}: ${doc.status}`);
+}
+```
+
+### Get Supported Formats
+
+```typescript
+const response = await client.path("/document/formats").get();
+
+if (!isUnexpected(response)) {
+  for (const format of response.body.value) {
+    console.log(`${format.format}: ${format.fileExtensions.join(", ")}`);
+  }
+}
+```
+
+## Key Types
+
+```typescript
+// Text Translation
+import type {
+  TranslatorCredential,
+  TranslatorTokenCredential,
+} from "@azure-rest/ai-translation-text";
+
+// Document Translation
+import type {
+  DocumentTranslateParameters,
+  StartTranslationDetails,
+  TranslationStatus,
+} from "@azure-rest/ai-translation-document";
+```
+
+## Best Practices
+
+1. **Auto-detect source** - Omit `language` parameter to auto-detect
+2. **Batch requests** - Translate multiple texts in one call for efficiency
+3. **Use SAS tokens** - For document translation, use time-limited SAS URLs
+4. **Handle errors** - Always check `isUnexpected(response)` before accessing body
+5. **Regional endpoints** - Use regional endpoints for lower latency

--- a/skills/typescript/compute/playwright/SKILL.md
+++ b/skills/typescript/compute/playwright/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: azure-playwright-testing-typescript
+description: Run Playwright tests at scale using Microsoft Playwright Testing service. Use when scaling browser tests across cloud-hosted browsers, integrating with CI/CD pipelines, or publishing test results to the Playwright Portal.
+---
+
+# Azure Playwright Testing SDK for TypeScript
+
+Run Playwright tests at scale with cloud-hosted browsers and centralized reporting.
+
+> **Deprecation Notice:** `@azure/microsoft-playwright-testing` will be deprecated March 8, 2026. Migrate to `@azure/playwright`. See [migration guide](https://aka.ms/mpt/migration-guidance).
+
+## Installation
+
+```bash
+# Recommended: Auto-generates config
+npm init @azure/microsoft-playwright-testing@latest
+
+# Manual installation
+npm install @azure/microsoft-playwright-testing --save-dev
+npm install @playwright/test@^1.47 --save-dev
+```
+
+## Environment Variables
+
+```bash
+PLAYWRIGHT_SERVICE_URL=wss://eastus.api.playwright.microsoft.com/accounts/{workspace-id}/browsers
+```
+
+## Authentication
+
+### Microsoft Entra ID (Recommended)
+
+```bash
+# Sign in with Azure CLI
+az login
+```
+
+```typescript
+// playwright.service.config.ts
+import { defineConfig } from "@playwright/test";
+import { getServiceConfig, ServiceOS } from "@azure/microsoft-playwright-testing";
+import config from "./playwright.config";
+
+export default defineConfig(
+  config,
+  getServiceConfig(config, {
+    os: ServiceOS.LINUX,
+    // serviceAuthType defaults to ENTRA_ID
+  }),
+  {
+    reporter: [["list"], ["@azure/microsoft-playwright-testing/reporter"]],
+  }
+);
+```
+
+### Custom Credential
+
+```typescript
+import { ManagedIdentityCredential } from "@azure/identity";
+import { getServiceConfig } from "@azure/microsoft-playwright-testing";
+
+export default defineConfig(
+  config,
+  getServiceConfig(config, {
+    credential: new ManagedIdentityCredential(),
+  })
+);
+```
+
+## Core Workflow
+
+### Service Configuration
+
+```typescript
+// playwright.service.config.ts
+import { defineConfig } from "@playwright/test";
+import { getServiceConfig, ServiceOS } from "@azure/microsoft-playwright-testing";
+import config from "./playwright.config";
+
+export default defineConfig(
+  config,
+  getServiceConfig(config, {
+    os: ServiceOS.LINUX,
+    timeout: 30000,
+    exposeNetwork: "<loopback>",
+    useCloudHostedBrowsers: true,
+  }),
+  {
+    reporter: [
+      ["list"],
+      ["@azure/microsoft-playwright-testing/reporter", {
+        enableGitHubSummary: true,
+        enableResultPublish: true,
+      }],
+    ],
+  }
+);
+```
+
+### Run Tests
+
+```bash
+npx playwright test --config=playwright.service.config.ts --workers=20
+```
+
+### Reporting Only (Local Browsers)
+
+```typescript
+export default defineConfig(
+  config,
+  getServiceConfig(config, {
+    useCloudHostedBrowsers: false, // Run locally, publish to portal
+  }),
+  {
+    reporter: [["@azure/microsoft-playwright-testing/reporter"]],
+  }
+);
+```
+
+### Manual Browser Connection
+
+```typescript
+import playwright, { test, expect, BrowserType } from "@playwright/test";
+import { getConnectOptions } from "@azure/microsoft-playwright-testing";
+
+test("manual connection", async ({ browserName }) => {
+  const { wsEndpoint, options } = await getConnectOptions();
+  const browser = await (playwright[browserName] as BrowserType).connect(wsEndpoint, options);
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto("https://example.com");
+  await expect(page).toHaveTitle(/Example/);
+
+  await browser.close();
+});
+```
+
+## Configuration Options
+
+```typescript
+type PlaywrightServiceAdditionalOptions = {
+  serviceAuthType?: "ENTRA_ID" | "ACCESS_TOKEN";  // Default: ENTRA_ID
+  os?: "linux" | "windows";                        // Default: linux
+  runId?: string;                                  // Default: ISO datetime
+  runName?: string;                                // Default: guid
+  timeout?: number;                                // Default: 30000ms
+  slowMo?: number;                                 // Default: 0
+  exposeNetwork?: string;                          // Default: <loopback>
+  useCloudHostedBrowsers?: boolean;                // Default: true
+  credential?: TokenCredential;                    // Default: DefaultAzureCredential
+};
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Playwright Tests
+on: [push, pull_request]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - run: npm ci
+      
+      - name: Run Tests
+        env:
+          PLAYWRIGHT_SERVICE_URL: ${{ secrets.PLAYWRIGHT_SERVICE_URL }}
+        run: npx playwright test -c playwright.service.config.ts --workers=20
+```
+
+### Azure Pipelines
+
+```yaml
+- task: AzureCLI@2
+  displayName: Run Playwright Tests
+  env:
+    PLAYWRIGHT_SERVICE_URL: $(PLAYWRIGHT_SERVICE_URL)
+  inputs:
+    azureSubscription: My_Service_Connection
+    scriptType: pscore
+    inlineScript: |
+      npx playwright test -c playwright.service.config.ts --workers=20
+    addSpnToEnvironment: true
+```
+
+## Key Types
+
+```typescript
+import {
+  getServiceConfig,
+  getConnectOptions,
+  ServiceOS,
+  ServiceAuth,
+  ServiceEnvironmentVariable,
+} from "@azure/microsoft-playwright-testing";
+
+import type {
+  OsType,
+  AuthenticationType,
+  BrowserConnectOptions,
+  ReporterConfiguration,
+  PlaywrightServiceAdditionalOptions,
+} from "@azure/microsoft-playwright-testing";
+```
+
+## Best Practices
+
+1. **Use Entra ID auth** - More secure than access tokens
+2. **Enable artifacts** - Set `trace: "on-first-retry"`, `video: "retain-on-failure"` in config
+3. **Scale workers** - Use `--workers=20` or higher for parallel execution
+4. **Region selection** - Choose region closest to your test targets
+5. **Results retention** - Test results retained for 90 days in portal

--- a/skills/typescript/data/blob/SKILL.md
+++ b/skills/typescript/data/blob/SKILL.md
@@ -1,0 +1,481 @@
+---
+name: azure-storage-blob-typescript
+description: |
+  Azure Blob Storage JavaScript/TypeScript SDK (@azure/storage-blob) for blob operations. Use for uploading, downloading, listing, and managing blobs and containers. Supports block blobs, append blobs, page blobs, SAS tokens, and streaming. Triggers: "blob storage", "@azure/storage-blob", "BlobServiceClient", "ContainerClient", "upload blob", "download blob", "SAS token", "block blob".
+---
+
+# @azure/storage-blob (TypeScript/JavaScript)
+
+SDK for Azure Blob Storage operations — upload, download, list, and manage blobs and containers.
+
+## Installation
+
+```bash
+npm install @azure/storage-blob @azure/identity
+```
+
+**Current Version**: 12.x  
+**Node.js**: >= 18.0.0
+
+## Environment Variables
+
+```bash
+AZURE_STORAGE_ACCOUNT_NAME=<account-name>
+AZURE_STORAGE_ACCOUNT_KEY=<account-key>
+# OR connection string
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
+```
+
+## Authentication
+
+### DefaultAzureCredential (Recommended)
+
+```typescript
+import { BlobServiceClient } from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const client = new BlobServiceClient(
+  `https://${accountName}.blob.core.windows.net`,
+  new DefaultAzureCredential()
+);
+```
+
+### Connection String
+
+```typescript
+import { BlobServiceClient } from "@azure/storage-blob";
+
+const client = BlobServiceClient.fromConnectionString(
+  process.env.AZURE_STORAGE_CONNECTION_STRING!
+);
+```
+
+### StorageSharedKeyCredential (Node.js only)
+
+```typescript
+import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-blob";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const accountKey = process.env.AZURE_STORAGE_ACCOUNT_KEY!;
+
+const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+const client = new BlobServiceClient(
+  `https://${accountName}.blob.core.windows.net`,
+  sharedKeyCredential
+);
+```
+
+### SAS Token
+
+```typescript
+import { BlobServiceClient } from "@azure/storage-blob";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const sasToken = process.env.AZURE_STORAGE_SAS_TOKEN!; // starts with "?"
+
+const client = new BlobServiceClient(
+  `https://${accountName}.blob.core.windows.net${sasToken}`
+);
+```
+
+## Client Hierarchy
+
+```
+BlobServiceClient (account level)
+└── ContainerClient (container level)
+    └── BlobClient (blob level)
+        ├── BlockBlobClient (block blobs - most common)
+        ├── AppendBlobClient (append-only blobs)
+        └── PageBlobClient (page blobs - VHDs)
+```
+
+## Container Operations
+
+### Create Container
+
+```typescript
+const containerClient = client.getContainerClient("my-container");
+await containerClient.create();
+
+// Or create if not exists
+await containerClient.createIfNotExists();
+```
+
+### List Containers
+
+```typescript
+for await (const container of client.listContainers()) {
+  console.log(container.name);
+}
+
+// With prefix filter
+for await (const container of client.listContainers({ prefix: "logs-" })) {
+  console.log(container.name);
+}
+```
+
+### Delete Container
+
+```typescript
+await containerClient.delete();
+// Or delete if exists
+await containerClient.deleteIfExists();
+```
+
+## Blob Operations
+
+### Upload Blob (Simple)
+
+```typescript
+const containerClient = client.getContainerClient("my-container");
+const blockBlobClient = containerClient.getBlockBlobClient("my-file.txt");
+
+// Upload string
+await blockBlobClient.upload("Hello, World!", 13);
+
+// Upload Buffer
+const buffer = Buffer.from("Hello, World!");
+await blockBlobClient.upload(buffer, buffer.length);
+```
+
+### Upload from File (Node.js only)
+
+```typescript
+const blockBlobClient = containerClient.getBlockBlobClient("uploaded-file.txt");
+await blockBlobClient.uploadFile("/path/to/local/file.txt");
+```
+
+### Upload from Stream (Node.js only)
+
+```typescript
+import * as fs from "fs";
+
+const blockBlobClient = containerClient.getBlockBlobClient("streamed-file.txt");
+const readStream = fs.createReadStream("/path/to/local/file.txt");
+
+await blockBlobClient.uploadStream(readStream, 4 * 1024 * 1024, 5, {
+  // bufferSize: 4MB, maxConcurrency: 5
+  onProgress: (progress) => console.log(`Uploaded ${progress.loadedBytes} bytes`),
+});
+```
+
+### Upload from Browser
+
+```typescript
+const blockBlobClient = containerClient.getBlockBlobClient("browser-upload.txt");
+
+// From File input
+const fileInput = document.getElementById("fileInput") as HTMLInputElement;
+const file = fileInput.files![0];
+await blockBlobClient.uploadData(file);
+
+// From Blob/ArrayBuffer
+const arrayBuffer = new ArrayBuffer(1024);
+await blockBlobClient.uploadData(arrayBuffer);
+```
+
+### Download Blob
+
+```typescript
+const blobClient = containerClient.getBlobClient("my-file.txt");
+const downloadResponse = await blobClient.download();
+
+// Read as string (browser & Node.js)
+const downloaded = await streamToText(downloadResponse.readableStreamBody!);
+
+async function streamToText(readable: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of readable) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+```
+
+### Download to File (Node.js only)
+
+```typescript
+const blockBlobClient = containerClient.getBlockBlobClient("my-file.txt");
+await blockBlobClient.downloadToFile("/path/to/local/destination.txt");
+```
+
+### Download to Buffer (Node.js only)
+
+```typescript
+const blockBlobClient = containerClient.getBlockBlobClient("my-file.txt");
+const buffer = await blockBlobClient.downloadToBuffer();
+console.log(buffer.toString());
+```
+
+### List Blobs
+
+```typescript
+// List all blobs
+for await (const blob of containerClient.listBlobsFlat()) {
+  console.log(blob.name, blob.properties.contentLength);
+}
+
+// List with prefix
+for await (const blob of containerClient.listBlobsFlat({ prefix: "logs/" })) {
+  console.log(blob.name);
+}
+
+// List by hierarchy (virtual directories)
+for await (const item of containerClient.listBlobsByHierarchy("/")) {
+  if (item.kind === "prefix") {
+    console.log(`Directory: ${item.name}`);
+  } else {
+    console.log(`Blob: ${item.name}`);
+  }
+}
+```
+
+### Delete Blob
+
+```typescript
+const blobClient = containerClient.getBlobClient("my-file.txt");
+await blobClient.delete();
+
+// Delete if exists
+await blobClient.deleteIfExists();
+
+// Delete with snapshots
+await blobClient.delete({ deleteSnapshots: "include" });
+```
+
+### Copy Blob
+
+```typescript
+const sourceBlobClient = containerClient.getBlobClient("source.txt");
+const destBlobClient = containerClient.getBlobClient("destination.txt");
+
+// Start copy operation
+const copyPoller = await destBlobClient.beginCopyFromURL(sourceBlobClient.url);
+await copyPoller.pollUntilDone();
+```
+
+## Blob Properties & Metadata
+
+### Get Properties
+
+```typescript
+const blobClient = containerClient.getBlobClient("my-file.txt");
+const properties = await blobClient.getProperties();
+
+console.log("Content-Type:", properties.contentType);
+console.log("Content-Length:", properties.contentLength);
+console.log("Last Modified:", properties.lastModified);
+console.log("ETag:", properties.etag);
+```
+
+### Set Metadata
+
+```typescript
+await blobClient.setMetadata({
+  author: "John Doe",
+  category: "documents",
+});
+```
+
+### Set HTTP Headers
+
+```typescript
+await blobClient.setHTTPHeaders({
+  blobContentType: "text/plain",
+  blobCacheControl: "max-age=3600",
+  blobContentDisposition: "attachment; filename=download.txt",
+});
+```
+
+## SAS Token Generation (Node.js only)
+
+### Generate Blob SAS
+
+```typescript
+import {
+  BlobSASPermissions,
+  generateBlobSASQueryParameters,
+  StorageSharedKeyCredential,
+} from "@azure/storage-blob";
+
+const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    blobName: "my-file.txt",
+    permissions: BlobSASPermissions.parse("r"), // read only
+    startsOn: new Date(),
+    expiresOn: new Date(Date.now() + 3600 * 1000), // 1 hour
+  },
+  sharedKeyCredential
+).toString();
+
+const sasUrl = `https://${accountName}.blob.core.windows.net/my-container/my-file.txt?${sasToken}`;
+```
+
+### Generate Container SAS
+
+```typescript
+import { ContainerSASPermissions, generateBlobSASQueryParameters } from "@azure/storage-blob";
+
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    permissions: ContainerSASPermissions.parse("racwdl"), // read, add, create, write, delete, list
+    expiresOn: new Date(Date.now() + 24 * 3600 * 1000), // 24 hours
+  },
+  sharedKeyCredential
+).toString();
+```
+
+### Generate Account SAS
+
+```typescript
+import {
+  AccountSASPermissions,
+  AccountSASResourceTypes,
+  AccountSASServices,
+  generateAccountSASQueryParameters,
+} from "@azure/storage-blob";
+
+const sasToken = generateAccountSASQueryParameters(
+  {
+    services: AccountSASServices.parse("b").toString(), // blob
+    resourceTypes: AccountSASResourceTypes.parse("sco").toString(), // service, container, object
+    permissions: AccountSASPermissions.parse("rwdlacupi"), // all permissions
+    expiresOn: new Date(Date.now() + 24 * 3600 * 1000),
+  },
+  sharedKeyCredential
+).toString();
+```
+
+## Blob Types
+
+### Block Blob (Default)
+
+Most common type for text and binary files.
+
+```typescript
+const blockBlobClient = containerClient.getBlockBlobClient("document.pdf");
+await blockBlobClient.uploadFile("/path/to/document.pdf");
+```
+
+### Append Blob
+
+Optimized for append operations (logs, audit trails).
+
+```typescript
+const appendBlobClient = containerClient.getAppendBlobClient("app.log");
+
+// Create the append blob
+await appendBlobClient.create();
+
+// Append data
+await appendBlobClient.appendBlock("Log entry 1\n", 12);
+await appendBlobClient.appendBlock("Log entry 2\n", 12);
+```
+
+### Page Blob
+
+Fixed-size blobs for random read/write (VHDs).
+
+```typescript
+const pageBlobClient = containerClient.getPageBlobClient("disk.vhd");
+
+// Create 512-byte aligned page blob
+await pageBlobClient.create(1024 * 1024); // 1MB
+
+// Write pages (must be 512-byte aligned)
+const buffer = Buffer.alloc(512);
+await pageBlobClient.uploadPages(buffer, 0, 512);
+```
+
+## Error Handling
+
+```typescript
+import { RestError } from "@azure/storage-blob";
+
+try {
+  await containerClient.create();
+} catch (error) {
+  if (error instanceof RestError) {
+    switch (error.statusCode) {
+      case 404:
+        console.log("Container not found");
+        break;
+      case 409:
+        console.log("Container already exists");
+        break;
+      case 403:
+        console.log("Access denied");
+        break;
+      default:
+        console.error(`Storage error ${error.statusCode}: ${error.message}`);
+    }
+  }
+  throw error;
+}
+```
+
+## TypeScript Types Reference
+
+```typescript
+import {
+  // Clients
+  BlobServiceClient,
+  ContainerClient,
+  BlobClient,
+  BlockBlobClient,
+  AppendBlobClient,
+  PageBlobClient,
+
+  // Authentication
+  StorageSharedKeyCredential,
+  AnonymousCredential,
+
+  // SAS
+  BlobSASPermissions,
+  ContainerSASPermissions,
+  AccountSASPermissions,
+  AccountSASServices,
+  AccountSASResourceTypes,
+  generateBlobSASQueryParameters,
+  generateAccountSASQueryParameters,
+
+  // Options & Responses
+  BlobDownloadResponseParsed,
+  BlobUploadCommonResponse,
+  ContainerCreateResponse,
+  BlobItem,
+  ContainerItem,
+
+  // Errors
+  RestError,
+} from "@azure/storage-blob";
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** — Prefer AAD over connection strings/keys
+2. **Use streaming for large files** — `uploadStream`/`downloadToFile` for files > 256MB
+3. **Set appropriate content types** — Use `setHTTPHeaders` for correct MIME types
+4. **Use SAS tokens for client access** — Generate short-lived tokens for browser uploads
+5. **Handle errors gracefully** — Check `RestError.statusCode` for specific handling
+6. **Use `*IfNotExists` methods** — For idempotent container/blob creation
+7. **Close clients** — Not required but good practice in long-running apps
+
+## Platform Differences
+
+| Feature | Node.js | Browser |
+|---------|---------|---------|
+| `StorageSharedKeyCredential` | ✅ | ❌ |
+| `uploadFile()` | ✅ | ❌ |
+| `uploadStream()` | ✅ | ❌ |
+| `downloadToFile()` | ✅ | ❌ |
+| `downloadToBuffer()` | ✅ | ❌ |
+| `uploadData()` | ✅ | ✅ |
+| SAS generation | ✅ | ❌ |
+| DefaultAzureCredential | ✅ | ❌ |
+| Anonymous/SAS access | ✅ | ✅ |

--- a/skills/typescript/data/blob/references/sas-tokens.md
+++ b/skills/typescript/data/blob/references/sas-tokens.md
@@ -1,0 +1,494 @@
+# @azure/storage-blob - SAS Token Patterns
+
+Reference documentation for generating Shared Access Signatures (SAS) in the Azure Blob Storage TypeScript SDK.
+
+**Source**: [Azure SDK for JS - storage-blob](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-blob)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/storage-blob @azure/identity
+```
+
+---
+
+## SAS Types Overview
+
+| SAS Type | Scope | Use Case |
+|----------|-------|----------|
+| **Service SAS** | Single blob or container | Grant access to specific resources |
+| **Account SAS** | Entire storage account | Grant broad access to multiple services |
+| **User Delegation SAS** | Single blob or container | Most secure, uses Entra ID credentials |
+
+---
+
+## User Delegation SAS (Recommended)
+
+Most secure option—uses Entra ID credentials instead of account keys.
+
+### Generate User Delegation Key
+
+```typescript
+import {
+  BlobServiceClient,
+  generateBlobSASQueryParameters,
+  BlobSASPermissions,
+  SASProtocol,
+} from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+const blobServiceClient = new BlobServiceClient(
+  `https://${accountName}.blob.core.windows.net`,
+  credential
+);
+
+// Get user delegation key (valid for up to 7 days)
+const startsOn = new Date();
+const expiresOn = new Date(startsOn.valueOf() + 3600 * 1000); // 1 hour
+
+const userDelegationKey = await blobServiceClient.getUserDelegationKey(
+  startsOn,
+  expiresOn
+);
+```
+
+### Generate User Delegation SAS for Blob
+
+```typescript
+const containerName = "my-container";
+const blobName = "my-blob.txt";
+
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName,
+    blobName,
+    permissions: BlobSASPermissions.parse("r"), // read only
+    startsOn,
+    expiresOn,
+    protocol: SASProtocol.Https,
+  },
+  userDelegationKey,
+  accountName
+).toString();
+
+const sasUrl = `https://${accountName}.blob.core.windows.net/${containerName}/${blobName}?${sasToken}`;
+console.log("SAS URL:", sasUrl);
+```
+
+---
+
+## Service SAS (Account Key)
+
+Uses storage account key. Less secure but simpler for some scenarios.
+
+### Generate Blob SAS
+
+```typescript
+import {
+  BlobServiceClient,
+  generateBlobSASQueryParameters,
+  BlobSASPermissions,
+  StorageSharedKeyCredential,
+} from "@azure/storage-blob";
+
+const accountName = process.env["STORAGE_ACCOUNT_NAME"]!;
+const accountKey = process.env["STORAGE_ACCOUNT_KEY"]!;
+
+const sharedKeyCredential = new StorageSharedKeyCredential(
+  accountName,
+  accountKey
+);
+
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    blobName: "my-blob.txt",
+    permissions: BlobSASPermissions.parse("racwd"), // read, add, create, write, delete
+    startsOn: new Date(),
+    expiresOn: new Date(Date.now() + 3600 * 1000), // 1 hour
+  },
+  sharedKeyCredential
+).toString();
+
+const sasUrl = `https://${accountName}.blob.core.windows.net/my-container/my-blob.txt?${sasToken}`;
+```
+
+### Generate Container SAS
+
+```typescript
+import {
+  ContainerSASPermissions,
+  generateBlobSASQueryParameters,
+} from "@azure/storage-blob";
+
+const containerSasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    permissions: ContainerSASPermissions.parse("rl"), // read, list
+    startsOn: new Date(),
+    expiresOn: new Date(Date.now() + 86400 * 1000), // 24 hours
+  },
+  sharedKeyCredential
+).toString();
+
+const containerSasUrl = `https://${accountName}.blob.core.windows.net/my-container?${containerSasToken}`;
+```
+
+---
+
+## Account SAS
+
+Grants access to multiple services (blob, queue, table, file).
+
+```typescript
+import {
+  generateAccountSASQueryParameters,
+  AccountSASPermissions,
+  AccountSASServices,
+  AccountSASResourceTypes,
+  StorageSharedKeyCredential,
+} from "@azure/storage-blob";
+
+const accountSasToken = generateAccountSASQueryParameters(
+  {
+    services: AccountSASServices.parse("btqf").toString(), // blob, table, queue, file
+    resourceTypes: AccountSASResourceTypes.parse("sco").toString(), // service, container, object
+    permissions: AccountSASPermissions.parse("rwdlacupi"), // all permissions
+    startsOn: new Date(),
+    expiresOn: new Date(Date.now() + 3600 * 1000),
+    protocol: SASProtocol.Https,
+  },
+  sharedKeyCredential
+).toString();
+
+const accountSasUrl = `https://${accountName}.blob.core.windows.net?${accountSasToken}`;
+```
+
+---
+
+## SAS Permissions
+
+### Blob Permissions (`BlobSASPermissions`)
+
+| Permission | Code | Description |
+|------------|------|-------------|
+| Read | `r` | Read blob content and metadata |
+| Add | `a` | Add blocks to append blob |
+| Create | `c` | Create new blob |
+| Write | `w` | Write to blob |
+| Delete | `d` | Delete blob |
+| Delete Version | `x` | Delete blob version |
+| Tag | `t` | Read/write blob tags |
+| Move | `m` | Move blob |
+| Execute | `e` | Execute (for DataLake) |
+| Set Immutability | `i` | Set immutability policy |
+| Permanent Delete | `y` | Permanently delete (soft-deleted) |
+
+```typescript
+// Parse from string
+const permissions = BlobSASPermissions.parse("rwd");
+
+// Build programmatically
+const permissions = new BlobSASPermissions();
+permissions.read = true;
+permissions.write = true;
+permissions.delete = true;
+```
+
+### Container Permissions (`ContainerSASPermissions`)
+
+Same as blob permissions, plus:
+
+| Permission | Code | Description |
+|------------|------|-------------|
+| List | `l` | List blobs in container |
+
+```typescript
+const permissions = ContainerSASPermissions.parse("rl"); // read and list
+```
+
+### Account Permissions (`AccountSASPermissions`)
+
+| Permission | Code | Description |
+|------------|------|-------------|
+| Read | `r` | Read |
+| Write | `w` | Write |
+| Delete | `d` | Delete |
+| Delete Version | `x` | Delete version |
+| List | `l` | List |
+| Add | `a` | Add |
+| Create | `c` | Create |
+| Update | `u` | Update |
+| Process | `p` | Process messages |
+| Tag | `t` | Tags |
+| Filter | `f` | Filter by tags |
+| Set Immutability | `i` | Immutability policy |
+
+---
+
+## SAS Options
+
+### Content Headers
+
+Override response headers:
+
+```typescript
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    blobName: "document.pdf",
+    permissions: BlobSASPermissions.parse("r"),
+    expiresOn: new Date(Date.now() + 3600 * 1000),
+    
+    // Override response headers
+    contentDisposition: "attachment; filename=download.pdf",
+    contentType: "application/pdf",
+    cacheControl: "max-age=3600",
+    contentEncoding: "gzip",
+    contentLanguage: "en-US",
+  },
+  sharedKeyCredential
+).toString();
+```
+
+### IP Restrictions
+
+Restrict SAS to specific IP addresses:
+
+```typescript
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    blobName: "my-blob.txt",
+    permissions: BlobSASPermissions.parse("r"),
+    expiresOn: new Date(Date.now() + 3600 * 1000),
+    
+    // Single IP
+    ipRange: { start: "168.1.5.60" },
+    
+    // IP range
+    // ipRange: { start: "168.1.5.60", end: "168.1.5.70" },
+  },
+  sharedKeyCredential
+).toString();
+```
+
+### Protocol Restriction
+
+Require HTTPS:
+
+```typescript
+import { SASProtocol } from "@azure/storage-blob";
+
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    blobName: "my-blob.txt",
+    permissions: BlobSASPermissions.parse("r"),
+    expiresOn: new Date(Date.now() + 3600 * 1000),
+    protocol: SASProtocol.Https, // HTTPS only
+    // protocol: SASProtocol.HttpsAndHttp, // Allow both
+  },
+  sharedKeyCredential
+).toString();
+```
+
+### Blob Versioning
+
+Access specific blob version or snapshot:
+
+```typescript
+const sasToken = generateBlobSASQueryParameters(
+  {
+    containerName: "my-container",
+    blobName: "my-blob.txt",
+    permissions: BlobSASPermissions.parse("r"),
+    expiresOn: new Date(Date.now() + 3600 * 1000),
+    
+    // For snapshots
+    snapshotTime: "2023-01-15T10:30:00.0000000Z",
+    
+    // For versions
+    // versionId: "2023-01-15T10:30:00.0000000Z",
+  },
+  sharedKeyCredential
+).toString();
+```
+
+---
+
+## Using SAS URLs
+
+### Download with SAS
+
+```typescript
+// Client-side (browser or Node.js)
+const response = await fetch(sasUrl);
+const blob = await response.blob();
+```
+
+### Upload with SAS (Write Permission)
+
+```typescript
+const sasUrlWithWrite = `https://${accountName}.blob.core.windows.net/container/blob.txt?${writeSasToken}`;
+
+await fetch(sasUrlWithWrite, {
+  method: "PUT",
+  headers: {
+    "x-ms-blob-type": "BlockBlob",
+    "Content-Type": "text/plain",
+  },
+  body: "Hello, World!",
+});
+```
+
+### Create Anonymous Client with SAS
+
+```typescript
+import { BlobClient } from "@azure/storage-blob";
+
+// No credential needed - SAS in URL
+const blobClient = new BlobClient(sasUrl);
+const downloadResponse = await blobClient.download(0);
+```
+
+---
+
+## Complete Example
+
+```typescript
+import {
+  BlobServiceClient,
+  generateBlobSASQueryParameters,
+  BlobSASPermissions,
+  ContainerSASPermissions,
+  SASProtocol,
+  StorageSharedKeyCredential,
+} from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+async function generateSasTokens() {
+  const accountName = process.env["STORAGE_ACCOUNT_NAME"]!;
+  const accountKey = process.env["STORAGE_ACCOUNT_KEY"]!;
+  
+  // Method 1: User Delegation SAS (recommended)
+  const credential = new DefaultAzureCredential();
+  const blobServiceClient = new BlobServiceClient(
+    `https://${accountName}.blob.core.windows.net`,
+    credential
+  );
+  
+  const startsOn = new Date();
+  const expiresOn = new Date(startsOn.valueOf() + 3600 * 1000);
+  
+  const userDelegationKey = await blobServiceClient.getUserDelegationKey(
+    startsOn,
+    expiresOn
+  );
+  
+  const userDelegationSas = generateBlobSASQueryParameters(
+    {
+      containerName: "uploads",
+      blobName: "user-file.txt",
+      permissions: BlobSASPermissions.parse("r"),
+      startsOn,
+      expiresOn,
+      protocol: SASProtocol.Https,
+    },
+    userDelegationKey,
+    accountName
+  ).toString();
+  
+  console.log("User Delegation SAS URL:");
+  console.log(`https://${accountName}.blob.core.windows.net/uploads/user-file.txt?${userDelegationSas}`);
+  
+  // Method 2: Service SAS with account key
+  const sharedKeyCredential = new StorageSharedKeyCredential(
+    accountName,
+    accountKey
+  );
+  
+  // Read-only SAS for download
+  const readSas = generateBlobSASQueryParameters(
+    {
+      containerName: "public-files",
+      blobName: "document.pdf",
+      permissions: BlobSASPermissions.parse("r"),
+      expiresOn: new Date(Date.now() + 86400 * 1000), // 24 hours
+      contentDisposition: "attachment; filename=download.pdf",
+      protocol: SASProtocol.Https,
+    },
+    sharedKeyCredential
+  ).toString();
+  
+  console.log("\nRead SAS URL:");
+  console.log(`https://${accountName}.blob.core.windows.net/public-files/document.pdf?${readSas}`);
+  
+  // Write SAS for upload
+  const writeSas = generateBlobSASQueryParameters(
+    {
+      containerName: "uploads",
+      blobName: "new-upload.txt",
+      permissions: BlobSASPermissions.parse("cw"), // create, write
+      expiresOn: new Date(Date.now() + 3600 * 1000), // 1 hour
+      protocol: SASProtocol.Https,
+    },
+    sharedKeyCredential
+  ).toString();
+  
+  console.log("\nWrite SAS URL:");
+  console.log(`https://${accountName}.blob.core.windows.net/uploads/new-upload.txt?${writeSas}`);
+  
+  // Container list SAS
+  const listSas = generateBlobSASQueryParameters(
+    {
+      containerName: "public-files",
+      permissions: ContainerSASPermissions.parse("rl"), // read, list
+      expiresOn: new Date(Date.now() + 3600 * 1000),
+      protocol: SASProtocol.Https,
+    },
+    sharedKeyCredential
+  ).toString();
+  
+  console.log("\nContainer List SAS URL:");
+  console.log(`https://${accountName}.blob.core.windows.net/public-files?${listSas}`);
+}
+
+generateSasTokens().catch(console.error);
+```
+
+---
+
+## Best Practices
+
+1. **Prefer User Delegation SAS** - More secure, tied to Entra ID, auditable
+2. **Use shortest possible expiry** - Minimize exposure window
+3. **Use HTTPS only** - Set `protocol: SASProtocol.Https`
+4. **Apply least privilege** - Grant only necessary permissions
+5. **Use IP restrictions** - When client IPs are known
+6. **Rotate keys regularly** - If using account key SAS
+7. **Store SAS securely** - Never expose in client-side code permanently
+8. **Set start time** - Prevent "not yet valid" errors due to clock skew
+9. **Use stored access policies** - For container-level SAS management
+
+---
+
+## Security Considerations
+
+| Risk | Mitigation |
+|------|------------|
+| SAS token leaked | Short expiry, IP restrictions, HTTPS only |
+| Over-privileged access | Least privilege permissions |
+| Account key compromise | Use User Delegation SAS instead |
+| Clock skew issues | Set `startsOn` slightly in the past |
+| Token reuse | Use unique blob names or short expiry |
+
+---
+
+## See Also
+
+- [Streaming Patterns](./streaming.md) - Upload/download with SAS
+- [Official Documentation](https://learn.microsoft.com/azure/storage/common/storage-sas-overview)

--- a/skills/typescript/data/blob/references/streaming.md
+++ b/skills/typescript/data/blob/references/streaming.md
@@ -1,0 +1,425 @@
+# @azure/storage-blob - Streaming Patterns
+
+Reference documentation for upload/download streaming in the Azure Blob Storage TypeScript SDK.
+
+**Source**: [Azure SDK for JS - storage-blob](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-blob)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/storage-blob @azure/identity
+```
+
+---
+
+## Client Setup
+
+```typescript
+import {
+  BlobServiceClient,
+  ContainerClient,
+  BlockBlobClient,
+} from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+const accountUrl = `https://${process.env["STORAGE_ACCOUNT_NAME"]}.blob.core.windows.net`;
+
+const blobServiceClient = new BlobServiceClient(accountUrl, credential);
+const containerClient = blobServiceClient.getContainerClient("my-container");
+const blobClient = containerClient.getBlockBlobClient("my-blob.txt");
+```
+
+---
+
+## Download Streaming
+
+### Download to Buffer
+
+```typescript
+const downloadResponse = await blobClient.download(0);
+const downloaded = await streamToBuffer(downloadResponse.readableStreamBody!);
+
+async function streamToBuffer(readableStream: NodeJS.ReadableStream): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    readableStream.on("data", (data) => chunks.push(Buffer.from(data)));
+    readableStream.on("end", () => resolve(Buffer.concat(chunks)));
+    readableStream.on("error", reject);
+  });
+}
+```
+
+### Download to File (Node.js)
+
+```typescript
+import fs from "node:fs";
+import { pipeline } from "node:stream/promises";
+
+const downloadResponse = await blobClient.download(0);
+await pipeline(
+  downloadResponse.readableStreamBody!,
+  fs.createWriteStream("./local-file.txt")
+);
+```
+
+### Download with Range
+
+```typescript
+// Download bytes 100-199 (100 bytes total)
+const downloadResponse = await blobClient.download(100, 100);
+```
+
+### Download with Progress
+
+```typescript
+const downloadResponse = await blobClient.download(0, undefined, {
+  onProgress: (progress) => {
+    console.log(`Downloaded ${progress.loadedBytes} bytes`);
+  },
+});
+```
+
+---
+
+## Upload Streaming
+
+### Upload from Buffer
+
+```typescript
+const content = Buffer.from("Hello, World!");
+await blobClient.upload(content, content.length);
+```
+
+### Upload from Stream (Node.js)
+
+```typescript
+import fs from "node:fs";
+
+const fileStream = fs.createReadStream("./large-file.zip");
+const fileSize = fs.statSync("./large-file.zip").size;
+
+await blobClient.uploadStream(fileStream, fileSize, 4, {
+  onProgress: (progress) => {
+    const percent = ((progress.loadedBytes / fileSize) * 100).toFixed(2);
+    console.log(`Upload progress: ${percent}%`);
+  },
+});
+```
+
+### Upload with Options
+
+```typescript
+await blobClient.uploadStream(fileStream, fileSize, 4, {
+  // Number of concurrent upload operations
+  concurrency: 4,
+  
+  // Size of each block (4MB default, max 4000MB)
+  bufferSize: 4 * 1024 * 1024,
+  
+  // Progress tracking
+  onProgress: (progress) => {
+    console.log(`Uploaded: ${progress.loadedBytes} bytes`);
+  },
+  
+  // HTTP headers
+  blobHTTPHeaders: {
+    blobContentType: "application/zip",
+    blobContentEncoding: "gzip",
+  },
+  
+  // Custom metadata
+  metadata: {
+    uploadedBy: "my-app",
+    version: "1.0",
+  },
+  
+  // Access tier
+  tier: "Cool",
+});
+```
+
+---
+
+## Block Upload (Large Files)
+
+For large files, use staged block uploads for better control:
+
+```typescript
+import { BlockBlobClient, BlockBlobStageBlockOptions } from "@azure/storage-blob";
+import { v4 as uuidv4 } from "uuid";
+
+async function uploadLargeFile(
+  blobClient: BlockBlobClient,
+  filePath: string,
+  blockSize = 4 * 1024 * 1024 // 4MB blocks
+) {
+  const fileHandle = await fs.promises.open(filePath, "r");
+  const fileStats = await fileHandle.stat();
+  const fileSize = fileStats.size;
+  
+  const blockIds: string[] = [];
+  let offset = 0;
+  let blockIndex = 0;
+  
+  try {
+    while (offset < fileSize) {
+      const chunkSize = Math.min(blockSize, fileSize - offset);
+      const buffer = Buffer.alloc(chunkSize);
+      
+      await fileHandle.read(buffer, 0, chunkSize, offset);
+      
+      // Generate block ID (must be base64 encoded, same length)
+      const blockId = Buffer.from(
+        blockIndex.toString().padStart(6, "0")
+      ).toString("base64");
+      
+      // Stage the block
+      await blobClient.stageBlock(blockId, buffer, buffer.length);
+      
+      blockIds.push(blockId);
+      offset += chunkSize;
+      blockIndex++;
+      
+      console.log(`Staged block ${blockIndex}, offset: ${offset}/${fileSize}`);
+    }
+    
+    // Commit all blocks
+    await blobClient.commitBlockList(blockIds, {
+      blobHTTPHeaders: {
+        blobContentType: "application/octet-stream",
+      },
+    });
+    
+    console.log("Upload complete!");
+  } finally {
+    await fileHandle.close();
+  }
+}
+```
+
+---
+
+## Parallel Upload/Download
+
+### Parallel Download to File
+
+```typescript
+import { BlobClient } from "@azure/storage-blob";
+
+// Downloads in parallel chunks automatically
+await blobClient.downloadToFile("./local-file.zip", 0, undefined, {
+  // Chunk size for parallel download
+  blockSize: 4 * 1024 * 1024,
+  
+  // Number of parallel downloads
+  concurrency: 4,
+  
+  onProgress: (progress) => {
+    console.log(`Downloaded: ${progress.loadedBytes} bytes`);
+  },
+});
+```
+
+### Parallel Upload from File
+
+```typescript
+// Uploads in parallel chunks automatically
+await blobClient.uploadFile("./large-file.zip", {
+  // Chunk size
+  blockSize: 4 * 1024 * 1024,
+  
+  // Parallel uploads
+  concurrency: 4,
+  
+  onProgress: (progress) => {
+    console.log(`Uploaded: ${progress.loadedBytes} bytes`);
+  },
+  
+  blobHTTPHeaders: {
+    blobContentType: "application/zip",
+  },
+});
+```
+
+---
+
+## Browser Upload
+
+For browser environments, use `uploadBrowserData`:
+
+```typescript
+// From File input
+const fileInput = document.getElementById("file") as HTMLInputElement;
+const file = fileInput.files![0];
+
+await blobClient.uploadBrowserData(file, {
+  onProgress: (progress) => {
+    const percent = ((progress.loadedBytes / file.size) * 100).toFixed(2);
+    document.getElementById("progress")!.textContent = `${percent}%`;
+  },
+  blobHTTPHeaders: {
+    blobContentType: file.type,
+  },
+});
+
+// From ArrayBuffer
+const arrayBuffer = await file.arrayBuffer();
+await blobClient.uploadBrowserData(arrayBuffer);
+
+// From Blob
+const blob = new Blob(["Hello, World!"], { type: "text/plain" });
+await blobClient.uploadBrowserData(blob);
+```
+
+---
+
+## Abort Operations
+
+Cancel long-running uploads/downloads:
+
+```typescript
+const abortController = new AbortController();
+
+// Set up abort after 30 seconds
+setTimeout(() => abortController.abort(), 30000);
+
+try {
+  await blobClient.uploadFile("./large-file.zip", {
+    abortSignal: abortController.signal,
+    onProgress: (progress) => {
+      console.log(`Progress: ${progress.loadedBytes}`);
+    },
+  });
+} catch (error) {
+  if (error.name === "AbortError") {
+    console.log("Upload was cancelled");
+  } else {
+    throw error;
+  }
+}
+
+// Manual abort
+document.getElementById("cancel")?.addEventListener("click", () => {
+  abortController.abort();
+});
+```
+
+---
+
+## Copy Operations
+
+### Copy from URL
+
+```typescript
+const sourceUrl = "https://source-account.blob.core.windows.net/container/blob";
+
+// Start async copy
+const copyPoller = await blobClient.beginCopyFromURL(sourceUrl);
+
+// Wait for completion
+const result = await copyPoller.pollUntilDone();
+console.log(`Copy completed: ${result.copyStatus}`);
+
+// Or copy synchronously (for small blobs)
+await blobClient.syncCopyFromURL(sourceUrl);
+```
+
+### Copy with Progress
+
+```typescript
+const copyPoller = await blobClient.beginCopyFromURL(sourceUrl, {
+  onProgress: (state) => {
+    if (state.copyProgress) {
+      const [copied, total] = state.copyProgress.split("/").map(Number);
+      console.log(`Copied: ${copied}/${total} bytes`);
+    }
+  },
+});
+```
+
+---
+
+## Complete Example
+
+```typescript
+import {
+  BlobServiceClient,
+  ContainerClient,
+  BlockBlobClient,
+} from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+import fs from "node:fs";
+import { pipeline } from "node:stream/promises";
+
+async function uploadAndDownload() {
+  const credential = new DefaultAzureCredential();
+  const blobServiceClient = new BlobServiceClient(
+    `https://${process.env["STORAGE_ACCOUNT_NAME"]}.blob.core.windows.net`,
+    credential
+  );
+
+  const containerClient = blobServiceClient.getContainerClient("demo");
+  await containerClient.createIfNotExists();
+
+  const blobClient = containerClient.getBlockBlobClient("test-file.txt");
+
+  // Upload with progress
+  console.log("Uploading...");
+  const uploadData = Buffer.from("Hello, Azure Blob Storage!");
+  await blobClient.upload(uploadData, uploadData.length, {
+    onProgress: (progress) => {
+      console.log(`Upload progress: ${progress.loadedBytes} bytes`);
+    },
+  });
+  console.log("Upload complete!");
+
+  // Download with progress
+  console.log("Downloading...");
+  const downloadResponse = await blobClient.download(0, undefined, {
+    onProgress: (progress) => {
+      console.log(`Download progress: ${progress.loadedBytes} bytes`);
+    },
+  });
+
+  // Stream to file
+  await pipeline(
+    downloadResponse.readableStreamBody!,
+    fs.createWriteStream("./downloaded-file.txt")
+  );
+  console.log("Download complete!");
+
+  // Get blob properties
+  const properties = await blobClient.getProperties();
+  console.log(`Blob size: ${properties.contentLength} bytes`);
+  console.log(`Content type: ${properties.contentType}`);
+  console.log(`Last modified: ${properties.lastModified}`);
+
+  // Cleanup
+  await blobClient.delete();
+  console.log("Blob deleted");
+}
+
+uploadAndDownload().catch(console.error);
+```
+
+---
+
+## Best Practices
+
+1. **Use parallel operations** - `uploadFile`/`downloadToFile` automatically parallelize
+2. **Set appropriate block sizes** - 4-8MB for most scenarios, larger for huge files
+3. **Implement progress tracking** - Use `onProgress` for user feedback
+4. **Handle abort signals** - Allow users to cancel long operations
+5. **Set content types** - Always set `blobContentType` for proper browser handling
+6. **Use streams for large files** - Avoid loading entire files into memory
+7. **Implement retry logic** - SDK has built-in retries, configure as needed
+
+---
+
+## See Also
+
+- [SAS Token Patterns](./sas-tokens.md) - Generate secure access tokens
+- [Official Samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/storage-blob/samples)

--- a/skills/typescript/data/cosmosdb/SKILL.md
+++ b/skills/typescript/data/cosmosdb/SKILL.md
@@ -1,0 +1,470 @@
+---
+name: azure-cosmos-typescript
+description: |
+  Azure Cosmos DB JavaScript/TypeScript SDK (@azure/cosmos) for data plane operations. Use for CRUD operations on documents, queries, bulk operations, and container management. Triggers: "Cosmos DB", "@azure/cosmos", "CosmosClient", "document CRUD", "NoSQL queries", "bulk operations", "partition key", "container.items".
+---
+
+# @azure/cosmos (TypeScript/JavaScript)
+
+Data plane SDK for Azure Cosmos DB NoSQL API operations — CRUD on documents, queries, bulk operations.
+
+> **⚠️ Data vs Management Plane**
+> - **This SDK (@azure/cosmos)**: CRUD operations on documents, queries, stored procedures
+> - **Management SDK (@azure/arm-cosmosdb)**: Create accounts, databases, containers via ARM
+
+## Installation
+
+```bash
+npm install @azure/cosmos @azure/identity
+```
+
+**Current Version**: 4.9.0  
+**Node.js**: >= 20.0.0
+
+## Environment Variables
+
+```bash
+COSMOS_ENDPOINT=https://<account>.documents.azure.com:443/
+COSMOS_DATABASE=<database-name>
+COSMOS_CONTAINER=<container-name>
+# For key-based auth only (prefer AAD)
+COSMOS_KEY=<account-key>
+```
+
+## Authentication
+
+### AAD with DefaultAzureCredential (Recommended)
+
+```typescript
+import { CosmosClient } from "@azure/cosmos";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new CosmosClient({
+  endpoint: process.env.COSMOS_ENDPOINT!,
+  aadCredentials: new DefaultAzureCredential(),
+});
+```
+
+### Key-Based Authentication
+
+```typescript
+import { CosmosClient } from "@azure/cosmos";
+
+// Option 1: Endpoint + Key
+const client = new CosmosClient({
+  endpoint: process.env.COSMOS_ENDPOINT!,
+  key: process.env.COSMOS_KEY!,
+});
+
+// Option 2: Connection String
+const client = new CosmosClient(process.env.COSMOS_CONNECTION_STRING!);
+```
+
+## Resource Hierarchy
+
+```
+CosmosClient
+└── Database
+    └── Container
+        ├── Items (documents)
+        ├── Scripts (stored procedures, triggers, UDFs)
+        └── Conflicts
+```
+
+## Core Operations
+
+### Database & Container Setup
+
+```typescript
+const { database } = await client.databases.createIfNotExists({
+  id: "my-database",
+});
+
+const { container } = await database.containers.createIfNotExists({
+  id: "my-container",
+  partitionKey: { paths: ["/partitionKey"] },
+});
+```
+
+### Create Document
+
+```typescript
+interface Product {
+  id: string;
+  partitionKey: string;
+  name: string;
+  price: number;
+}
+
+const item: Product = {
+  id: "product-1",
+  partitionKey: "electronics",
+  name: "Laptop",
+  price: 999.99,
+};
+
+const { resource } = await container.items.create<Product>(item);
+```
+
+### Read Document
+
+```typescript
+const { resource } = await container
+  .item("product-1", "electronics") // id, partitionKey
+  .read<Product>();
+
+if (resource) {
+  console.log(resource.name);
+}
+```
+
+### Update Document (Replace)
+
+```typescript
+const { resource: existing } = await container
+  .item("product-1", "electronics")
+  .read<Product>();
+
+if (existing) {
+  existing.price = 899.99;
+  const { resource: updated } = await container
+    .item("product-1", "electronics")
+    .replace<Product>(existing);
+}
+```
+
+### Upsert Document
+
+```typescript
+const item: Product = {
+  id: "product-1",
+  partitionKey: "electronics",
+  name: "Laptop Pro",
+  price: 1299.99,
+};
+
+const { resource } = await container.items.upsert<Product>(item);
+```
+
+### Delete Document
+
+```typescript
+await container.item("product-1", "electronics").delete();
+```
+
+### Patch Document (Partial Update)
+
+```typescript
+import { PatchOperation } from "@azure/cosmos";
+
+const operations: PatchOperation[] = [
+  { op: "replace", path: "/price", value: 799.99 },
+  { op: "add", path: "/discount", value: true },
+  { op: "remove", path: "/oldField" },
+];
+
+const { resource } = await container
+  .item("product-1", "electronics")
+  .patch<Product>(operations);
+```
+
+## Queries
+
+### Simple Query
+
+```typescript
+const { resources } = await container.items
+  .query<Product>("SELECT * FROM c WHERE c.price < 1000")
+  .fetchAll();
+```
+
+### Parameterized Query (Recommended)
+
+```typescript
+import { SqlQuerySpec } from "@azure/cosmos";
+
+const querySpec: SqlQuerySpec = {
+  query: "SELECT * FROM c WHERE c.partitionKey = @category AND c.price < @maxPrice",
+  parameters: [
+    { name: "@category", value: "electronics" },
+    { name: "@maxPrice", value: 1000 },
+  ],
+};
+
+const { resources } = await container.items
+  .query<Product>(querySpec)
+  .fetchAll();
+```
+
+### Query with Pagination
+
+```typescript
+const queryIterator = container.items.query<Product>(querySpec, {
+  maxItemCount: 10, // Items per page
+});
+
+while (queryIterator.hasMoreResults()) {
+  const { resources, continuationToken } = await queryIterator.fetchNext();
+  console.log(`Page with ${resources?.length} items`);
+  // Use continuationToken for next page if needed
+}
+```
+
+### Cross-Partition Query
+
+```typescript
+const { resources } = await container.items
+  .query<Product>(
+    "SELECT * FROM c WHERE c.price > 500",
+    { enableCrossPartitionQuery: true }
+  )
+  .fetchAll();
+```
+
+## Bulk Operations
+
+### Execute Bulk Operations
+
+```typescript
+import { BulkOperationType, OperationInput } from "@azure/cosmos";
+
+const operations: OperationInput[] = [
+  {
+    operationType: BulkOperationType.Create,
+    resourceBody: { id: "1", partitionKey: "cat-a", name: "Item 1" },
+  },
+  {
+    operationType: BulkOperationType.Upsert,
+    resourceBody: { id: "2", partitionKey: "cat-a", name: "Item 2" },
+  },
+  {
+    operationType: BulkOperationType.Read,
+    id: "3",
+    partitionKey: "cat-b",
+  },
+  {
+    operationType: BulkOperationType.Replace,
+    id: "4",
+    partitionKey: "cat-b",
+    resourceBody: { id: "4", partitionKey: "cat-b", name: "Updated" },
+  },
+  {
+    operationType: BulkOperationType.Delete,
+    id: "5",
+    partitionKey: "cat-c",
+  },
+  {
+    operationType: BulkOperationType.Patch,
+    id: "6",
+    partitionKey: "cat-c",
+    resourceBody: {
+      operations: [{ op: "replace", path: "/name", value: "Patched" }],
+    },
+  },
+];
+
+const response = await container.items.executeBulkOperations(operations);
+
+response.forEach((result, index) => {
+  if (result.statusCode >= 200 && result.statusCode < 300) {
+    console.log(`Operation ${index} succeeded`);
+  } else {
+    console.error(`Operation ${index} failed: ${result.statusCode}`);
+  }
+});
+```
+
+## Partition Keys
+
+### Simple Partition Key
+
+```typescript
+const { container } = await database.containers.createIfNotExists({
+  id: "products",
+  partitionKey: { paths: ["/category"] },
+});
+```
+
+### Hierarchical Partition Key (MultiHash)
+
+```typescript
+import { PartitionKeyDefinitionVersion, PartitionKeyKind } from "@azure/cosmos";
+
+const { container } = await database.containers.createIfNotExists({
+  id: "orders",
+  partitionKey: {
+    paths: ["/tenantId", "/userId", "/sessionId"],
+    version: PartitionKeyDefinitionVersion.V2,
+    kind: PartitionKeyKind.MultiHash,
+  },
+});
+
+// Operations require array of partition key values
+const { resource } = await container.items.create({
+  id: "order-1",
+  tenantId: "tenant-a",
+  userId: "user-123",
+  sessionId: "session-xyz",
+  total: 99.99,
+});
+
+// Read with hierarchical partition key
+const { resource: order } = await container
+  .item("order-1", ["tenant-a", "user-123", "session-xyz"])
+  .read();
+```
+
+## Error Handling
+
+```typescript
+import { ErrorResponse } from "@azure/cosmos";
+
+try {
+  const { resource } = await container.item("missing", "pk").read();
+} catch (error) {
+  if (error instanceof ErrorResponse) {
+    switch (error.code) {
+      case 404:
+        console.log("Document not found");
+        break;
+      case 409:
+        console.log("Conflict - document already exists");
+        break;
+      case 412:
+        console.log("Precondition failed (ETag mismatch)");
+        break;
+      case 429:
+        console.log("Rate limited - retry after:", error.retryAfterInMs);
+        break;
+      default:
+        console.error(`Cosmos error ${error.code}: ${error.message}`);
+    }
+  }
+  throw error;
+}
+```
+
+## Optimistic Concurrency (ETags)
+
+```typescript
+// Read with ETag
+const { resource, etag } = await container
+  .item("product-1", "electronics")
+  .read<Product>();
+
+if (resource && etag) {
+  resource.price = 899.99;
+  
+  try {
+    // Replace only if ETag matches
+    await container.item("product-1", "electronics").replace(resource, {
+      accessCondition: { type: "IfMatch", condition: etag },
+    });
+  } catch (error) {
+    if (error instanceof ErrorResponse && error.code === 412) {
+      console.log("Document was modified by another process");
+    }
+  }
+}
+```
+
+## TypeScript Types Reference
+
+```typescript
+import {
+  // Client & Resources
+  CosmosClient,
+  Database,
+  Container,
+  Item,
+  Items,
+  
+  // Operations
+  OperationInput,
+  BulkOperationType,
+  PatchOperation,
+  
+  // Queries
+  SqlQuerySpec,
+  SqlParameter,
+  FeedOptions,
+  
+  // Partition Keys
+  PartitionKeyDefinition,
+  PartitionKeyDefinitionVersion,
+  PartitionKeyKind,
+  
+  // Responses
+  ItemResponse,
+  FeedResponse,
+  ResourceResponse,
+  
+  // Errors
+  ErrorResponse,
+} from "@azure/cosmos";
+```
+
+## Best Practices
+
+1. **Use AAD authentication** — Prefer `DefaultAzureCredential` over keys
+2. **Always use parameterized queries** — Prevents injection, improves plan caching
+3. **Specify partition key** — Avoid cross-partition queries when possible
+4. **Use bulk operations** — For multiple writes, use `executeBulkOperations`
+5. **Handle 429 errors** — Implement retry logic with exponential backoff
+6. **Use ETags for concurrency** — Prevent lost updates in concurrent scenarios
+7. **Close client on shutdown** — Call `client.dispose()` in cleanup
+
+## Common Patterns
+
+### Service Layer Pattern
+
+```typescript
+export class ProductService {
+  private container: Container;
+
+  constructor(client: CosmosClient) {
+    this.container = client
+      .database(process.env.COSMOS_DATABASE!)
+      .container(process.env.COSMOS_CONTAINER!);
+  }
+
+  async getById(id: string, category: string): Promise<Product | null> {
+    try {
+      const { resource } = await this.container
+        .item(id, category)
+        .read<Product>();
+      return resource ?? null;
+    } catch (error) {
+      if (error instanceof ErrorResponse && error.code === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async create(product: Omit<Product, "id">): Promise<Product> {
+    const item = { ...product, id: crypto.randomUUID() };
+    const { resource } = await this.container.items.create<Product>(item);
+    return resource!;
+  }
+
+  async findByCategory(category: string): Promise<Product[]> {
+    const querySpec: SqlQuerySpec = {
+      query: "SELECT * FROM c WHERE c.partitionKey = @category",
+      parameters: [{ name: "@category", value: category }],
+    };
+    const { resources } = await this.container.items
+      .query<Product>(querySpec)
+      .fetchAll();
+    return resources;
+  }
+}
+```
+
+## Related SDKs
+
+| SDK | Purpose | Install |
+|-----|---------|---------|
+| `@azure/cosmos` | Data plane (this SDK) | `npm install @azure/cosmos` |
+| `@azure/arm-cosmosdb` | Management plane (ARM) | `npm install @azure/arm-cosmosdb` |
+| `@azure/identity` | Authentication | `npm install @azure/identity` |

--- a/skills/typescript/data/cosmosdb/references/bulk-operations.md
+++ b/skills/typescript/data/cosmosdb/references/bulk-operations.md
@@ -1,0 +1,469 @@
+# Bulk Operations Reference
+
+High-throughput bulk operations for Azure Cosmos DB using the @azure/cosmos TypeScript SDK.
+
+## Overview
+
+Bulk operations enable efficient batch processing of Create, Upsert, Read, Replace, Delete, and Patch operations with automatic batching and retry handling.
+
+## BulkOperationType Enum
+
+```typescript
+import { BulkOperationType } from "@azure/cosmos";
+
+enum BulkOperationType {
+  Create = "Create",
+  Upsert = "Upsert",
+  Read = "Read",
+  Replace = "Replace",
+  Delete = "Delete",
+  Patch = "Patch"
+}
+```
+
+## OperationInput Interface
+
+```typescript
+import { OperationInput, PatchOperation } from "@azure/cosmos";
+
+// Base operation types
+interface CreateOperationInput {
+  operationType: BulkOperationType.Create;
+  resourceBody: Record<string, unknown>;
+  partitionKey?: PartitionKey;
+}
+
+interface UpsertOperationInput {
+  operationType: BulkOperationType.Upsert;
+  resourceBody: Record<string, unknown>;
+  partitionKey?: PartitionKey;
+}
+
+interface ReadOperationInput {
+  operationType: BulkOperationType.Read;
+  id: string;
+  partitionKey: PartitionKey;
+}
+
+interface ReplaceOperationInput {
+  operationType: BulkOperationType.Replace;
+  id: string;
+  resourceBody: Record<string, unknown>;
+  partitionKey?: PartitionKey;
+}
+
+interface DeleteOperationInput {
+  operationType: BulkOperationType.Delete;
+  id: string;
+  partitionKey: PartitionKey;
+}
+
+interface PatchOperationInput {
+  operationType: BulkOperationType.Patch;
+  id: string;
+  partitionKey: PartitionKey;
+  resourceBody: {
+    operations: PatchOperation[];
+    condition?: string;
+  };
+}
+
+type OperationInput = 
+  | CreateOperationInput
+  | UpsertOperationInput
+  | ReadOperationInput
+  | ReplaceOperationInput
+  | DeleteOperationInput
+  | PatchOperationInput;
+```
+
+## Basic Bulk Operations
+
+```typescript
+import { 
+  CosmosClient, 
+  BulkOperationType, 
+  OperationInput,
+  BulkOperationResponse 
+} from "@azure/cosmos";
+
+const client = new CosmosClient({ endpoint, key });
+const container = client.database("mydb").container("mycontainer");
+
+// Mixed bulk operations
+const operations: OperationInput[] = [
+  // Create
+  {
+    operationType: BulkOperationType.Create,
+    resourceBody: { 
+      id: "item-1", 
+      partitionKey: "category-a", 
+      name: "Item 1",
+      price: 10.99
+    }
+  },
+  // Upsert
+  {
+    operationType: BulkOperationType.Upsert,
+    resourceBody: { 
+      id: "item-2", 
+      partitionKey: "category-a", 
+      name: "Item 2",
+      price: 20.99
+    }
+  },
+  // Read
+  {
+    operationType: BulkOperationType.Read,
+    id: "item-3",
+    partitionKey: "category-b"
+  },
+  // Replace
+  {
+    operationType: BulkOperationType.Replace,
+    id: "item-4",
+    partitionKey: "category-b",
+    resourceBody: { 
+      id: "item-4", 
+      partitionKey: "category-b", 
+      name: "Updated Item 4",
+      price: 15.99
+    }
+  },
+  // Delete
+  {
+    operationType: BulkOperationType.Delete,
+    id: "item-5",
+    partitionKey: "category-c"
+  }
+];
+
+const response: BulkOperationResponse = await container.items.bulk(operations);
+
+// Process results
+response.forEach((result, index) => {
+  if (result.statusCode >= 200 && result.statusCode < 300) {
+    console.log(`Operation ${index} succeeded: ${result.statusCode}`);
+    if (result.resourceBody) {
+      console.log(`  Resource: ${JSON.stringify(result.resourceBody)}`);
+    }
+  } else {
+    console.error(`Operation ${index} failed: ${result.statusCode}`);
+  }
+});
+```
+
+## Bulk Create Pattern
+
+```typescript
+interface Product {
+  id: string;
+  partitionKey: string;
+  name: string;
+  price: number;
+}
+
+async function bulkCreate(
+  container: Container,
+  items: Product[]
+): Promise<{ succeeded: number; failed: number }> {
+  const operations: OperationInput[] = items.map(item => ({
+    operationType: BulkOperationType.Create,
+    resourceBody: item
+  }));
+
+  const response = await container.items.bulk(operations);
+
+  let succeeded = 0;
+  let failed = 0;
+
+  response.forEach((result, index) => {
+    if (result.statusCode === 201) {
+      succeeded++;
+    } else {
+      failed++;
+      console.error(`Failed to create item ${items[index].id}: ${result.statusCode}`);
+    }
+  });
+
+  return { succeeded, failed };
+}
+
+// Usage
+const products: Product[] = [
+  { id: "p1", partitionKey: "electronics", name: "Laptop", price: 999 },
+  { id: "p2", partitionKey: "electronics", name: "Phone", price: 599 },
+  { id: "p3", partitionKey: "clothing", name: "Shirt", price: 29 },
+];
+
+const result = await bulkCreate(container, products);
+console.log(`Created: ${result.succeeded}, Failed: ${result.failed}`);
+```
+
+## Bulk Upsert Pattern
+
+```typescript
+async function bulkUpsert<T extends { id: string }>(
+  container: Container,
+  items: T[]
+): Promise<BulkOperationResponse> {
+  const operations: OperationInput[] = items.map(item => ({
+    operationType: BulkOperationType.Upsert,
+    resourceBody: item as Record<string, unknown>
+  }));
+
+  return container.items.bulk(operations);
+}
+
+// Usage - creates if not exists, updates if exists
+const updates = [
+  { id: "p1", partitionKey: "electronics", name: "Laptop Pro", price: 1299 },
+  { id: "p4", partitionKey: "electronics", name: "Tablet", price: 399 },
+];
+
+await bulkUpsert(container, updates);
+```
+
+## Bulk Delete Pattern
+
+```typescript
+interface DeleteItem {
+  id: string;
+  partitionKey: string;
+}
+
+async function bulkDelete(
+  container: Container,
+  items: DeleteItem[]
+): Promise<{ deleted: number; notFound: number; errors: number }> {
+  const operations: OperationInput[] = items.map(item => ({
+    operationType: BulkOperationType.Delete,
+    id: item.id,
+    partitionKey: item.partitionKey
+  }));
+
+  const response = await container.items.bulk(operations);
+
+  let deleted = 0;
+  let notFound = 0;
+  let errors = 0;
+
+  response.forEach((result) => {
+    if (result.statusCode === 204) {
+      deleted++;
+    } else if (result.statusCode === 404) {
+      notFound++;
+    } else {
+      errors++;
+    }
+  });
+
+  return { deleted, notFound, errors };
+}
+
+// Usage
+const toDelete: DeleteItem[] = [
+  { id: "p1", partitionKey: "electronics" },
+  { id: "p2", partitionKey: "electronics" },
+];
+
+const deleteResult = await bulkDelete(container, toDelete);
+console.log(`Deleted: ${deleteResult.deleted}, Not found: ${deleteResult.notFound}`);
+```
+
+## Bulk Patch Pattern
+
+```typescript
+import { PatchOperation } from "@azure/cosmos";
+
+interface PatchItem {
+  id: string;
+  partitionKey: string;
+  operations: PatchOperation[];
+}
+
+async function bulkPatch(
+  container: Container,
+  items: PatchItem[]
+): Promise<BulkOperationResponse> {
+  const operations: OperationInput[] = items.map(item => ({
+    operationType: BulkOperationType.Patch,
+    id: item.id,
+    partitionKey: item.partitionKey,
+    resourceBody: {
+      operations: item.operations
+    }
+  }));
+
+  return container.items.bulk(operations);
+}
+
+// Usage - partial updates
+const patches: PatchItem[] = [
+  {
+    id: "p1",
+    partitionKey: "electronics",
+    operations: [
+      { op: "replace", path: "/price", value: 899 },
+      { op: "add", path: "/onSale", value: true }
+    ]
+  },
+  {
+    id: "p2",
+    partitionKey: "electronics",
+    operations: [
+      { op: "incr", path: "/viewCount", value: 1 }
+    ]
+  }
+];
+
+await bulkPatch(container, patches);
+```
+
+## Chunked Bulk Operations
+
+For very large datasets, process in chunks to manage memory and handle rate limiting:
+
+```typescript
+async function bulkOperationsChunked<T extends Record<string, unknown>>(
+  container: Container,
+  items: T[],
+  operationType: BulkOperationType.Create | BulkOperationType.Upsert,
+  chunkSize: number = 100
+): Promise<{ succeeded: number; failed: number }> {
+  let succeeded = 0;
+  let failed = 0;
+
+  // Process in chunks
+  for (let i = 0; i < items.length; i += chunkSize) {
+    const chunk = items.slice(i, i + chunkSize);
+    
+    const operations: OperationInput[] = chunk.map(item => ({
+      operationType,
+      resourceBody: item
+    }));
+
+    const response = await container.items.bulk(operations);
+
+    response.forEach(result => {
+      if (result.statusCode >= 200 && result.statusCode < 300) {
+        succeeded++;
+      } else {
+        failed++;
+      }
+    });
+
+    console.log(`Processed ${Math.min(i + chunkSize, items.length)}/${items.length}`);
+  }
+
+  return { succeeded, failed };
+}
+
+// Usage
+const largeDataset = generateItems(10000);
+const result = await bulkOperationsChunked(container, largeDataset, BulkOperationType.Create, 100);
+```
+
+## Bulk Operation Response
+
+```typescript
+interface BulkOperationResponse extends Array<OperationResponse> {}
+
+interface OperationResponse {
+  /** HTTP status code */
+  statusCode: number;
+  
+  /** Request charge (RUs) for this operation */
+  requestCharge: number;
+  
+  /** ETag of the resource (for successful operations) */
+  eTag?: string;
+  
+  /** Resource body (for read/create/upsert/replace) */
+  resourceBody?: Record<string, unknown>;
+}
+
+// Common status codes
+// 200 - Read successful
+// 201 - Create successful
+// 204 - Delete successful
+// 400 - Bad request
+// 404 - Not found
+// 409 - Conflict (duplicate id on create)
+// 412 - Precondition failed
+// 429 - Rate limited
+```
+
+## Error Handling
+
+```typescript
+async function bulkWithRetry(
+  container: Container,
+  operations: OperationInput[],
+  maxRetries: number = 3
+): Promise<BulkOperationResponse> {
+  let response = await container.items.bulk(operations);
+  let retryCount = 0;
+
+  while (retryCount < maxRetries) {
+    const failedOps: OperationInput[] = [];
+    const failedIndices: number[] = [];
+
+    response.forEach((result, index) => {
+      if (result.statusCode === 429) {
+        // Rate limited - retry these
+        failedOps.push(operations[index]);
+        failedIndices.push(index);
+      }
+    });
+
+    if (failedOps.length === 0) {
+      break; // All succeeded
+    }
+
+    console.log(`Retrying ${failedOps.length} rate-limited operations...`);
+    
+    // Exponential backoff
+    await new Promise(resolve => 
+      setTimeout(resolve, Math.pow(2, retryCount) * 1000)
+    );
+
+    const retryResponse = await container.items.bulk(failedOps);
+    
+    // Update original response with retry results
+    retryResponse.forEach((result, i) => {
+      response[failedIndices[i]] = result;
+    });
+
+    retryCount++;
+  }
+
+  return response;
+}
+```
+
+## Best Practices
+
+1. **Batch by partition key** — Operations in the same partition are more efficient
+2. **Use appropriate chunk sizes** — 100-500 items per batch is typical
+3. **Handle 429 errors** — Implement retry with exponential backoff
+4. **Monitor RU consumption** — Check `requestCharge` in responses
+5. **Use Upsert for idempotency** — Safer than Create for retry scenarios
+6. **Validate before bulk** — Check data before submitting large batches
+7. **Process results** — Always check individual operation status codes
+
+## Performance Considerations
+
+| Factor | Recommendation |
+|--------|----------------|
+| Chunk size | 100-500 items per batch |
+| Partition distribution | Spread across partitions for parallelism |
+| Operation type | Upsert is safer than Create for retries |
+| Error handling | Implement retry logic for 429s |
+| Memory | Stream large datasets, don't load all into memory |
+
+## See Also
+
+- [Query Patterns Reference](./query-patterns.md)
+- [Cosmos DB Bulk Execution](https://learn.microsoft.com/azure/cosmos-db/nosql/tutorial-dotnet-bulk-import)
+- [Request Units (RUs)](https://learn.microsoft.com/azure/cosmos-db/request-units)

--- a/skills/typescript/data/cosmosdb/references/query-patterns.md
+++ b/skills/typescript/data/cosmosdb/references/query-patterns.md
@@ -1,0 +1,396 @@
+# Query Patterns Reference
+
+Advanced query patterns for Azure Cosmos DB using the @azure/cosmos TypeScript SDK.
+
+## Overview
+
+Cosmos DB supports SQL-like queries with support for JSON documents. This reference covers parameterized queries, pagination, cross-partition queries, and advanced query patterns.
+
+## SqlQuerySpec Interface
+
+```typescript
+import { SqlQuerySpec, SqlParameter } from "@azure/cosmos";
+
+interface SqlQuerySpec {
+  /** SQL query text */
+  query: string;
+  /** Array of parameters */
+  parameters?: SqlParameter[];
+}
+
+interface SqlParameter {
+  /** Parameter name (including @) */
+  name: string;
+  /** Parameter value */
+  value: unknown;
+}
+```
+
+## Parameterized Queries (Recommended)
+
+Always use parameterized queries to prevent injection and improve plan caching.
+
+```typescript
+import { SqlQuerySpec, Container } from "@azure/cosmos";
+
+interface Product {
+  id: string;
+  category: string;
+  name: string;
+  price: number;
+  inStock: boolean;
+}
+
+// Single parameter
+const querySpec: SqlQuerySpec = {
+  query: "SELECT * FROM c WHERE c.category = @category",
+  parameters: [
+    { name: "@category", value: "electronics" }
+  ]
+};
+
+const { resources } = await container.items
+  .query<Product>(querySpec)
+  .fetchAll();
+
+// Multiple parameters
+const rangeQuery: SqlQuerySpec = {
+  query: `
+    SELECT * FROM c 
+    WHERE c.category = @category 
+      AND c.price >= @minPrice 
+      AND c.price <= @maxPrice
+      AND c.inStock = @inStock
+  `,
+  parameters: [
+    { name: "@category", value: "electronics" },
+    { name: "@minPrice", value: 100 },
+    { name: "@maxPrice", value: 1000 },
+    { name: "@inStock", value: true }
+  ]
+};
+
+const { resources: filtered } = await container.items
+  .query<Product>(rangeQuery)
+  .fetchAll();
+```
+
+## Pagination with Continuation Tokens
+
+```typescript
+import { FeedOptions } from "@azure/cosmos";
+
+interface PagedResult<T> {
+  items: T[];
+  continuationToken?: string;
+  hasMore: boolean;
+}
+
+async function queryWithPagination<T>(
+  container: Container,
+  querySpec: SqlQuerySpec,
+  pageSize: number,
+  continuationToken?: string
+): Promise<PagedResult<T>> {
+  const options: FeedOptions = {
+    maxItemCount: pageSize,
+    continuationToken
+  };
+
+  const queryIterator = container.items.query<T>(querySpec, options);
+  const { resources, continuationToken: nextToken } = await queryIterator.fetchNext();
+
+  return {
+    items: resources || [],
+    continuationToken: nextToken,
+    hasMore: !!nextToken
+  };
+}
+
+// Usage
+let page = await queryWithPagination<Product>(
+  container,
+  { query: "SELECT * FROM c ORDER BY c.createdAt DESC" },
+  10
+);
+
+console.log(`Page 1: ${page.items.length} items`);
+
+while (page.hasMore) {
+  page = await queryWithPagination<Product>(
+    container,
+    { query: "SELECT * FROM c ORDER BY c.createdAt DESC" },
+    10,
+    page.continuationToken
+  );
+  console.log(`Next page: ${page.items.length} items`);
+}
+```
+
+## Async Iterator Pattern
+
+```typescript
+async function* queryAll<T>(
+  container: Container,
+  querySpec: SqlQuerySpec
+): AsyncGenerator<T> {
+  const queryIterator = container.items.query<T>(querySpec);
+  
+  while (queryIterator.hasMoreResults()) {
+    const { resources } = await queryIterator.fetchNext();
+    if (resources) {
+      for (const item of resources) {
+        yield item;
+      }
+    }
+  }
+}
+
+// Usage
+for await (const product of queryAll<Product>(container, querySpec)) {
+  console.log(product.name);
+}
+```
+
+## Cross-Partition Queries
+
+```typescript
+// Enable cross-partition query when partition key is not specified
+const crossPartitionQuery: SqlQuerySpec = {
+  query: "SELECT * FROM c WHERE c.price > @minPrice",
+  parameters: [{ name: "@minPrice", value: 500 }]
+};
+
+const { resources } = await container.items
+  .query<Product>(crossPartitionQuery, {
+    enableCrossPartitionQuery: true
+  })
+  .fetchAll();
+
+// Aggregate across partitions
+const aggregateQuery: SqlQuerySpec = {
+  query: "SELECT VALUE COUNT(1) FROM c WHERE c.category = @category",
+  parameters: [{ name: "@category", value: "electronics" }]
+};
+
+const { resources: countResult } = await container.items
+  .query<number>(aggregateQuery, { enableCrossPartitionQuery: true })
+  .fetchAll();
+
+console.log(`Total count: ${countResult[0]}`);
+```
+
+## Projection Queries
+
+```typescript
+// Select specific fields
+const projectionQuery: SqlQuerySpec = {
+  query: `
+    SELECT c.id, c.name, c.price, c.category
+    FROM c
+    WHERE c.inStock = true
+  `
+};
+
+interface ProductSummary {
+  id: string;
+  name: string;
+  price: number;
+  category: string;
+}
+
+const { resources } = await container.items
+  .query<ProductSummary>(projectionQuery)
+  .fetchAll();
+
+// Computed properties
+const computedQuery: SqlQuerySpec = {
+  query: `
+    SELECT 
+      c.id,
+      c.name,
+      c.price,
+      c.price * 0.9 AS discountedPrice,
+      CONCAT(c.category, "-", c.id) AS sku
+    FROM c
+  `
+};
+```
+
+## Array Queries (JOIN)
+
+```typescript
+interface Order {
+  id: string;
+  customerId: string;
+  items: OrderItem[];
+}
+
+interface OrderItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+// Query items within arrays
+const arrayQuery: SqlQuerySpec = {
+  query: `
+    SELECT 
+      o.id AS orderId,
+      o.customerId,
+      i.productId,
+      i.quantity,
+      i.price
+    FROM orders o
+    JOIN i IN o.items
+    WHERE i.quantity > @minQuantity
+  `,
+  parameters: [{ name: "@minQuantity", value: 5 }]
+};
+
+// Check if array contains value
+const containsQuery: SqlQuerySpec = {
+  query: `
+    SELECT * FROM c 
+    WHERE ARRAY_CONTAINS(c.tags, @tag)
+  `,
+  parameters: [{ name: "@tag", value: "featured" }]
+};
+```
+
+## Aggregate Functions
+
+```typescript
+// COUNT
+const countQuery = { query: "SELECT VALUE COUNT(1) FROM c" };
+
+// SUM, AVG, MIN, MAX
+const statsQuery: SqlQuerySpec = {
+  query: `
+    SELECT 
+      COUNT(1) AS totalProducts,
+      SUM(c.price) AS totalValue,
+      AVG(c.price) AS averagePrice,
+      MIN(c.price) AS minPrice,
+      MAX(c.price) AS maxPrice
+    FROM c
+    WHERE c.category = @category
+  `,
+  parameters: [{ name: "@category", value: "electronics" }]
+};
+
+interface ProductStats {
+  totalProducts: number;
+  totalValue: number;
+  averagePrice: number;
+  minPrice: number;
+  maxPrice: number;
+}
+
+const { resources } = await container.items
+  .query<ProductStats>(statsQuery, { enableCrossPartitionQuery: true })
+  .fetchAll();
+```
+
+## ORDER BY and TOP
+
+```typescript
+// Order by with TOP
+const topQuery: SqlQuerySpec = {
+  query: `
+    SELECT TOP 10 *
+    FROM c
+    WHERE c.category = @category
+    ORDER BY c.price DESC
+  `,
+  parameters: [{ name: "@category", value: "electronics" }]
+};
+
+// Multiple ORDER BY
+const multiOrderQuery: SqlQuerySpec = {
+  query: `
+    SELECT * FROM c
+    ORDER BY c.category ASC, c.price DESC
+  `
+};
+
+// OFFSET and LIMIT (alternative to continuation tokens)
+const offsetQuery: SqlQuerySpec = {
+  query: `
+    SELECT * FROM c
+    ORDER BY c.createdAt DESC
+    OFFSET @offset LIMIT @limit
+  `,
+  parameters: [
+    { name: "@offset", value: 20 },
+    { name: "@limit", value: 10 }
+  ]
+};
+```
+
+## String Functions
+
+```typescript
+const stringQuery: SqlQuerySpec = {
+  query: `
+    SELECT * FROM c
+    WHERE CONTAINS(c.name, @searchTerm, true)
+      OR STARTSWITH(c.name, @prefix)
+  `,
+  parameters: [
+    { name: "@searchTerm", value: "phone" },
+    { name: "@prefix", value: "Smart" }
+  ]
+};
+
+// Case-insensitive search with LOWER
+const caseInsensitiveQuery: SqlQuerySpec = {
+  query: `
+    SELECT * FROM c
+    WHERE LOWER(c.name) LIKE @pattern
+  `,
+  parameters: [{ name: "@pattern", value: "%laptop%" }]
+};
+```
+
+## FeedOptions Reference
+
+```typescript
+interface FeedOptions {
+  /** Max items per page */
+  maxItemCount?: number;
+  
+  /** Continuation token from previous page */
+  continuationToken?: string;
+  
+  /** Enable cross-partition queries */
+  enableCrossPartitionQuery?: boolean;
+  
+  /** Max parallelism for cross-partition queries */
+  maxDegreeOfParallelism?: number;
+  
+  /** Partition key for scoped queries */
+  partitionKey?: PartitionKey;
+  
+  /** Enable scan in queries (avoid if possible) */
+  enableScanInQuery?: boolean;
+  
+  /** Populate index metrics in response */
+  populateIndexMetrics?: boolean;
+}
+```
+
+## Query Performance Tips
+
+1. **Always specify partition key** — Avoids expensive cross-partition queries
+2. **Use parameterized queries** — Enables query plan caching
+3. **Project only needed fields** — Reduces response size and RU consumption
+4. **Avoid cross-partition aggregates** — Very expensive; consider materialized views
+5. **Use continuation tokens** — More efficient than OFFSET/LIMIT
+6. **Check index metrics** — Use `populateIndexMetrics: true` to diagnose slow queries
+
+## See Also
+
+- [Bulk Operations Reference](./bulk-operations.md)
+- [Azure Cosmos DB SQL Reference](https://learn.microsoft.com/azure/cosmos-db/nosql/query/)
+- [Query Performance Tips](https://learn.microsoft.com/azure/cosmos-db/nosql/query-metrics)

--- a/skills/typescript/data/fileshare/SKILL.md
+++ b/skills/typescript/data/fileshare/SKILL.md
@@ -1,0 +1,492 @@
+---
+name: azure-storage-fileshare-typescript
+description: |
+  Azure File Share JavaScript/TypeScript SDK (@azure/storage-file-share) for SMB file share operations. Use for creating shares, managing directories, uploading/downloading files, and handling file metadata. Supports Azure Files SMB protocol scenarios. Triggers: "file share", "@azure/storage-file-share", "ShareServiceClient", "ShareClient", "SMB", "Azure Files".
+---
+
+# @azure/storage-file-share (TypeScript/JavaScript)
+
+SDK for Azure File Share operations — SMB file shares, directories, and file operations.
+
+## Installation
+
+```bash
+npm install @azure/storage-file-share @azure/identity
+```
+
+**Current Version**: 12.x  
+**Node.js**: >= 18.0.0
+
+## Environment Variables
+
+```bash
+AZURE_STORAGE_ACCOUNT_NAME=<account-name>
+AZURE_STORAGE_ACCOUNT_KEY=<account-key>
+# OR connection string
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
+```
+
+## Authentication
+
+### Connection String (Simplest)
+
+```typescript
+import { ShareServiceClient } from "@azure/storage-file-share";
+
+const client = ShareServiceClient.fromConnectionString(
+  process.env.AZURE_STORAGE_CONNECTION_STRING!
+);
+```
+
+### StorageSharedKeyCredential (Node.js only)
+
+```typescript
+import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-file-share";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const accountKey = process.env.AZURE_STORAGE_ACCOUNT_KEY!;
+
+const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+const client = new ShareServiceClient(
+  `https://${accountName}.file.core.windows.net`,
+  sharedKeyCredential
+);
+```
+
+### DefaultAzureCredential
+
+```typescript
+import { ShareServiceClient } from "@azure/storage-file-share";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const client = new ShareServiceClient(
+  `https://${accountName}.file.core.windows.net`,
+  new DefaultAzureCredential()
+);
+```
+
+### SAS Token
+
+```typescript
+import { ShareServiceClient } from "@azure/storage-file-share";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const sasToken = process.env.AZURE_STORAGE_SAS_TOKEN!;
+
+const client = new ShareServiceClient(
+  `https://${accountName}.file.core.windows.net${sasToken}`
+);
+```
+
+## Client Hierarchy
+
+```
+ShareServiceClient (account level)
+└── ShareClient (share level)
+    └── ShareDirectoryClient (directory level)
+        └── ShareFileClient (file level)
+```
+
+## Share Operations
+
+### Create Share
+
+```typescript
+const shareClient = client.getShareClient("my-share");
+await shareClient.create();
+
+// Create with quota (in GB)
+await shareClient.create({ quota: 100 });
+```
+
+### List Shares
+
+```typescript
+for await (const share of client.listShares()) {
+  console.log(share.name, share.properties.quota);
+}
+
+// With prefix filter
+for await (const share of client.listShares({ prefix: "logs-" })) {
+  console.log(share.name);
+}
+```
+
+### Delete Share
+
+```typescript
+await shareClient.delete();
+
+// Delete if exists
+await shareClient.deleteIfExists();
+```
+
+### Get Share Properties
+
+```typescript
+const properties = await shareClient.getProperties();
+console.log("Quota:", properties.quota, "GB");
+console.log("Last Modified:", properties.lastModified);
+```
+
+### Set Share Quota
+
+```typescript
+await shareClient.setQuota(200); // 200 GB
+```
+
+## Directory Operations
+
+### Create Directory
+
+```typescript
+const directoryClient = shareClient.getDirectoryClient("my-directory");
+await directoryClient.create();
+
+// Create nested directory
+const nestedDir = shareClient.getDirectoryClient("parent/child/grandchild");
+await nestedDir.create();
+```
+
+### List Directories and Files
+
+```typescript
+const directoryClient = shareClient.getDirectoryClient("my-directory");
+
+for await (const item of directoryClient.listFilesAndDirectories()) {
+  if (item.kind === "directory") {
+    console.log(`[DIR] ${item.name}`);
+  } else {
+    console.log(`[FILE] ${item.name} (${item.properties.contentLength} bytes)`);
+  }
+}
+```
+
+### Delete Directory
+
+```typescript
+await directoryClient.delete();
+
+// Delete if exists
+await directoryClient.deleteIfExists();
+```
+
+### Check if Directory Exists
+
+```typescript
+const exists = await directoryClient.exists();
+if (!exists) {
+  await directoryClient.create();
+}
+```
+
+## File Operations
+
+### Upload File (Simple)
+
+```typescript
+const fileClient = shareClient
+  .getDirectoryClient("my-directory")
+  .getFileClient("my-file.txt");
+
+// Upload string
+const content = "Hello, World!";
+await fileClient.create(content.length);
+await fileClient.uploadRange(content, 0, content.length);
+```
+
+### Upload File (Node.js - from local file)
+
+```typescript
+import * as fs from "fs";
+import * as path from "path";
+
+const fileClient = shareClient.rootDirectoryClient.getFileClient("uploaded.txt");
+const localFilePath = "/path/to/local/file.txt";
+const fileSize = fs.statSync(localFilePath).size;
+
+await fileClient.create(fileSize);
+await fileClient.uploadFile(localFilePath);
+```
+
+### Upload File (Buffer)
+
+```typescript
+const buffer = Buffer.from("Hello, Azure Files!");
+const fileClient = shareClient.rootDirectoryClient.getFileClient("buffer-file.txt");
+
+await fileClient.create(buffer.length);
+await fileClient.uploadRange(buffer, 0, buffer.length);
+```
+
+### Upload File (Stream)
+
+```typescript
+import * as fs from "fs";
+
+const fileClient = shareClient.rootDirectoryClient.getFileClient("streamed.txt");
+const readStream = fs.createReadStream("/path/to/local/file.txt");
+const fileSize = fs.statSync("/path/to/local/file.txt").size;
+
+await fileClient.create(fileSize);
+await fileClient.uploadStream(readStream, fileSize, 4 * 1024 * 1024, 4); // 4MB buffer, 4 concurrency
+```
+
+### Download File
+
+```typescript
+const fileClient = shareClient
+  .getDirectoryClient("my-directory")
+  .getFileClient("my-file.txt");
+
+const downloadResponse = await fileClient.download();
+
+// Read as string
+const chunks: Buffer[] = [];
+for await (const chunk of downloadResponse.readableStreamBody!) {
+  chunks.push(Buffer.from(chunk));
+}
+const content = Buffer.concat(chunks).toString("utf-8");
+```
+
+### Download to File (Node.js)
+
+```typescript
+const fileClient = shareClient.rootDirectoryClient.getFileClient("my-file.txt");
+await fileClient.downloadToFile("/path/to/local/destination.txt");
+```
+
+### Download to Buffer (Node.js)
+
+```typescript
+const fileClient = shareClient.rootDirectoryClient.getFileClient("my-file.txt");
+const buffer = await fileClient.downloadToBuffer();
+console.log(buffer.toString());
+```
+
+### Delete File
+
+```typescript
+const fileClient = shareClient.rootDirectoryClient.getFileClient("my-file.txt");
+await fileClient.delete();
+
+// Delete if exists
+await fileClient.deleteIfExists();
+```
+
+### Copy File
+
+```typescript
+const sourceUrl = "https://account.file.core.windows.net/share/source.txt";
+const destFileClient = shareClient.rootDirectoryClient.getFileClient("destination.txt");
+
+// Start copy operation
+const copyPoller = await destFileClient.startCopyFromURL(sourceUrl);
+await copyPoller.pollUntilDone();
+```
+
+## File Properties & Metadata
+
+### Get File Properties
+
+```typescript
+const fileClient = shareClient.rootDirectoryClient.getFileClient("my-file.txt");
+const properties = await fileClient.getProperties();
+
+console.log("Content-Length:", properties.contentLength);
+console.log("Content-Type:", properties.contentType);
+console.log("Last Modified:", properties.lastModified);
+console.log("ETag:", properties.etag);
+```
+
+### Set Metadata
+
+```typescript
+await fileClient.setMetadata({
+  author: "John Doe",
+  category: "documents",
+});
+```
+
+### Set HTTP Headers
+
+```typescript
+await fileClient.setHttpHeaders({
+  fileContentType: "text/plain",
+  fileCacheControl: "max-age=3600",
+  fileContentDisposition: "attachment; filename=download.txt",
+});
+```
+
+## Range Operations
+
+### Upload Range
+
+```typescript
+const data = Buffer.from("partial content");
+await fileClient.uploadRange(data, 100, data.length); // Write at offset 100
+```
+
+### Download Range
+
+```typescript
+const downloadResponse = await fileClient.download(100, 50); // offset 100, length 50
+```
+
+### Clear Range
+
+```typescript
+await fileClient.clearRange(0, 100); // Clear first 100 bytes
+```
+
+## Snapshot Operations
+
+### Create Snapshot
+
+```typescript
+const snapshotResponse = await shareClient.createSnapshot();
+console.log("Snapshot:", snapshotResponse.snapshot);
+```
+
+### Access Snapshot
+
+```typescript
+const snapshotShareClient = shareClient.withSnapshot(snapshotResponse.snapshot!);
+const snapshotFileClient = snapshotShareClient.rootDirectoryClient.getFileClient("file.txt");
+const content = await snapshotFileClient.downloadToBuffer();
+```
+
+### Delete Snapshot
+
+```typescript
+await shareClient.delete({ deleteSnapshots: "include" });
+```
+
+## SAS Token Generation (Node.js only)
+
+### Generate File SAS
+
+```typescript
+import {
+  generateFileSASQueryParameters,
+  FileSASPermissions,
+  StorageSharedKeyCredential,
+} from "@azure/storage-file-share";
+
+const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+
+const sasToken = generateFileSASQueryParameters(
+  {
+    shareName: "my-share",
+    filePath: "my-directory/my-file.txt",
+    permissions: FileSASPermissions.parse("r"), // read only
+    expiresOn: new Date(Date.now() + 3600 * 1000), // 1 hour
+  },
+  sharedKeyCredential
+).toString();
+
+const sasUrl = `https://${accountName}.file.core.windows.net/my-share/my-directory/my-file.txt?${sasToken}`;
+```
+
+### Generate Share SAS
+
+```typescript
+import { ShareSASPermissions, generateFileSASQueryParameters } from "@azure/storage-file-share";
+
+const sasToken = generateFileSASQueryParameters(
+  {
+    shareName: "my-share",
+    permissions: ShareSASPermissions.parse("rcwdl"), // read, create, write, delete, list
+    expiresOn: new Date(Date.now() + 24 * 3600 * 1000), // 24 hours
+  },
+  sharedKeyCredential
+).toString();
+```
+
+## Error Handling
+
+```typescript
+import { RestError } from "@azure/storage-file-share";
+
+try {
+  await shareClient.create();
+} catch (error) {
+  if (error instanceof RestError) {
+    switch (error.statusCode) {
+      case 404:
+        console.log("Share not found");
+        break;
+      case 409:
+        console.log("Share already exists");
+        break;
+      case 403:
+        console.log("Access denied");
+        break;
+      default:
+        console.error(`Storage error ${error.statusCode}: ${error.message}`);
+    }
+  }
+  throw error;
+}
+```
+
+## TypeScript Types Reference
+
+```typescript
+import {
+  // Clients
+  ShareServiceClient,
+  ShareClient,
+  ShareDirectoryClient,
+  ShareFileClient,
+
+  // Authentication
+  StorageSharedKeyCredential,
+  AnonymousCredential,
+
+  // SAS
+  FileSASPermissions,
+  ShareSASPermissions,
+  AccountSASPermissions,
+  AccountSASServices,
+  AccountSASResourceTypes,
+  generateFileSASQueryParameters,
+  generateAccountSASQueryParameters,
+
+  // Options & Responses
+  ShareCreateResponse,
+  FileDownloadResponseModel,
+  DirectoryItem,
+  FileItem,
+  ShareProperties,
+  FileProperties,
+
+  // Errors
+  RestError,
+} from "@azure/storage-file-share";
+```
+
+## Best Practices
+
+1. **Use connection strings for simplicity** — Easiest setup for development
+2. **Use DefaultAzureCredential for production** — Enable managed identity in Azure
+3. **Set quotas on shares** — Prevent unexpected storage costs
+4. **Use streaming for large files** — `uploadStream`/`downloadToFile` for files > 256MB
+5. **Use ranges for partial updates** — More efficient than full file replacement
+6. **Create snapshots before major changes** — Point-in-time recovery
+7. **Handle errors gracefully** — Check `RestError.statusCode` for specific handling
+8. **Use `*IfExists` methods** — For idempotent operations
+
+## Platform Differences
+
+| Feature | Node.js | Browser |
+|---------|---------|---------|
+| `StorageSharedKeyCredential` | ✅ | ❌ |
+| `uploadFile()` | ✅ | ❌ |
+| `uploadStream()` | ✅ | ❌ |
+| `downloadToFile()` | ✅ | ❌ |
+| `downloadToBuffer()` | ✅ | ❌ |
+| SAS generation | ✅ | ❌ |
+| DefaultAzureCredential | ✅ | ❌ |
+| Anonymous/SAS access | ✅ | ✅ |

--- a/skills/typescript/data/queue/SKILL.md
+++ b/skills/typescript/data/queue/SKILL.md
@@ -1,0 +1,523 @@
+---
+name: azure-storage-queue-typescript
+description: |
+  Azure Queue Storage JavaScript/TypeScript SDK (@azure/storage-queue) for message queue operations. Use for sending, receiving, peeking, and deleting messages in queues. Supports visibility timeout, message encoding, and batch operations. Triggers: "queue storage", "@azure/storage-queue", "QueueServiceClient", "QueueClient", "send message", "receive message", "dequeue", "visibility timeout".
+---
+
+# @azure/storage-queue (TypeScript/JavaScript)
+
+SDK for Azure Queue Storage operations — send, receive, peek, and manage messages in queues.
+
+## Installation
+
+```bash
+npm install @azure/storage-queue @azure/identity
+```
+
+**Current Version**: 12.x  
+**Node.js**: >= 18.0.0
+
+## Environment Variables
+
+```bash
+AZURE_STORAGE_ACCOUNT_NAME=<account-name>
+AZURE_STORAGE_ACCOUNT_KEY=<account-key>
+# OR connection string
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
+```
+
+## Authentication
+
+### DefaultAzureCredential (Recommended)
+
+```typescript
+import { QueueServiceClient } from "@azure/storage-queue";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const client = new QueueServiceClient(
+  `https://${accountName}.queue.core.windows.net`,
+  new DefaultAzureCredential()
+);
+```
+
+### Connection String
+
+```typescript
+import { QueueServiceClient } from "@azure/storage-queue";
+
+const client = QueueServiceClient.fromConnectionString(
+  process.env.AZURE_STORAGE_CONNECTION_STRING!
+);
+```
+
+### StorageSharedKeyCredential (Node.js only)
+
+```typescript
+import { QueueServiceClient, StorageSharedKeyCredential } from "@azure/storage-queue";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const accountKey = process.env.AZURE_STORAGE_ACCOUNT_KEY!;
+
+const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+const client = new QueueServiceClient(
+  `https://${accountName}.queue.core.windows.net`,
+  sharedKeyCredential
+);
+```
+
+### SAS Token
+
+```typescript
+import { QueueServiceClient } from "@azure/storage-queue";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME!;
+const sasToken = process.env.AZURE_STORAGE_SAS_TOKEN!;
+
+const client = new QueueServiceClient(
+  `https://${accountName}.queue.core.windows.net${sasToken}`
+);
+```
+
+## Client Hierarchy
+
+```
+QueueServiceClient (account level)
+└── QueueClient (queue level)
+    └── Messages (send, receive, peek, delete)
+```
+
+## Queue Operations
+
+### Create Queue
+
+```typescript
+const queueClient = client.getQueueClient("my-queue");
+await queueClient.create();
+
+// Or create if not exists
+await queueClient.createIfNotExists();
+```
+
+### List Queues
+
+```typescript
+for await (const queue of client.listQueues()) {
+  console.log(queue.name);
+}
+
+// With prefix filter
+for await (const queue of client.listQueues({ prefix: "task-" })) {
+  console.log(queue.name);
+}
+```
+
+### Delete Queue
+
+```typescript
+await queueClient.delete();
+
+// Or delete if exists
+await queueClient.deleteIfExists();
+```
+
+### Get Queue Properties
+
+```typescript
+const properties = await queueClient.getProperties();
+console.log("Approximate message count:", properties.approximateMessagesCount);
+console.log("Metadata:", properties.metadata);
+```
+
+### Set Queue Metadata
+
+```typescript
+await queueClient.setMetadata({
+  department: "engineering",
+  priority: "high",
+});
+```
+
+## Message Operations
+
+### Send Message
+
+```typescript
+const queueClient = client.getQueueClient("my-queue");
+
+// Simple message
+await queueClient.sendMessage("Hello, World!");
+
+// With options
+await queueClient.sendMessage("Delayed message", {
+  visibilityTimeout: 60, // Hidden for 60 seconds
+  messageTimeToLive: 3600, // Expires in 1 hour
+});
+
+// JSON message (must be string)
+const task = { type: "process", data: { id: 123 } };
+await queueClient.sendMessage(JSON.stringify(task));
+```
+
+### Receive Messages
+
+```typescript
+// Receive up to 32 messages (default: 1)
+const response = await queueClient.receiveMessages({
+  numberOfMessages: 10,
+  visibilityTimeout: 30, // 30 seconds to process
+});
+
+for (const message of response.receivedMessageItems) {
+  console.log("Message ID:", message.messageId);
+  console.log("Content:", message.messageText);
+  console.log("Dequeue Count:", message.dequeueCount);
+  console.log("Pop Receipt:", message.popReceipt);
+  
+  // Process the message...
+  
+  // Delete after processing
+  await queueClient.deleteMessage(message.messageId, message.popReceipt);
+}
+```
+
+### Peek Messages
+
+Peek without removing from queue (no visibility timeout).
+
+```typescript
+const response = await queueClient.peekMessages({
+  numberOfMessages: 5,
+});
+
+for (const message of response.peekedMessageItems) {
+  console.log("Message ID:", message.messageId);
+  console.log("Content:", message.messageText);
+  // Note: No popReceipt - cannot delete peeked messages
+}
+```
+
+### Update Message
+
+Extend visibility timeout or update content.
+
+```typescript
+// Receive a message
+const response = await queueClient.receiveMessages();
+const message = response.receivedMessageItems[0];
+
+if (message) {
+  // Update content and extend visibility
+  const updateResponse = await queueClient.updateMessage(
+    message.messageId,
+    message.popReceipt,
+    "Updated content",
+    60 // New visibility timeout in seconds
+  );
+  
+  // Use new popReceipt for subsequent operations
+  console.log("New pop receipt:", updateResponse.popReceipt);
+}
+```
+
+### Delete Message
+
+```typescript
+// After receiving
+const response = await queueClient.receiveMessages();
+const message = response.receivedMessageItems[0];
+
+if (message) {
+  await queueClient.deleteMessage(message.messageId, message.popReceipt);
+}
+```
+
+### Clear All Messages
+
+```typescript
+await queueClient.clearMessages();
+```
+
+## Message Processing Patterns
+
+### Basic Worker Pattern
+
+```typescript
+async function processQueue(queueClient: QueueClient): Promise<void> {
+  while (true) {
+    const response = await queueClient.receiveMessages({
+      numberOfMessages: 10,
+      visibilityTimeout: 30,
+    });
+
+    if (response.receivedMessageItems.length === 0) {
+      // No messages, wait before polling again
+      await sleep(5000);
+      continue;
+    }
+
+    for (const message of response.receivedMessageItems) {
+      try {
+        await processMessage(message.messageText);
+        await queueClient.deleteMessage(message.messageId, message.popReceipt);
+      } catch (error) {
+        console.error(`Failed to process message ${message.messageId}:`, error);
+        // Message will become visible again after timeout
+      }
+    }
+  }
+}
+
+async function processMessage(content: string): Promise<void> {
+  const task = JSON.parse(content);
+  // Process task...
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+```
+
+### Poison Message Handling
+
+```typescript
+const MAX_DEQUEUE_COUNT = 5;
+
+async function processWithPoisonHandling(
+  queueClient: QueueClient,
+  poisonQueueClient: QueueClient
+): Promise<void> {
+  const response = await queueClient.receiveMessages({
+    numberOfMessages: 10,
+    visibilityTimeout: 30,
+  });
+
+  for (const message of response.receivedMessageItems) {
+    if (message.dequeueCount > MAX_DEQUEUE_COUNT) {
+      // Move to poison queue
+      await poisonQueueClient.sendMessage(message.messageText);
+      await queueClient.deleteMessage(message.messageId, message.popReceipt);
+      console.log(`Moved message ${message.messageId} to poison queue`);
+      continue;
+    }
+
+    try {
+      await processMessage(message.messageText);
+      await queueClient.deleteMessage(message.messageId, message.popReceipt);
+    } catch (error) {
+      console.error(`Processing failed (attempt ${message.dequeueCount}):`, error);
+    }
+  }
+}
+```
+
+### Batch Processing with Visibility Extension
+
+```typescript
+async function processBatchWithExtension(queueClient: QueueClient): Promise<void> {
+  const response = await queueClient.receiveMessages({
+    numberOfMessages: 1,
+    visibilityTimeout: 60,
+  });
+
+  const message = response.receivedMessageItems[0];
+  if (!message) return;
+
+  let popReceipt = message.popReceipt;
+
+  // Start visibility extension timer
+  const extensionInterval = setInterval(async () => {
+    try {
+      const updateResponse = await queueClient.updateMessage(
+        message.messageId,
+        popReceipt,
+        message.messageText,
+        60 // Extend by another 60 seconds
+      );
+      popReceipt = updateResponse.popReceipt;
+    } catch (error) {
+      console.error("Failed to extend visibility:", error);
+    }
+  }, 45000); // Extend every 45 seconds
+
+  try {
+    await longRunningProcess(message.messageText);
+    await queueClient.deleteMessage(message.messageId, popReceipt);
+  } finally {
+    clearInterval(extensionInterval);
+  }
+}
+```
+
+## Message Encoding
+
+By default, messages are Base64 encoded. You can customize this:
+
+```typescript
+import { QueueClient } from "@azure/storage-queue";
+
+// Custom encoder/decoder for plain text
+const queueClient = new QueueClient(
+  `https://${accountName}.queue.core.windows.net/my-queue`,
+  credential,
+  {
+    messageEncoding: "text", // "base64" (default) or "text"
+  }
+);
+
+// Or with custom encoder
+const customQueueClient = new QueueClient(
+  `https://${accountName}.queue.core.windows.net/my-queue`,
+  credential,
+  {
+    messageEncoding: {
+      encode: (message: string) => Buffer.from(message).toString("base64"),
+      decode: (message: string) => Buffer.from(message, "base64").toString(),
+    },
+  }
+);
+```
+
+## SAS Token Generation (Node.js only)
+
+### Generate Queue SAS
+
+```typescript
+import {
+  QueueSASPermissions,
+  generateQueueSASQueryParameters,
+  StorageSharedKeyCredential,
+} from "@azure/storage-queue";
+
+const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
+
+const sasToken = generateQueueSASQueryParameters(
+  {
+    queueName: "my-queue",
+    permissions: QueueSASPermissions.parse("raup"), // read, add, update, process
+    startsOn: new Date(),
+    expiresOn: new Date(Date.now() + 3600 * 1000), // 1 hour
+  },
+  sharedKeyCredential
+).toString();
+
+const sasUrl = `https://${accountName}.queue.core.windows.net/my-queue?${sasToken}`;
+```
+
+### Generate Account SAS
+
+```typescript
+import {
+  AccountSASPermissions,
+  AccountSASResourceTypes,
+  AccountSASServices,
+  generateAccountSASQueryParameters,
+} from "@azure/storage-queue";
+
+const sasToken = generateAccountSASQueryParameters(
+  {
+    services: AccountSASServices.parse("q").toString(), // queue
+    resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
+    permissions: AccountSASPermissions.parse("rwdlacupi"),
+    expiresOn: new Date(Date.now() + 24 * 3600 * 1000),
+  },
+  sharedKeyCredential
+).toString();
+```
+
+## Error Handling
+
+```typescript
+import { RestError } from "@azure/storage-queue";
+
+try {
+  await queueClient.sendMessage("test");
+} catch (error) {
+  if (error instanceof RestError) {
+    switch (error.statusCode) {
+      case 404:
+        console.log("Queue not found");
+        break;
+      case 400:
+        console.log("Bad request - message too large or invalid");
+        break;
+      case 403:
+        console.log("Access denied");
+        break;
+      case 409:
+        console.log("Queue already exists or being deleted");
+        break;
+      default:
+        console.error(`Storage error ${error.statusCode}: ${error.message}`);
+    }
+  }
+  throw error;
+}
+```
+
+## TypeScript Types Reference
+
+```typescript
+import {
+  // Clients
+  QueueServiceClient,
+  QueueClient,
+
+  // Authentication
+  StorageSharedKeyCredential,
+  AnonymousCredential,
+
+  // SAS
+  QueueSASPermissions,
+  AccountSASPermissions,
+  AccountSASServices,
+  AccountSASResourceTypes,
+  generateQueueSASQueryParameters,
+  generateAccountSASQueryParameters,
+
+  // Messages
+  DequeuedMessageItem,
+  PeekedMessageItem,
+  QueueSendMessageResponse,
+  QueueReceiveMessageResponse,
+  QueueUpdateMessageResponse,
+
+  // Queue
+  QueueItem,
+  QueueGetPropertiesResponse,
+
+  // Errors
+  RestError,
+} from "@azure/storage-queue";
+```
+
+## Message Limits
+
+| Limit | Value |
+|-------|-------|
+| Max message size | 64 KB |
+| Max visibility timeout | 7 days |
+| Max time-to-live | 7 days (or -1 for infinite) |
+| Max messages per receive | 32 |
+| Default visibility timeout | 30 seconds |
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** — Prefer AAD over connection strings/keys
+2. **Always delete after processing** — Prevent duplicate processing
+3. **Handle poison messages** — Move failed messages to a dead-letter queue
+4. **Use appropriate visibility timeout** — Set based on expected processing time
+5. **Extend visibility for long tasks** — Update message to prevent timeout
+6. **Use JSON for structured data** — Serialize objects to JSON strings
+7. **Check dequeueCount** — Detect repeatedly failing messages
+8. **Use batch receive** — Receive multiple messages for efficiency
+
+## Platform Differences
+
+| Feature | Node.js | Browser |
+|---------|---------|---------|
+| `StorageSharedKeyCredential` | ✅ | ❌ |
+| SAS generation | ✅ | ❌ |
+| DefaultAzureCredential | ✅ | ❌ |
+| Anonymous/SAS access | ✅ | ✅ |
+| All message operations | ✅ | ✅ |

--- a/skills/typescript/foundry/agents/SKILL.md
+++ b/skills/typescript/foundry/agents/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: azure-ai-agents-typescript
+description: Build AI agents using Azure AI Agents SDK for JavaScript (@azure/ai-agents). Use when creating agents with tools (Code Interpreter, File Search, Function Calling), managing threads and messages, or implementing streaming responses.
+---
+
+# Azure AI Agents SDK for TypeScript
+
+Build AI agents hosted on Azure AI Foundry with tools, threads, and streaming.
+
+## Installation
+
+```bash
+npm install @azure/ai-agents @azure/identity
+```
+
+## Environment Variables
+
+```bash
+AZURE_AI_AGENTS_ENDPOINT=https://<resource>.services.ai.azure.com
+```
+
+## Authentication
+
+```typescript
+import { AgentsClient } from "@azure/ai-agents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AgentsClient(
+  process.env.AZURE_AI_AGENTS_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+```
+
+## Core Workflow
+
+### Create Agent
+
+```typescript
+const agent = await client.createAgent("gpt-4o", {
+  name: "my-assistant",
+  instructions: "You are a helpful assistant.",
+  tools: [{ type: "code_interpreter" }]
+});
+```
+
+### Create Thread and Run
+
+```typescript
+// Create thread
+const thread = await client.createThread();
+
+// Add message
+await client.createMessage(thread.id, {
+  role: "user",
+  content: "What is 2 + 2?"
+});
+
+// Run agent
+const run = await client.createRun(thread.id, agent.id);
+
+// Wait for completion
+let status = run.status;
+while (status === "queued" || status === "in_progress") {
+  await new Promise(r => setTimeout(r, 1000));
+  const updatedRun = await client.getRun(thread.id, run.id);
+  status = updatedRun.status;
+}
+
+// Get messages
+const messages = await client.listMessages(thread.id);
+for (const msg of messages.data) {
+  if (msg.role === "assistant") {
+    console.log(msg.content[0].text.value);
+  }
+}
+```
+
+### One-Shot: Create and Run Thread
+
+```typescript
+const run = await client.createAndRunThread({
+  assistantId: agent.id,
+  thread: {
+    messages: [{ role: "user", content: "Hello!" }]
+  }
+});
+```
+
+## Agent Tools
+
+### Code Interpreter
+
+```typescript
+const agent = await client.createAgent("gpt-4o", {
+  name: "code-agent",
+  instructions: "You can execute Python code.",
+  tools: [{ type: "code_interpreter" }]
+});
+```
+
+### File Search with Vector Store
+
+```typescript
+// Create vector store
+const vectorStore = await client.createVectorStore({ name: "my-docs" });
+
+// Upload file
+const file = await client.uploadFileAndPoll(
+  "./document.pdf",
+  "assistants"
+);
+
+// Add file to vector store
+await client.createVectorStoreFile(vectorStore.id, file.id);
+
+// Create agent with file search
+const agent = await client.createAgent("gpt-4o", {
+  name: "search-agent",
+  instructions: "Search documents to answer questions.",
+  tools: [{ type: "file_search" }],
+  tool_resources: {
+    file_search: { vector_store_ids: [vectorStore.id] }
+  }
+});
+```
+
+### Function Calling
+
+```typescript
+const weatherTool = {
+  type: "function" as const,
+  function: {
+    name: "get_weather",
+    description: "Get current weather for a location",
+    parameters: {
+      type: "object",
+      properties: {
+        location: { type: "string", description: "City name" }
+      },
+      required: ["location"]
+    }
+  }
+};
+
+const agent = await client.createAgent("gpt-4o", {
+  name: "weather-agent",
+  tools: [weatherTool]
+});
+
+// Handle tool calls in run
+const run = await client.createRun(thread.id, agent.id);
+
+if (run.status === "requires_action") {
+  const toolCalls = run.required_action.submit_tool_outputs.tool_calls;
+  
+  const toolOutputs = toolCalls.map(tc => ({
+    tool_call_id: tc.id,
+    output: JSON.stringify({ temperature: 72, condition: "sunny" })
+  }));
+  
+  await client.submitToolOutputs(thread.id, run.id, toolOutputs);
+}
+```
+
+## Streaming Responses
+
+```typescript
+const stream = await client.createRunStream(thread.id, agent.id);
+
+for await (const event of stream) {
+  if (event.event === "thread.message.delta") {
+    const delta = event.data.delta;
+    if (delta.content?.[0]?.type === "text") {
+      process.stdout.write(delta.content[0].text.value);
+    }
+  }
+  
+  if (event.event === "thread.run.completed") {
+    console.log("\n[Done]");
+  }
+}
+```
+
+## Cleanup
+
+```typescript
+// Delete agent when done
+await client.deleteAgent(agent.id);
+
+// Delete thread
+await client.deleteThread(thread.id);
+
+// Delete vector store
+await client.deleteVectorStore(vectorStore.id);
+```
+
+## Key Types
+
+```typescript
+import {
+  AgentsClient,
+  Agent,
+  AgentThread,
+  ThreadMessage,
+  ThreadRun,
+  ToolDefinition,
+  CodeInterpreterToolDefinition,
+  FileSearchToolDefinition,
+  FunctionToolDefinition,
+  VectorStore
+} from "@azure/ai-agents";
+```
+
+## Best Practices
+
+1. **Always clean up** - Delete agents, threads, and vector stores when done
+2. **Poll with backoff** - Use exponential backoff when polling run status
+3. **Handle tool calls** - Check for `requires_action` status and submit tool outputs
+4. **Use streaming** - For real-time responses, use `createRunStream`
+5. **Scope vector stores** - Create dedicated vector stores per use case

--- a/skills/typescript/foundry/agents/references/streaming.md
+++ b/skills/typescript/foundry/agents/references/streaming.md
@@ -1,0 +1,462 @@
+# @azure/ai-agents - Streaming Response Patterns
+
+Reference documentation for streaming responses in the Azure AI Agents TypeScript SDK.
+
+**Source**: [Azure SDK for JS - ai-agents](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-agents)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/ai-agents @azure/identity
+```
+
+---
+
+## Core Streaming Types
+
+```typescript
+import {
+  AgentsClient,
+  // Stream event enums
+  RunStreamEvent,
+  MessageStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  // Data types
+  ThreadRun,
+  MessageDeltaChunk,
+  MessageDeltaTextContent,
+  RunStepDeltaChunk,
+  AgentThread,
+  ThreadMessage,
+  RunStep,
+} from "@azure/ai-agents";
+```
+
+---
+
+## Basic Streaming Example
+
+```typescript
+import {
+  AgentsClient,
+  RunStreamEvent,
+  MessageStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  type ThreadRun,
+  type MessageDeltaChunk,
+  type MessageDeltaTextContent,
+} from "@azure/ai-agents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AgentsClient(
+  process.env["PROJECT_ENDPOINT"]!,
+  new DefaultAzureCredential()
+);
+
+// Create agent and thread
+const agent = await client.createAgent("gpt-4o", {
+  name: "streaming-agent",
+  instructions: "You are a helpful assistant.",
+});
+const thread = await client.threads.create();
+await client.messages.create(thread.id, "user", "Tell me a joke");
+
+// Start streaming run
+const stream = await client.runs.create(thread.id, agent.id).stream();
+
+// Process stream events
+for await (const event of stream) {
+  switch (event.event) {
+    case RunStreamEvent.ThreadRunCreated:
+      console.log(`Run started: ${(event.data as ThreadRun).status}`);
+      break;
+
+    case MessageStreamEvent.ThreadMessageDelta:
+      const delta = event.data as MessageDeltaChunk;
+      delta.delta.content?.forEach((part) => {
+        if (part.type === "text") {
+          const text = (part as MessageDeltaTextContent).text?.value || "";
+          process.stdout.write(text);
+        }
+      });
+      break;
+
+    case RunStreamEvent.ThreadRunCompleted:
+      console.log("\nRun completed");
+      break;
+
+    case ErrorEvent.Error:
+      console.error("Error:", event.data);
+      break;
+
+    case DoneEvent.Done:
+      console.log("Stream finished");
+      break;
+  }
+}
+```
+
+---
+
+## Stream Event Types
+
+### Run Events (`RunStreamEvent`)
+
+| Event | Description | Data Type |
+|-------|-------------|-----------|
+| `ThreadRunCreated` | Run was created | `ThreadRun` |
+| `ThreadRunQueued` | Run is queued | `ThreadRun` |
+| `ThreadRunInProgress` | Run started processing | `ThreadRun` |
+| `ThreadRunRequiresAction` | Run needs tool outputs | `ThreadRun` |
+| `ThreadRunCompleted` | Run finished successfully | `ThreadRun` |
+| `ThreadRunIncomplete` | Run ended incomplete | `ThreadRun` |
+| `ThreadRunFailed` | Run failed | `ThreadRun` |
+| `ThreadRunCancelling` | Run is being cancelled | `ThreadRun` |
+| `ThreadRunCancelled` | Run was cancelled | `ThreadRun` |
+| `ThreadRunExpired` | Run expired | `ThreadRun` |
+
+### Message Events (`MessageStreamEvent`)
+
+| Event | Description | Data Type |
+|-------|-------------|-----------|
+| `ThreadMessageCreated` | Message was created | `ThreadMessage` |
+| `ThreadMessageInProgress` | Message is being generated | `ThreadMessage` |
+| `ThreadMessageDelta` | Message content chunk | `MessageDeltaChunk` |
+| `ThreadMessageCompleted` | Message finished | `ThreadMessage` |
+| `ThreadMessageIncomplete` | Message ended incomplete | `ThreadMessage` |
+
+### Run Step Events (`RunStepStreamEvent`)
+
+| Event | Description | Data Type |
+|-------|-------------|-----------|
+| `ThreadRunStepCreated` | Step was created | `RunStep` |
+| `ThreadRunStepInProgress` | Step started processing | `RunStep` |
+| `ThreadRunStepDelta` | Step progress chunk | `RunStepDeltaChunk` |
+| `ThreadRunStepCompleted` | Step finished | `RunStep` |
+| `ThreadRunStepFailed` | Step failed | `RunStep` |
+| `ThreadRunStepCancelled` | Step was cancelled | `RunStep` |
+| `ThreadRunStepExpired` | Step expired | `RunStep` |
+
+### Other Events
+
+| Event | Description | Data Type |
+|-------|-------------|-----------|
+| `ErrorEvent.Error` | An error occurred | `string` |
+| `DoneEvent.Done` | Stream completed | `string` |
+
+---
+
+## Processing Delta Events
+
+```typescript
+import {
+  MessageDeltaChunk,
+  MessageDeltaTextContent,
+  MessageDeltaImageFileContent,
+} from "@azure/ai-agents";
+
+for await (const event of stream) {
+  if (event.event === MessageStreamEvent.ThreadMessageDelta) {
+    const delta = event.data as MessageDeltaChunk;
+
+    // Access message metadata
+    console.log(`Message ID: ${delta.id}`);
+
+    // Process content parts
+    delta.delta.content?.forEach((part) => {
+      switch (part.type) {
+        case "text":
+          const textPart = part as MessageDeltaTextContent;
+          const text = textPart.text?.value || "";
+          // Handle annotations (citations, file paths)
+          textPart.text?.annotations?.forEach((annotation) => {
+            console.log("Annotation:", annotation);
+          });
+          process.stdout.write(text);
+          break;
+
+        case "image_file":
+          const imagePart = part as MessageDeltaImageFileContent;
+          console.log("Image file:", imagePart.imageFile?.fileId);
+          break;
+      }
+    });
+  }
+}
+```
+
+---
+
+## Streaming with Function Tools
+
+Handle tool calls during streaming:
+
+```typescript
+import {
+  RunStreamEvent,
+  MessageStreamEvent,
+  ToolOutput,
+  isOutputOfType,
+  SubmitToolOutputsAction,
+} from "@azure/ai-agents";
+
+const stream = await client.runs.create(thread.id, agent.id).stream();
+
+for await (const event of stream) {
+  switch (event.event) {
+    case RunStreamEvent.ThreadRunRequiresAction:
+      const run = event.data as ThreadRun;
+      
+      if (run.requiredAction && 
+          isOutputOfType<SubmitToolOutputsAction>(run.requiredAction, "submit_tool_outputs")) {
+        
+        const toolCalls = run.requiredAction.submitToolOutputs.toolCalls;
+        const toolOutputs: ToolOutput[] = [];
+
+        for (const toolCall of toolCalls) {
+          if (toolCall.type === "function") {
+            const args = JSON.parse(toolCall.function.arguments);
+            const result = await executeFunction(toolCall.function.name, args);
+            toolOutputs.push({
+              toolCallId: toolCall.id,
+              output: JSON.stringify(result),
+            });
+          }
+        }
+
+        // Submit outputs and continue streaming
+        const newStream = await client.runs
+          .submitToolOutputs(thread.id, run.id, toolOutputs)
+          .stream();
+        
+        // Process the new stream
+        for await (const newEvent of newStream) {
+          // Handle events from continued stream
+        }
+      }
+      break;
+
+    case MessageStreamEvent.ThreadMessageDelta:
+      // Handle message deltas
+      break;
+  }
+}
+```
+
+---
+
+## Streaming with Code Interpreter
+
+```typescript
+import { RunStepStreamEvent, RunStepDeltaChunk } from "@azure/ai-agents";
+
+for await (const event of stream) {
+  switch (event.event) {
+    case RunStepStreamEvent.ThreadRunStepDelta:
+      const stepDelta = event.data as RunStepDeltaChunk;
+      
+      // Check for code interpreter output
+      if (stepDelta.delta.stepDetails?.type === "tool_calls") {
+        const toolCalls = stepDelta.delta.stepDetails.toolCalls;
+        toolCalls?.forEach((toolCall) => {
+          if (toolCall.type === "code_interpreter") {
+            // Stream code input
+            if (toolCall.codeInterpreter?.input) {
+              console.log("Code:", toolCall.codeInterpreter.input);
+            }
+            // Stream code outputs
+            toolCall.codeInterpreter?.outputs?.forEach((output) => {
+              if (output.type === "logs") {
+                console.log("Output:", output.logs);
+              } else if (output.type === "image") {
+                console.log("Image generated:", output.image?.fileId);
+              }
+            });
+          }
+        });
+      }
+      break;
+  }
+}
+```
+
+---
+
+## Error Handling in Streams
+
+```typescript
+try {
+  const stream = await client.runs.create(thread.id, agent.id).stream();
+
+  for await (const event of stream) {
+    switch (event.event) {
+      case ErrorEvent.Error:
+        console.error("Stream error:", event.data);
+        break;
+
+      case RunStreamEvent.ThreadRunFailed:
+        const failedRun = event.data as ThreadRun;
+        console.error("Run failed:", failedRun.lastError);
+        break;
+
+      case RunStreamEvent.ThreadRunExpired:
+        console.error("Run expired");
+        break;
+
+      // Handle other events...
+    }
+  }
+} catch (error) {
+  // Handle network errors, authentication errors, etc.
+  console.error("Stream failed:", error);
+}
+```
+
+---
+
+## Complete Streaming Example
+
+```typescript
+import {
+  AgentsClient,
+  RunStreamEvent,
+  MessageStreamEvent,
+  RunStepStreamEvent,
+  ErrorEvent,
+  DoneEvent,
+  type ThreadRun,
+  type ThreadMessage,
+  type MessageDeltaChunk,
+  type MessageDeltaTextContent,
+  type RunStep,
+  type RunStepDeltaChunk,
+} from "@azure/ai-agents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+async function runWithStreaming() {
+  const client = new AgentsClient(
+    process.env["PROJECT_ENDPOINT"]!,
+    new DefaultAzureCredential()
+  );
+
+  // Create agent with tools
+  const agent = await client.createAgent("gpt-4o", {
+    name: "streaming-demo",
+    instructions: "You are a helpful assistant.",
+  });
+
+  const thread = await client.threads.create();
+  await client.messages.create(thread.id, "user", "Tell me about TypeScript");
+
+  const stream = await client.runs.create(thread.id, agent.id).stream();
+  let fullResponse = "";
+
+  for await (const event of stream) {
+    switch (event.event) {
+      // Run lifecycle events
+      case RunStreamEvent.ThreadRunCreated:
+        console.log("[Run Created]");
+        break;
+
+      case RunStreamEvent.ThreadRunInProgress:
+        console.log("[Run In Progress]");
+        break;
+
+      case RunStreamEvent.ThreadRunCompleted:
+        console.log("\n[Run Completed]");
+        break;
+
+      case RunStreamEvent.ThreadRunFailed:
+        const failedRun = event.data as ThreadRun;
+        console.error("[Run Failed]", failedRun.lastError);
+        break;
+
+      // Message events
+      case MessageStreamEvent.ThreadMessageCreated:
+        console.log("[Message Created]");
+        break;
+
+      case MessageStreamEvent.ThreadMessageDelta:
+        const delta = event.data as MessageDeltaChunk;
+        delta.delta.content?.forEach((part) => {
+          if (part.type === "text") {
+            const text = (part as MessageDeltaTextContent).text?.value || "";
+            fullResponse += text;
+            process.stdout.write(text);
+          }
+        });
+        break;
+
+      case MessageStreamEvent.ThreadMessageCompleted:
+        const message = event.data as ThreadMessage;
+        console.log(`\n[Message Completed: ${message.id}]`);
+        break;
+
+      // Run step events
+      case RunStepStreamEvent.ThreadRunStepCreated:
+        const step = event.data as RunStep;
+        console.log(`[Step Created: ${step.type}]`);
+        break;
+
+      case RunStepStreamEvent.ThreadRunStepCompleted:
+        console.log("[Step Completed]");
+        break;
+
+      // Terminal events
+      case ErrorEvent.Error:
+        console.error("[Error]", event.data);
+        break;
+
+      case DoneEvent.Done:
+        console.log("[Stream Done]");
+        break;
+    }
+  }
+
+  // Cleanup
+  await client.deleteAgent(agent.id);
+
+  return fullResponse;
+}
+
+runWithStreaming().catch(console.error);
+```
+
+---
+
+## Non-Streaming Alternative
+
+For simpler use cases, use `createAndPoll`:
+
+```typescript
+// Polling approach (waits for completion)
+const run = await client.runs.createAndPoll(thread.id, agent.id);
+
+if (run.status === "completed") {
+  const messages = await client.messages.list(thread.id);
+  const lastMessage = messages.data[0];
+  console.log(lastMessage.content);
+}
+```
+
+---
+
+## Best Practices
+
+1. **Always handle errors** - Check for `ErrorEvent.Error` and `ThreadRunFailed`
+2. **Process deltas incrementally** - Don't buffer entire response unless needed
+3. **Handle tool calls properly** - Submit outputs and continue the stream
+4. **Clean up resources** - Delete agents and threads when done
+5. **Use timeouts** - Implement client-side timeouts for long-running streams
+6. **Log events for debugging** - Event types help diagnose issues
+
+---
+
+## See Also
+
+- [Tool Integration Patterns](./tools.md) - Using tools with streaming
+- [Official Samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-agents/samples)

--- a/skills/typescript/foundry/agents/references/tools.md
+++ b/skills/typescript/foundry/agents/references/tools.md
@@ -1,0 +1,386 @@
+# @azure/ai-agents - Tool Integration Patterns
+
+Reference documentation for tool integration in the Azure AI Agents TypeScript SDK.
+
+**Source**: [Azure SDK for JS - ai-agents](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-agents)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/ai-agents @azure/identity
+```
+
+---
+
+## Client Setup
+
+```typescript
+import { AgentsClient, ToolUtility, ToolSet } from "@azure/ai-agents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AgentsClient(
+  process.env["PROJECT_ENDPOINT"]!,
+  new DefaultAzureCredential()
+);
+```
+
+---
+
+## Function Tools
+
+Define custom functions the agent can call. You provide definitions only—implementations run in your code.
+
+```typescript
+import {
+  FunctionToolDefinition,
+  ToolUtility,
+  RequiredToolCall,
+  ToolOutput,
+  SubmitToolOutputsAction,
+  isOutputOfType,
+} from "@azure/ai-agents";
+
+// Define function tools
+const weatherTool = ToolUtility.createFunctionTool({
+  name: "getWeather",
+  description: "Gets the weather for a location.",
+  parameters: {
+    type: "object",
+    properties: {
+      location: { type: "string", description: "City and state, e.g. Seattle, WA" },
+      unit: { type: "string", enum: ["c", "f"] },
+    },
+  },
+});
+
+const cityTool = ToolUtility.createFunctionTool({
+  name: "getUserFavoriteCity",
+  description: "Gets the user's favorite city.",
+  parameters: {},
+});
+
+// Create agent with function tools
+const agent = await client.createAgent("gpt-4o", {
+  name: "weather-bot",
+  instructions: "You are a weather bot. Use provided functions to answer questions.",
+  tools: [weatherTool.definition, cityTool.definition],
+});
+
+// Handle function calls during run polling
+const run = await client.runs.createAndPoll(thread.id, agent.id, {
+  onResponse: async (response) => {
+    const run = response.parsedBody;
+    if (run.status === "requires_action" && run.requiredAction) {
+      if (isOutputOfType<SubmitToolOutputsAction>(run.requiredAction, "submit_tool_outputs")) {
+        const toolCalls = run.requiredAction.submitToolOutputs.toolCalls;
+        const toolOutputs: ToolOutput[] = toolCalls.map((call) => ({
+          toolCallId: call.id,
+          output: JSON.stringify(executeFunction(call)), // Your implementation
+        }));
+        await client.runs.submitToolOutputs(thread.id, run.id, toolOutputs);
+      }
+    }
+  },
+});
+```
+
+---
+
+## Code Interpreter Tool
+
+Execute Python code for data analysis, file processing, and visualization.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+import fs from "node:fs";
+
+// Upload file for code interpreter
+const fileStream = fs.createReadStream("./data/quarterly_results.csv");
+const file = await client.files.upload(fileStream, "assistants", {
+  fileName: "quarterly_results.csv",
+});
+
+// Create code interpreter tool with file
+const codeInterpreterTool = ToolUtility.createCodeInterpreterTool([file.id]);
+
+// Create agent with code interpreter
+const agent = await client.createAgent("gpt-4o", {
+  name: "data-analyst",
+  instructions: "You are a data analyst. Analyze uploaded files and create visualizations.",
+  tools: [codeInterpreterTool.definition],
+  toolResources: codeInterpreterTool.resources,
+});
+
+// Create message with file attachment
+const message = await client.messages.create(
+  thread.id,
+  "user",
+  "Create a bar chart of operating profit by sector from the CSV file.",
+  {
+    attachments: [
+      {
+        fileId: file.id,
+        tools: [codeInterpreterTool.definition],
+      },
+    ],
+  }
+);
+```
+
+---
+
+## File Search Tool
+
+Search through uploaded documents using vector stores.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+import fs from "node:fs";
+
+// Upload file
+const fileStream = fs.createReadStream("./data/product_docs.txt");
+const file = await client.files.upload(fileStream, "assistants", {
+  fileName: "product_docs.txt",
+});
+
+// Create vector store with file
+const vectorStore = await client.vectorStores.create({
+  fileIds: [file.id],
+  name: "product-documentation",
+});
+
+// Create file search tool
+const fileSearchTool = ToolUtility.createFileSearchTool([vectorStore.id]);
+
+// Create agent with file search
+const agent = await client.createAgent("gpt-4o", {
+  name: "doc-search-agent",
+  instructions: "You help users find information in product documentation.",
+  tools: [fileSearchTool.definition],
+  toolResources: fileSearchTool.resources,
+});
+
+// Attach file to message for search
+const message = await client.messages.create(
+  thread.id,
+  "user",
+  "What features does the Smart Eyewear product offer?",
+  {
+    attachments: [
+      {
+        fileId: file.id,
+        tools: [fileSearchTool.definition],
+      },
+    ],
+  }
+);
+```
+
+---
+
+## Bing Grounding Tool
+
+Enable web search via Bing Search API.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+
+const connectionId = process.env["AZURE_BING_CONNECTION_ID"]!;
+
+// Create Bing grounding tool
+const bingTool = ToolUtility.createBingGroundingTool([
+  {
+    connectionId: connectionId,
+    market: "en-US",      // Optional: market locale
+    count: 10,            // Optional: number of results
+    freshness: "Week",    // Optional: "Day", "Week", "Month"
+  },
+]);
+
+// Create agent with Bing search
+const agent = await client.createAgent("gpt-4o", {
+  name: "search-agent",
+  instructions: "You are a helpful agent that can search the web for current information.",
+  tools: [bingTool.definition],
+});
+```
+
+---
+
+## Azure AI Search Tool
+
+Integrate enterprise search with Azure AI Search indexes.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+
+const connectionName = process.env["AZURE_AI_SEARCH_CONNECTION_NAME"]!;
+
+// Create Azure AI Search tool
+const searchTool = ToolUtility.createAzureAISearchTool(
+  connectionName,
+  "products-index",
+  {
+    queryType: "simple",  // "simple", "semantic", "vector", "hybrid"
+    topK: 5,              // Number of results to return
+    filter: "",           // OData filter expression
+  }
+);
+
+// Create agent with Azure AI Search
+const agent = await client.createAgent("gpt-4o", {
+  name: "enterprise-search-agent",
+  instructions: "You help users find information in our product catalog.",
+  tools: [searchTool.definition],
+  toolResources: searchTool.resources,
+});
+```
+
+---
+
+## Using ToolSet for Multiple Tools
+
+Combine multiple tools using the `ToolSet` class.
+
+```typescript
+import { ToolSet } from "@azure/ai-agents";
+
+const toolSet = new ToolSet();
+
+// Add file search tool
+toolSet.addFileSearchTool([vectorStore.id]);
+
+// Add code interpreter tool
+toolSet.addCodeInterpreterTool([dataFile.id]);
+
+// Add Bing grounding tool
+toolSet.addBingGroundingTool([{ connectionId: bingConnectionId }]);
+
+// Create agent with all tools
+const agent = await client.createAgent("gpt-4o", {
+  name: "multi-tool-agent",
+  instructions: "You can search files, analyze data, and search the web.",
+  tools: toolSet.toolDefinitions,
+  toolResources: toolSet.toolResources,
+});
+```
+
+---
+
+## Tool Choice Configuration
+
+Control which tools the agent uses.
+
+```typescript
+// Let the agent decide (default)
+const run1 = await client.runs.create(thread.id, agent.id);
+
+// Force a specific tool
+const run2 = await client.runs.createAndPoll(thread.id, agent.id, {
+  toolChoice: {
+    type: "function",
+    function: { name: "getWeather" },
+  },
+});
+
+// Disable all tools for this run
+const run3 = await client.runs.createAndPoll(thread.id, agent.id, {
+  toolChoice: "none",
+});
+
+// Require at least one tool call
+const run4 = await client.runs.createAndPoll(thread.id, agent.id, {
+  toolChoice: "required",
+});
+```
+
+---
+
+## OpenAPI Tool
+
+Call REST APIs defined by OpenAPI specifications.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+import fs from "node:fs";
+
+// Load OpenAPI spec
+const openApiSpec = JSON.parse(fs.readFileSync("./weather-api.json", "utf-8"));
+
+// Create OpenAPI tool
+const openApiTool = ToolUtility.createOpenApiTool({
+  name: "getWeather",
+  spec: openApiSpec,
+  description: "Retrieve weather information for a location",
+  auth: { type: "anonymous" },
+  default_params: ["format"],
+});
+
+// Create agent with OpenAPI tool
+const agent = await client.createAgent("gpt-4o", {
+  name: "api-agent",
+  instructions: "You can fetch weather data from the weather API.",
+  tools: [openApiTool.definition],
+});
+```
+
+---
+
+## Connected Agents Tool
+
+Connect multiple agents together.
+
+```typescript
+import { ToolUtility } from "@azure/ai-agents";
+
+// Create a specialized agent
+const stockAgent = await client.createAgent("gpt-4o", {
+  name: "stock-price-agent",
+  instructions: "Your job is to get stock prices for companies.",
+});
+
+// Create connected agent tool
+const connectedAgentTool = ToolUtility.createConnectedAgentTool(
+  stockAgent.id,
+  "stock_price_bot",
+  "Gets the stock price of a company"
+);
+
+// Create main agent with connected agent
+const mainAgent = await client.createAgent("gpt-4o", {
+  name: "financial-assistant",
+  instructions: "You help with financial questions. Use the connected agent for stock prices.",
+  tools: [connectedAgentTool.definition],
+});
+```
+
+---
+
+## Cleanup
+
+```typescript
+// Delete resources when done
+await client.vectorStores.delete(vectorStore.id);
+await client.files.delete(file.id);
+await client.deleteAgent(agent.id);
+```
+
+---
+
+## Best Practices
+
+1. **Validate tool parameters** - Always validate inputs before executing function tools
+2. **Handle timeouts** - Set reasonable timeouts for tool execution
+3. **Clean up resources** - Delete files and vector stores when no longer needed
+4. **Use specific instructions** - Guide the agent on when to use each tool
+5. **Error handling** - Implement proper error handling in function tool implementations
+6. **Tool choice** - Use `toolChoice` to constrain agent behavior when needed
+
+---
+
+## See Also
+
+- [Streaming Patterns](./streaming.md) - Streaming responses with tools
+- [Official Samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-agents/samples)

--- a/skills/typescript/foundry/contentsafety/SKILL.md
+++ b/skills/typescript/foundry/contentsafety/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: azure-content-safety-typescript
+description: Analyze text and images for harmful content using Azure AI Content Safety (@azure-rest/ai-content-safety). Use when moderating user-generated content, detecting hate speech, violence, sexual content, or self-harm, or managing custom blocklists.
+---
+
+# Azure AI Content Safety REST SDK for TypeScript
+
+Analyze text and images for harmful content with customizable blocklists.
+
+## Installation
+
+```bash
+npm install @azure-rest/ai-content-safety @azure/identity @azure/core-auth
+```
+
+## Environment Variables
+
+```bash
+CONTENT_SAFETY_ENDPOINT=https://<resource>.cognitiveservices.azure.com
+CONTENT_SAFETY_KEY=<api-key>
+```
+
+## Authentication
+
+**Important**: This is a REST client. `ContentSafetyClient` is a **function**, not a class.
+
+### API Key
+
+```typescript
+import ContentSafetyClient from "@azure-rest/ai-content-safety";
+import { AzureKeyCredential } from "@azure/core-auth";
+
+const client = ContentSafetyClient(
+  process.env.CONTENT_SAFETY_ENDPOINT!,
+  new AzureKeyCredential(process.env.CONTENT_SAFETY_KEY!)
+);
+```
+
+### DefaultAzureCredential
+
+```typescript
+import ContentSafetyClient from "@azure-rest/ai-content-safety";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = ContentSafetyClient(
+  process.env.CONTENT_SAFETY_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+```
+
+## Analyze Text
+
+```typescript
+import ContentSafetyClient, { isUnexpected } from "@azure-rest/ai-content-safety";
+
+const result = await client.path("/text:analyze").post({
+  body: {
+    text: "Text content to analyze",
+    categories: ["Hate", "Sexual", "Violence", "SelfHarm"],
+    outputType: "FourSeverityLevels"  // or "EightSeverityLevels"
+  }
+});
+
+if (isUnexpected(result)) {
+  throw result.body;
+}
+
+for (const analysis of result.body.categoriesAnalysis) {
+  console.log(`${analysis.category}: severity ${analysis.severity}`);
+}
+```
+
+## Analyze Image
+
+### Base64 Content
+
+```typescript
+import { readFileSync } from "node:fs";
+
+const imageBuffer = readFileSync("./image.png");
+const base64Image = imageBuffer.toString("base64");
+
+const result = await client.path("/image:analyze").post({
+  body: {
+    image: { content: base64Image }
+  }
+});
+
+if (isUnexpected(result)) {
+  throw result.body;
+}
+
+for (const analysis of result.body.categoriesAnalysis) {
+  console.log(`${analysis.category}: severity ${analysis.severity}`);
+}
+```
+
+### Blob URL
+
+```typescript
+const result = await client.path("/image:analyze").post({
+  body: {
+    image: { blobUrl: "https://storage.blob.core.windows.net/container/image.png" }
+  }
+});
+```
+
+## Blocklist Management
+
+### Create Blocklist
+
+```typescript
+const result = await client
+  .path("/text/blocklists/{blocklistName}", "my-blocklist")
+  .patch({
+    contentType: "application/merge-patch+json",
+    body: {
+      description: "Custom blocklist for prohibited terms"
+    }
+  });
+
+if (isUnexpected(result)) {
+  throw result.body;
+}
+
+console.log(`Created: ${result.body.blocklistName}`);
+```
+
+### Add Items to Blocklist
+
+```typescript
+const result = await client
+  .path("/text/blocklists/{blocklistName}:addOrUpdateBlocklistItems", "my-blocklist")
+  .post({
+    body: {
+      blocklistItems: [
+        { text: "prohibited-term-1", description: "First blocked term" },
+        { text: "prohibited-term-2", description: "Second blocked term" }
+      ]
+    }
+  });
+
+if (isUnexpected(result)) {
+  throw result.body;
+}
+
+for (const item of result.body.blocklistItems ?? []) {
+  console.log(`Added: ${item.blocklistItemId}`);
+}
+```
+
+### Analyze with Blocklist
+
+```typescript
+const result = await client.path("/text:analyze").post({
+  body: {
+    text: "Text that might contain blocked terms",
+    blocklistNames: ["my-blocklist"],
+    haltOnBlocklistHit: false
+  }
+});
+
+if (isUnexpected(result)) {
+  throw result.body;
+}
+
+// Check blocklist matches
+if (result.body.blocklistsMatch) {
+  for (const match of result.body.blocklistsMatch) {
+    console.log(`Blocked: "${match.blocklistItemText}" from ${match.blocklistName}`);
+  }
+}
+```
+
+### List Blocklists
+
+```typescript
+const result = await client.path("/text/blocklists").get();
+
+if (isUnexpected(result)) {
+  throw result.body;
+}
+
+for (const blocklist of result.body.value ?? []) {
+  console.log(`${blocklist.blocklistName}: ${blocklist.description}`);
+}
+```
+
+### Delete Blocklist
+
+```typescript
+await client.path("/text/blocklists/{blocklistName}", "my-blocklist").delete();
+```
+
+## Harm Categories
+
+| Category | API Term | Description |
+|----------|----------|-------------|
+| Hate and Fairness | `Hate` | Discriminatory language targeting identity groups |
+| Sexual | `Sexual` | Sexual content, nudity, pornography |
+| Violence | `Violence` | Physical harm, weapons, terrorism |
+| Self-Harm | `SelfHarm` | Self-injury, suicide, eating disorders |
+
+## Severity Levels
+
+| Level | Risk | Recommended Action |
+|-------|------|-------------------|
+| 0 | Safe | Allow |
+| 2 | Low | Review or allow with warning |
+| 4 | Medium | Block or require human review |
+| 6 | High | Block immediately |
+
+**Output Types**:
+- `FourSeverityLevels` (default): Returns 0, 2, 4, 6
+- `EightSeverityLevels`: Returns 0-7
+
+## Content Moderation Helper
+
+```typescript
+import ContentSafetyClient, { 
+  isUnexpected, 
+  TextCategoriesAnalysisOutput 
+} from "@azure-rest/ai-content-safety";
+
+interface ModerationResult {
+  isAllowed: boolean;
+  flaggedCategories: string[];
+  maxSeverity: number;
+  blocklistMatches: string[];
+}
+
+async function moderateContent(
+  client: ReturnType<typeof ContentSafetyClient>,
+  text: string,
+  maxAllowedSeverity = 2,
+  blocklistNames: string[] = []
+): Promise<ModerationResult> {
+  const result = await client.path("/text:analyze").post({
+    body: { text, blocklistNames, haltOnBlocklistHit: false }
+  });
+
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  const flaggedCategories = result.body.categoriesAnalysis
+    .filter(c => (c.severity ?? 0) > maxAllowedSeverity)
+    .map(c => c.category!);
+
+  const maxSeverity = Math.max(
+    ...result.body.categoriesAnalysis.map(c => c.severity ?? 0)
+  );
+
+  const blocklistMatches = (result.body.blocklistsMatch ?? [])
+    .map(m => m.blocklistItemText!);
+
+  return {
+    isAllowed: flaggedCategories.length === 0 && blocklistMatches.length === 0,
+    flaggedCategories,
+    maxSeverity,
+    blocklistMatches
+  };
+}
+```
+
+## API Endpoints
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| Analyze Text | POST | `/text:analyze` |
+| Analyze Image | POST | `/image:analyze` |
+| Create/Update Blocklist | PATCH | `/text/blocklists/{blocklistName}` |
+| List Blocklists | GET | `/text/blocklists` |
+| Delete Blocklist | DELETE | `/text/blocklists/{blocklistName}` |
+| Add Blocklist Items | POST | `/text/blocklists/{blocklistName}:addOrUpdateBlocklistItems` |
+| List Blocklist Items | GET | `/text/blocklists/{blocklistName}/blocklistItems` |
+| Remove Blocklist Items | POST | `/text/blocklists/{blocklistName}:removeBlocklistItems` |
+
+## Key Types
+
+```typescript
+import ContentSafetyClient, {
+  isUnexpected,
+  AnalyzeTextParameters,
+  AnalyzeImageParameters,
+  TextCategoriesAnalysisOutput,
+  ImageCategoriesAnalysisOutput,
+  TextBlocklist,
+  TextBlocklistItem
+} from "@azure-rest/ai-content-safety";
+```
+
+## Best Practices
+
+1. **Always use isUnexpected()** - Type guard for error handling
+2. **Set appropriate thresholds** - Different categories may need different severity thresholds
+3. **Use blocklists for domain-specific terms** - Supplement AI detection with custom rules
+4. **Log moderation decisions** - Keep audit trail for compliance
+5. **Handle edge cases** - Empty text, very long text, unsupported image formats

--- a/skills/typescript/foundry/document-intelligence/SKILL.md
+++ b/skills/typescript/foundry/document-intelligence/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: azure-document-intelligence-typescript
+description: Extract text, tables, and structured data from documents using Azure Document Intelligence (@azure-rest/ai-document-intelligence). Use when processing invoices, receipts, IDs, forms, or building custom document models.
+---
+
+# Azure Document Intelligence REST SDK for TypeScript
+
+Extract text, tables, and structured data from documents using prebuilt and custom models.
+
+## Installation
+
+```bash
+npm install @azure-rest/ai-document-intelligence @azure/identity
+```
+
+## Environment Variables
+
+```bash
+DOCUMENT_INTELLIGENCE_ENDPOINT=https://<resource>.cognitiveservices.azure.com
+DOCUMENT_INTELLIGENCE_API_KEY=<api-key>
+```
+
+## Authentication
+
+**Important**: This is a REST client. `DocumentIntelligence` is a **function**, not a class.
+
+### DefaultAzureCredential
+
+```typescript
+import DocumentIntelligence from "@azure-rest/ai-document-intelligence";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = DocumentIntelligence(
+  process.env.DOCUMENT_INTELLIGENCE_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+```
+
+### API Key
+
+```typescript
+import DocumentIntelligence from "@azure-rest/ai-document-intelligence";
+
+const client = DocumentIntelligence(
+  process.env.DOCUMENT_INTELLIGENCE_ENDPOINT!,
+  { key: process.env.DOCUMENT_INTELLIGENCE_API_KEY! }
+);
+```
+
+## Analyze Document (URL)
+
+```typescript
+import DocumentIntelligence, {
+  isUnexpected,
+  getLongRunningPoller,
+  AnalyzeOperationOutput
+} from "@azure-rest/ai-document-intelligence";
+
+const initialResponse = await client
+  .path("/documentModels/{modelId}:analyze", "prebuilt-layout")
+  .post({
+    contentType: "application/json",
+    body: {
+      urlSource: "https://example.com/document.pdf"
+    },
+    queryParameters: { locale: "en-US" }
+  });
+
+if (isUnexpected(initialResponse)) {
+  throw initialResponse.body.error;
+}
+
+const poller = getLongRunningPoller(client, initialResponse);
+const result = (await poller.pollUntilDone()).body as AnalyzeOperationOutput;
+
+console.log("Pages:", result.analyzeResult?.pages?.length);
+console.log("Tables:", result.analyzeResult?.tables?.length);
+```
+
+## Analyze Document (Local File)
+
+```typescript
+import { readFile } from "node:fs/promises";
+
+const fileBuffer = await readFile("./document.pdf");
+const base64Source = fileBuffer.toString("base64");
+
+const initialResponse = await client
+  .path("/documentModels/{modelId}:analyze", "prebuilt-invoice")
+  .post({
+    contentType: "application/json",
+    body: { base64Source }
+  });
+
+if (isUnexpected(initialResponse)) {
+  throw initialResponse.body.error;
+}
+
+const poller = getLongRunningPoller(client, initialResponse);
+const result = (await poller.pollUntilDone()).body as AnalyzeOperationOutput;
+```
+
+## Prebuilt Models
+
+| Model ID | Description |
+|----------|-------------|
+| `prebuilt-read` | OCR - text and language extraction |
+| `prebuilt-layout` | Text, tables, selection marks, structure |
+| `prebuilt-invoice` | Invoice fields |
+| `prebuilt-receipt` | Receipt fields |
+| `prebuilt-idDocument` | ID document fields |
+| `prebuilt-tax.us.w2` | W-2 tax form fields |
+| `prebuilt-healthInsuranceCard.us` | Health insurance card fields |
+| `prebuilt-contract` | Contract fields |
+| `prebuilt-bankStatement.us` | Bank statement fields |
+
+## Extract Invoice Fields
+
+```typescript
+const initialResponse = await client
+  .path("/documentModels/{modelId}:analyze", "prebuilt-invoice")
+  .post({
+    contentType: "application/json",
+    body: { urlSource: invoiceUrl }
+  });
+
+if (isUnexpected(initialResponse)) {
+  throw initialResponse.body.error;
+}
+
+const poller = getLongRunningPoller(client, initialResponse);
+const result = (await poller.pollUntilDone()).body as AnalyzeOperationOutput;
+
+const invoice = result.analyzeResult?.documents?.[0];
+if (invoice) {
+  console.log("Vendor:", invoice.fields?.VendorName?.content);
+  console.log("Total:", invoice.fields?.InvoiceTotal?.content);
+  console.log("Due Date:", invoice.fields?.DueDate?.content);
+}
+```
+
+## Extract Receipt Fields
+
+```typescript
+const initialResponse = await client
+  .path("/documentModels/{modelId}:analyze", "prebuilt-receipt")
+  .post({
+    contentType: "application/json",
+    body: { urlSource: receiptUrl }
+  });
+
+const poller = getLongRunningPoller(client, initialResponse);
+const result = (await poller.pollUntilDone()).body as AnalyzeOperationOutput;
+
+const receipt = result.analyzeResult?.documents?.[0];
+if (receipt) {
+  console.log("Merchant:", receipt.fields?.MerchantName?.content);
+  console.log("Total:", receipt.fields?.Total?.content);
+  
+  for (const item of receipt.fields?.Items?.values || []) {
+    console.log("Item:", item.properties?.Description?.content);
+    console.log("Price:", item.properties?.TotalPrice?.content);
+  }
+}
+```
+
+## List Document Models
+
+```typescript
+import DocumentIntelligence, { isUnexpected, paginate } from "@azure-rest/ai-document-intelligence";
+
+const response = await client.path("/documentModels").get();
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+for await (const model of paginate(client, response)) {
+  console.log(model.modelId);
+}
+```
+
+## Build Custom Model
+
+```typescript
+const initialResponse = await client.path("/documentModels:build").post({
+  body: {
+    modelId: "my-custom-model",
+    description: "Custom model for purchase orders",
+    buildMode: "template",  // or "neural"
+    azureBlobSource: {
+      containerUrl: process.env.TRAINING_CONTAINER_SAS_URL!,
+      prefix: "training-data/"
+    }
+  }
+});
+
+if (isUnexpected(initialResponse)) {
+  throw initialResponse.body.error;
+}
+
+const poller = getLongRunningPoller(client, initialResponse);
+const result = await poller.pollUntilDone();
+console.log("Model built:", result.body);
+```
+
+## Build Document Classifier
+
+```typescript
+import { DocumentClassifierBuildOperationDetailsOutput } from "@azure-rest/ai-document-intelligence";
+
+const containerSasUrl = process.env.TRAINING_CONTAINER_SAS_URL!;
+
+const initialResponse = await client.path("/documentClassifiers:build").post({
+  body: {
+    classifierId: "my-classifier",
+    description: "Invoice vs Receipt classifier",
+    docTypes: {
+      invoices: {
+        azureBlobSource: { containerUrl: containerSasUrl, prefix: "invoices/" }
+      },
+      receipts: {
+        azureBlobSource: { containerUrl: containerSasUrl, prefix: "receipts/" }
+      }
+    }
+  }
+});
+
+if (isUnexpected(initialResponse)) {
+  throw initialResponse.body.error;
+}
+
+const poller = getLongRunningPoller(client, initialResponse);
+const result = (await poller.pollUntilDone()).body as DocumentClassifierBuildOperationDetailsOutput;
+console.log("Classifier:", result.result?.classifierId);
+```
+
+## Classify Document
+
+```typescript
+const initialResponse = await client
+  .path("/documentClassifiers/{classifierId}:analyze", "my-classifier")
+  .post({
+    contentType: "application/json",
+    body: { urlSource: documentUrl },
+    queryParameters: { split: "auto" }
+  });
+
+if (isUnexpected(initialResponse)) {
+  throw initialResponse.body.error;
+}
+
+const poller = getLongRunningPoller(client, initialResponse);
+const result = await poller.pollUntilDone();
+console.log("Classification:", result.body.analyzeResult?.documents);
+```
+
+## Get Service Info
+
+```typescript
+const response = await client.path("/info").get();
+
+if (isUnexpected(response)) {
+  throw response.body.error;
+}
+
+console.log("Custom model limit:", response.body.customDocumentModels.limit);
+console.log("Custom model count:", response.body.customDocumentModels.count);
+```
+
+## Polling Pattern
+
+```typescript
+import DocumentIntelligence, {
+  isUnexpected,
+  getLongRunningPoller,
+  AnalyzeOperationOutput
+} from "@azure-rest/ai-document-intelligence";
+
+// 1. Start operation
+const initialResponse = await client
+  .path("/documentModels/{modelId}:analyze", "prebuilt-layout")
+  .post({ contentType: "application/json", body: { urlSource } });
+
+// 2. Check for errors
+if (isUnexpected(initialResponse)) {
+  throw initialResponse.body.error;
+}
+
+// 3. Create poller
+const poller = getLongRunningPoller(client, initialResponse);
+
+// 4. Optional: Monitor progress
+poller.onProgress((state) => {
+  console.log("Status:", state.status);
+});
+
+// 5. Wait for completion
+const result = (await poller.pollUntilDone()).body as AnalyzeOperationOutput;
+```
+
+## Key Types
+
+```typescript
+import DocumentIntelligence, {
+  isUnexpected,
+  getLongRunningPoller,
+  paginate,
+  parseResultIdFromResponse,
+  AnalyzeOperationOutput,
+  DocumentClassifierBuildOperationDetailsOutput
+} from "@azure-rest/ai-document-intelligence";
+```
+
+## Best Practices
+
+1. **Use getLongRunningPoller()** - Document analysis is async, always poll for results
+2. **Check isUnexpected()** - Type guard for proper error handling
+3. **Choose the right model** - Use prebuilt models when possible, custom for specialized docs
+4. **Handle confidence scores** - Fields have confidence values, set thresholds for your use case
+5. **Use pagination** - Use `paginate()` helper for listing models
+6. **Prefer neural mode** - For custom models, neural handles more variation than template

--- a/skills/typescript/foundry/projects/SKILL.md
+++ b/skills/typescript/foundry/projects/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: azure-ai-projects-typescript
+description: Build AI applications using Azure AI Projects SDK for JavaScript (@azure/ai-projects). Use when working with Foundry project clients, agents, connections, deployments, datasets, indexes, evaluations, or getting OpenAI clients.
+---
+
+# Azure AI Projects SDK for TypeScript
+
+High-level SDK for Azure AI Foundry projects with agents, connections, deployments, and evaluations.
+
+## Installation
+
+```bash
+npm install @azure/ai-projects @azure/identity
+```
+
+For tracing:
+```bash
+npm install @azure/monitor-opentelemetry @opentelemetry/api
+```
+
+## Environment Variables
+
+```bash
+AZURE_AI_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+MODEL_DEPLOYMENT_NAME=gpt-4o
+```
+
+## Authentication
+
+```typescript
+import { AIProjectClient } from "@azure/ai-projects";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AIProjectClient(
+  process.env.AZURE_AI_PROJECT_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+```
+
+## Operation Groups
+
+| Group | Purpose |
+|-------|---------|
+| `client.agents` | Create and manage AI agents |
+| `client.connections` | List connected Azure resources |
+| `client.deployments` | List model deployments |
+| `client.datasets` | Upload and manage datasets |
+| `client.indexes` | Create and manage search indexes |
+| `client.evaluators` | Manage evaluation metrics |
+| `client.memoryStores` | Manage agent memory |
+
+## Getting OpenAI Client
+
+```typescript
+const openAIClient = await client.getOpenAIClient();
+
+// Use for responses
+const response = await openAIClient.responses.create({
+  model: "gpt-4o",
+  input: "What is the capital of France?"
+});
+
+// Use for conversations
+const conversation = await openAIClient.conversations.create({
+  items: [{ type: "message", role: "user", content: "Hello!" }]
+});
+```
+
+## Agents
+
+### Create Agent
+
+```typescript
+const agent = await client.agents.createVersion("my-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  instructions: "You are a helpful assistant."
+});
+```
+
+### Agent with Tools
+
+```typescript
+// Code Interpreter
+const agent = await client.agents.createVersion("code-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  instructions: "You can execute code.",
+  tools: [{ type: "code_interpreter", container: { type: "auto" } }]
+});
+
+// File Search
+const agent = await client.agents.createVersion("search-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  tools: [{ type: "file_search", vector_store_ids: [vectorStoreId] }]
+});
+
+// Web Search
+const agent = await client.agents.createVersion("web-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  tools: [{
+    type: "web_search_preview",
+    user_location: { type: "approximate", country: "US", city: "Seattle" }
+  }]
+});
+
+// Azure AI Search
+const agent = await client.agents.createVersion("aisearch-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  tools: [{
+    type: "azure_ai_search",
+    azure_ai_search: {
+      indexes: [{
+        project_connection_id: connectionId,
+        index_name: "my-index",
+        query_type: "simple"
+      }]
+    }
+  }]
+});
+
+// Function Tool
+const agent = await client.agents.createVersion("func-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  tools: [{
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get weather for a location",
+      strict: true,
+      parameters: {
+        type: "object",
+        properties: { location: { type: "string" } },
+        required: ["location"]
+      }
+    }
+  }]
+});
+
+// MCP Tool
+const agent = await client.agents.createVersion("mcp-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  tools: [{
+    type: "mcp",
+    server_label: "my-mcp",
+    server_url: "https://mcp-server.example.com",
+    require_approval: "always"
+  }]
+});
+```
+
+### Run Agent
+
+```typescript
+const openAIClient = await client.getOpenAIClient();
+
+// Create conversation
+const conversation = await openAIClient.conversations.create({
+  items: [{ type: "message", role: "user", content: "Hello!" }]
+});
+
+// Generate response using agent
+const response = await openAIClient.responses.create(
+  { conversation: conversation.id },
+  { body: { agent: { name: agent.name, type: "agent_reference" } } }
+);
+
+// Cleanup
+await openAIClient.conversations.delete(conversation.id);
+await client.agents.deleteVersion(agent.name, agent.version);
+```
+
+## Connections
+
+```typescript
+// List all connections
+for await (const conn of client.connections.list()) {
+  console.log(conn.name, conn.type);
+}
+
+// Get connection by name
+const conn = await client.connections.get("my-connection");
+
+// Get connection with credentials
+const connWithCreds = await client.connections.getWithCredentials("my-connection");
+
+// Get default connection by type
+const defaultAzureOpenAI = await client.connections.getDefault("AzureOpenAI", true);
+```
+
+## Deployments
+
+```typescript
+// List all deployments
+for await (const deployment of client.deployments.list()) {
+  if (deployment.type === "ModelDeployment") {
+    console.log(deployment.name, deployment.modelName);
+  }
+}
+
+// Filter by publisher
+for await (const d of client.deployments.list({ modelPublisher: "OpenAI" })) {
+  console.log(d.name);
+}
+
+// Get specific deployment
+const deployment = await client.deployments.get("gpt-4o");
+```
+
+## Datasets
+
+```typescript
+// Upload single file
+const dataset = await client.datasets.uploadFile(
+  "my-dataset",
+  "1.0",
+  "./data/training.jsonl"
+);
+
+// Upload folder
+const dataset = await client.datasets.uploadFolder(
+  "my-dataset",
+  "2.0",
+  "./data/documents/"
+);
+
+// Get dataset
+const ds = await client.datasets.get("my-dataset", "1.0");
+
+// List versions
+for await (const version of client.datasets.listVersions("my-dataset")) {
+  console.log(version);
+}
+
+// Delete
+await client.datasets.delete("my-dataset", "1.0");
+```
+
+## Indexes
+
+```typescript
+import { AzureAISearchIndex } from "@azure/ai-projects";
+
+const indexConfig: AzureAISearchIndex = {
+  name: "my-index",
+  type: "AzureSearch",
+  version: "1",
+  indexName: "my-index",
+  connectionName: "search-connection"
+};
+
+// Create index
+const index = await client.indexes.createOrUpdate("my-index", "1", indexConfig);
+
+// List indexes
+for await (const idx of client.indexes.list()) {
+  console.log(idx.name);
+}
+
+// Delete
+await client.indexes.delete("my-index", "1");
+```
+
+## Key Types
+
+```typescript
+import {
+  AIProjectClient,
+  AIProjectClientOptionalParams,
+  Connection,
+  ModelDeployment,
+  DatasetVersionUnion,
+  AzureAISearchIndex
+} from "@azure/ai-projects";
+```
+
+## Best Practices
+
+1. **Use getOpenAIClient()** - For responses, conversations, files, and vector stores
+2. **Version your agents** - Use `createVersion` for reproducible agent definitions
+3. **Clean up resources** - Delete agents, conversations when done
+4. **Use connections** - Get credentials from project connections, don't hardcode
+5. **Filter deployments** - Use `modelPublisher` filter to find specific models

--- a/skills/typescript/foundry/projects/references/connections.md
+++ b/skills/typescript/foundry/projects/references/connections.md
@@ -1,0 +1,208 @@
+# Connections Reference
+
+Working with Azure AI Foundry project connections to access linked Azure resources.
+
+## Overview
+
+Connections represent linked Azure resources (Azure OpenAI, AI Search, Storage, etc.) configured in your Foundry project. The SDK provides methods to list, retrieve, and access credentials for these connections.
+
+## Connection Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| `AzureOpenAI` | Azure OpenAI Service | Chat completions, embeddings |
+| `AzureAISearch` | Azure AI Search | Vector search, RAG |
+| `AzureBlob` | Blob Storage | File storage for agents |
+| `AzureAIServices` | Cognitive Services | Speech, Vision, etc. |
+| `Custom` | Custom connections | External APIs |
+
+## List Connections
+
+```typescript
+import { AIProjectClient } from "@azure/ai-projects";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AIProjectClient(
+  process.env.AZURE_AI_PROJECT_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+
+// List all connections
+for await (const connection of client.connections.list()) {
+  console.log(`Name: ${connection.name}`);
+  console.log(`Type: ${connection.type}`);
+  console.log(`---`);
+}
+
+// Filter by category
+for await (const conn of client.connections.list({ 
+  category: "AzureOpenAI" 
+})) {
+  console.log(`OpenAI Connection: ${conn.name}`);
+}
+```
+
+## Get Connection by Name
+
+```typescript
+// Get connection metadata (no credentials)
+const connection = await client.connections.get("my-openai-connection");
+console.log(`Endpoint: ${connection.target}`);
+console.log(`Type: ${connection.type}`);
+
+// Get connection with credentials
+const connWithCreds = await client.connections.getWithCredentials(
+  "my-openai-connection"
+);
+
+// Access credentials based on auth type
+if (connWithCreds.credentials.type === "ApiKey") {
+  console.log(`API Key: ${connWithCreds.credentials.key}`);
+} else if (connWithCreds.credentials.type === "AAD") {
+  // Use DefaultAzureCredential for AAD-based connections
+  console.log("Uses Entra ID authentication");
+}
+```
+
+## Get Default Connection
+
+```typescript
+// Get default connection of a specific type
+const defaultOpenAI = await client.connections.getDefault(
+  "AzureOpenAI",
+  true // withCredentials
+);
+
+const defaultSearch = await client.connections.getDefault(
+  "AzureAISearch",
+  true
+);
+
+// Use the connection endpoint
+console.log(`OpenAI Endpoint: ${defaultOpenAI.target}`);
+console.log(`Search Endpoint: ${defaultSearch.target}`);
+```
+
+## Connection Interface
+
+```typescript
+interface Connection {
+  /** Connection name */
+  name: string;
+  
+  /** Connection type (e.g., "AzureOpenAI", "AzureAISearch") */
+  type: string;
+  
+  /** Target endpoint URL */
+  target: string;
+  
+  /** Authentication type */
+  authType: "ApiKey" | "AAD" | "SAS" | "CustomKeys";
+  
+  /** Additional metadata */
+  metadata?: Record<string, string>;
+}
+
+interface ConnectionWithCredentials extends Connection {
+  credentials: ApiKeyCredentials | AADCredentials | SASCredentials;
+}
+
+interface ApiKeyCredentials {
+  type: "ApiKey";
+  key: string;
+}
+
+interface AADCredentials {
+  type: "AAD";
+  // Use DefaultAzureCredential to get tokens
+}
+```
+
+## Using Connections with Agents
+
+```typescript
+// Get Search connection for agent tool
+const searchConn = await client.connections.getWithCredentials("my-search");
+
+// Create agent with Azure AI Search tool
+const agent = await client.agents.createVersion("search-agent", {
+  kind: "prompt",
+  model: "gpt-4o",
+  tools: [{
+    type: "azure_ai_search",
+    azure_ai_search: {
+      indexes: [{
+        project_connection_id: searchConn.name,
+        index_name: "my-index",
+        query_type: "vector_semantic_hybrid"
+      }]
+    }
+  }]
+});
+```
+
+## Using Connections for Direct SDK Access
+
+```typescript
+// Get Azure OpenAI connection
+const openAIConn = await client.connections.getWithCredentials("my-openai");
+
+// Create Azure OpenAI client directly
+import { AzureOpenAI } from "openai";
+
+const openAIClient = new AzureOpenAI({
+  endpoint: openAIConn.target,
+  apiKey: openAIConn.credentials.type === "ApiKey" 
+    ? openAIConn.credentials.key 
+    : undefined,
+  // Or use credential for AAD
+  azureADTokenProvider: openAIConn.credentials.type === "AAD"
+    ? () => getAccessToken() 
+    : undefined,
+});
+
+// Get AI Search connection
+const searchConn = await client.connections.getWithCredentials("my-search");
+
+// Create Search client directly
+import { SearchClient, AzureKeyCredential } from "@azure/search-documents";
+
+const searchClient = new SearchClient(
+  searchConn.target,
+  "my-index",
+  new AzureKeyCredential(searchConn.credentials.key)
+);
+```
+
+## Error Handling
+
+```typescript
+import { RestError } from "@azure/core-rest-pipeline";
+
+try {
+  const conn = await client.connections.get("non-existent");
+} catch (error) {
+  if (error instanceof RestError) {
+    if (error.statusCode === 404) {
+      console.log("Connection not found");
+    } else if (error.statusCode === 403) {
+      console.log("Not authorized to access connection");
+    }
+  }
+  throw error;
+}
+```
+
+## Best Practices
+
+1. **Use `getDefault()` for standard resources** — Avoids hardcoding connection names
+2. **Cache connections** — Connection metadata rarely changes; cache to reduce API calls
+3. **Use AAD when possible** — Prefer `AAD` auth over `ApiKey` for better security
+4. **Never log credentials** — Avoid logging `getWithCredentials()` responses
+5. **Validate connection type** — Check `type` before casting credentials
+
+## See Also
+
+- [AIProjectClient Reference](../SKILL.md)
+- [Agents with Tools](../../agents/references/tools.md)
+- [Azure OpenAI Integration](https://learn.microsoft.com/azure/ai-services/openai/)

--- a/skills/typescript/foundry/projects/references/evaluations.md
+++ b/skills/typescript/foundry/projects/references/evaluations.md
@@ -1,0 +1,314 @@
+# Evaluations Reference
+
+Running AI evaluations and metrics analysis using Azure AI Foundry project SDK.
+
+## Overview
+
+Evaluations allow you to assess the quality of AI model outputs using various metrics like groundedness, relevance, coherence, and custom evaluators.
+
+## Evaluator Types
+
+| Evaluator | Measures | Use Case |
+|-----------|----------|----------|
+| `groundedness` | Response factual accuracy vs context | RAG applications |
+| `relevance` | Response relevance to query | Search, Q&A |
+| `coherence` | Response logical consistency | Content generation |
+| `fluency` | Language quality | All text generation |
+| `similarity` | Semantic similarity | Paraphrasing, translation |
+| `f1_score` | Token overlap | Classification, NER |
+
+## List Available Evaluators
+
+```typescript
+import { AIProjectClient } from "@azure/ai-projects";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new AIProjectClient(
+  process.env.AZURE_AI_PROJECT_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+
+// List all evaluators in the project
+for await (const evaluator of client.evaluators.list()) {
+  console.log(`Name: ${evaluator.name}`);
+  console.log(`Type: ${evaluator.type}`);
+  console.log(`Description: ${evaluator.description}`);
+  console.log("---");
+}
+```
+
+## Run Evaluation
+
+```typescript
+// Prepare evaluation data
+const evaluationData = [
+  {
+    query: "What is the capital of France?",
+    context: "France is a country in Europe. Paris is the capital of France.",
+    response: "The capital of France is Paris.",
+    ground_truth: "Paris"
+  },
+  {
+    query: "What is machine learning?",
+    context: "Machine learning is a subset of AI that enables systems to learn from data.",
+    response: "Machine learning is a type of AI where computers learn from data without explicit programming.",
+    ground_truth: "Machine learning is a subset of AI that learns from data."
+  }
+];
+
+// Run evaluation with built-in evaluators
+const evaluationResult = await client.evaluations.create({
+  displayName: "RAG Evaluation - v1",
+  description: "Evaluating RAG pipeline quality",
+  data: evaluationData,
+  evaluators: {
+    groundedness: {
+      type: "builtin",
+      name: "groundedness"
+    },
+    relevance: {
+      type: "builtin", 
+      name: "relevance"
+    },
+    coherence: {
+      type: "builtin",
+      name: "coherence"
+    }
+  }
+});
+
+console.log(`Evaluation ID: ${evaluationResult.id}`);
+console.log(`Status: ${evaluationResult.status}`);
+```
+
+## Poll for Results
+
+```typescript
+// Poll until evaluation completes
+let evaluation = await client.evaluations.get(evaluationResult.id);
+
+while (evaluation.status === "Running" || evaluation.status === "Queued") {
+  console.log(`Status: ${evaluation.status}...`);
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  evaluation = await client.evaluations.get(evaluationResult.id);
+}
+
+if (evaluation.status === "Completed") {
+  console.log("Evaluation completed!");
+  console.log("Metrics:", evaluation.metrics);
+} else {
+  console.error("Evaluation failed:", evaluation.error);
+}
+```
+
+## Access Evaluation Results
+
+```typescript
+// Get detailed results
+const evaluation = await client.evaluations.get(evaluationId);
+
+// Overall metrics
+console.log("Overall Metrics:");
+for (const [metric, value] of Object.entries(evaluation.metrics || {})) {
+  console.log(`  ${metric}: ${value}`);
+}
+
+// Per-row results
+if (evaluation.results) {
+  console.log("\nPer-Row Results:");
+  for (const row of evaluation.results) {
+    console.log(`Query: ${row.query}`);
+    console.log(`Groundedness: ${row.groundedness}`);
+    console.log(`Relevance: ${row.relevance}`);
+    console.log("---");
+  }
+}
+```
+
+## Evaluation with Dataset
+
+```typescript
+// Upload dataset first
+const dataset = await client.datasets.uploadFile(
+  "evaluation-data",
+  "1.0",
+  "./data/eval_samples.jsonl"
+);
+
+// Run evaluation on dataset
+const evaluationResult = await client.evaluations.create({
+  displayName: "Dataset Evaluation",
+  datasetId: dataset.id,
+  datasetVersion: dataset.version,
+  evaluators: {
+    groundedness: { type: "builtin", name: "groundedness" },
+    relevance: { type: "builtin", name: "relevance" }
+  },
+  // Map dataset columns to evaluator inputs
+  columnMapping: {
+    query: "question",
+    context: "retrieved_context",
+    response: "model_answer",
+    ground_truth: "expected_answer"
+  }
+});
+```
+
+## Custom Evaluator
+
+```typescript
+// Define custom evaluator with prompt template
+const customEvaluator = await client.evaluators.create({
+  name: "custom-toxicity",
+  displayName: "Toxicity Check",
+  description: "Checks response for toxic content",
+  type: "prompt",
+  model: "gpt-4o",
+  promptTemplate: `
+    You are evaluating AI response quality.
+    
+    Response to evaluate: {{response}}
+    
+    Rate the toxicity of this response on a scale of 1-5:
+    1 = Not toxic at all
+    5 = Highly toxic
+    
+    Return only the numeric score.
+  `,
+  outputType: "number"
+});
+
+// Use custom evaluator
+const result = await client.evaluations.create({
+  displayName: "Toxicity Evaluation",
+  data: testData,
+  evaluators: {
+    toxicity: {
+      type: "custom",
+      id: customEvaluator.id
+    }
+  }
+});
+```
+
+## Evaluation Interfaces
+
+```typescript
+interface EvaluationConfig {
+  /** Display name for the evaluation run */
+  displayName: string;
+  
+  /** Optional description */
+  description?: string;
+  
+  /** Inline data to evaluate */
+  data?: EvaluationRow[];
+  
+  /** Or reference a dataset */
+  datasetId?: string;
+  datasetVersion?: string;
+  
+  /** Evaluators to run */
+  evaluators: Record<string, EvaluatorConfig>;
+  
+  /** Column mapping for dataset */
+  columnMapping?: Record<string, string>;
+}
+
+interface EvaluatorConfig {
+  type: "builtin" | "custom";
+  name?: string; // For builtin
+  id?: string;   // For custom
+}
+
+interface EvaluationResult {
+  id: string;
+  displayName: string;
+  status: "Queued" | "Running" | "Completed" | "Failed";
+  metrics?: Record<string, number>;
+  results?: EvaluationRowResult[];
+  error?: EvaluationError;
+  createdAt: Date;
+  completedAt?: Date;
+}
+
+interface EvaluationRowResult {
+  [key: string]: unknown;
+  // Contains original data plus evaluator scores
+}
+```
+
+## List Evaluation Runs
+
+```typescript
+// List all evaluations
+for await (const evaluation of client.evaluations.list()) {
+  console.log(`${evaluation.displayName}: ${evaluation.status}`);
+}
+
+// Filter by status
+for await (const evaluation of client.evaluations.list({ 
+  status: "Completed" 
+})) {
+  console.log(`${evaluation.displayName}: ${evaluation.metrics?.groundedness}`);
+}
+```
+
+## Delete Evaluation
+
+```typescript
+await client.evaluations.delete(evaluationId);
+```
+
+## Best Practices
+
+1. **Use multiple evaluators** — Combine groundedness, relevance, and coherence for comprehensive assessment
+2. **Provide ground truth** — Include expected answers for more accurate evaluation
+3. **Use datasets for scale** — Upload JSONL files for large-scale evaluations
+4. **Monitor costs** — Evaluations use model inference; large datasets incur costs
+5. **Version evaluations** — Use descriptive names to track evaluation iterations
+6. **Compare baselines** — Run evaluations on baseline vs improved models
+
+## Common Evaluation Patterns
+
+### RAG Quality Assessment
+
+```typescript
+const ragEvaluation = await client.evaluations.create({
+  displayName: "RAG Pipeline v2",
+  data: ragTestData,
+  evaluators: {
+    groundedness: { type: "builtin", name: "groundedness" },
+    relevance: { type: "builtin", name: "relevance" },
+    coherence: { type: "builtin", name: "coherence" }
+  }
+});
+```
+
+### A/B Model Comparison
+
+```typescript
+// Evaluate Model A
+const modelAResults = await client.evaluations.create({
+  displayName: "Model A Evaluation",
+  data: testData.map(d => ({ ...d, response: modelAResponses[d.id] })),
+  evaluators: { quality: { type: "builtin", name: "relevance" } }
+});
+
+// Evaluate Model B
+const modelBResults = await client.evaluations.create({
+  displayName: "Model B Evaluation", 
+  data: testData.map(d => ({ ...d, response: modelBResponses[d.id] })),
+  evaluators: { quality: { type: "builtin", name: "relevance" } }
+});
+
+// Compare
+console.log(`Model A: ${modelAResults.metrics?.quality}`);
+console.log(`Model B: ${modelBResults.metrics?.quality}`);
+```
+
+## See Also
+
+- [Datasets Reference](./datasets.md)
+- [Azure AI Evaluation](https://learn.microsoft.com/azure/ai-studio/concepts/evaluation-approach-gen-ai)
+- [Built-in Evaluators](https://learn.microsoft.com/azure/ai-studio/how-to/evaluate-generative-ai-app)

--- a/skills/typescript/foundry/voicelive/SKILL.md
+++ b/skills/typescript/foundry/voicelive/SKILL.md
@@ -1,0 +1,464 @@
+---
+name: azure-ai-voicelive-js
+description: |
+  Azure AI Voice Live SDK for JavaScript/TypeScript. Build real-time voice AI applications with bidirectional WebSocket communication. Use for voice assistants, conversational AI, real-time speech-to-speech, and voice-enabled chatbots in Node.js or browser environments. Triggers: "voice live", "real-time voice", "VoiceLiveClient", "VoiceLiveSession", "voice assistant TypeScript", "bidirectional audio", "speech-to-speech JavaScript".
+---
+
+# @azure/ai-voicelive (JavaScript/TypeScript)
+
+Real-time voice AI SDK for building bidirectional voice assistants with Azure AI in Node.js and browser environments.
+
+## Installation
+
+```bash
+npm install @azure/ai-voicelive @azure/identity
+# TypeScript users
+npm install @types/node
+```
+
+**Current Version**: 1.0.0-beta.3
+
+**Supported Environments**:
+- Node.js LTS versions (20+)
+- Modern browsers (Chrome, Firefox, Safari, Edge)
+
+## Environment Variables
+
+```bash
+AZURE_VOICELIVE_ENDPOINT=https://<resource>.cognitiveservices.azure.com
+# Optional: API key if not using Entra ID
+AZURE_VOICELIVE_API_KEY=<your-api-key>
+# Optional: Logging
+AZURE_LOG_LEVEL=info
+```
+
+## Authentication
+
+### Microsoft Entra ID (Recommended)
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { VoiceLiveClient } from "@azure/ai-voicelive";
+
+const credential = new DefaultAzureCredential();
+const endpoint = "https://your-resource.cognitiveservices.azure.com";
+
+const client = new VoiceLiveClient(endpoint, credential);
+```
+
+### API Key
+
+```typescript
+import { AzureKeyCredential } from "@azure/core-auth";
+import { VoiceLiveClient } from "@azure/ai-voicelive";
+
+const endpoint = "https://your-resource.cognitiveservices.azure.com";
+const credential = new AzureKeyCredential("your-api-key");
+
+const client = new VoiceLiveClient(endpoint, credential);
+```
+
+## Client Hierarchy
+
+```
+VoiceLiveClient
+└── VoiceLiveSession (WebSocket connection)
+    ├── updateSession()      → Configure session options
+    ├── subscribe()          → Event handlers (Azure SDK pattern)
+    ├── sendAudio()          → Stream audio input
+    ├── addConversationItem() → Add messages/function outputs
+    └── sendEvent()          → Send raw protocol events
+```
+
+## Quick Start
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { VoiceLiveClient } from "@azure/ai-voicelive";
+
+const credential = new DefaultAzureCredential();
+const endpoint = process.env.AZURE_VOICELIVE_ENDPOINT!;
+
+// Create client and start session
+const client = new VoiceLiveClient(endpoint, credential);
+const session = await client.startSession("gpt-4o-mini-realtime-preview");
+
+// Configure session
+await session.updateSession({
+  modalities: ["text", "audio"],
+  instructions: "You are a helpful AI assistant. Respond naturally.",
+  voice: {
+    type: "azure-standard",
+    name: "en-US-AvaNeural",
+  },
+  turnDetection: {
+    type: "server_vad",
+    threshold: 0.5,
+    prefixPaddingMs: 300,
+    silenceDurationMs: 500,
+  },
+  inputAudioFormat: "pcm16",
+  outputAudioFormat: "pcm16",
+});
+
+// Subscribe to events
+const subscription = session.subscribe({
+  onResponseAudioDelta: async (event, context) => {
+    // Handle streaming audio output
+    const audioData = event.delta;
+    playAudioChunk(audioData);
+  },
+  onResponseTextDelta: async (event, context) => {
+    // Handle streaming text
+    process.stdout.write(event.delta);
+  },
+  onInputAudioTranscriptionCompleted: async (event, context) => {
+    console.log("User said:", event.transcript);
+  },
+});
+
+// Send audio from microphone
+function sendAudioChunk(audioBuffer: ArrayBuffer) {
+  session.sendAudio(audioBuffer);
+}
+```
+
+## Session Configuration
+
+```typescript
+await session.updateSession({
+  // Modalities
+  modalities: ["audio", "text"],
+  
+  // System instructions
+  instructions: "You are a customer service representative.",
+  
+  // Voice selection
+  voice: {
+    type: "azure-standard",  // or "azure-custom", "openai"
+    name: "en-US-AvaNeural",
+  },
+  
+  // Turn detection (VAD)
+  turnDetection: {
+    type: "server_vad",      // or "azure_semantic_vad"
+    threshold: 0.5,
+    prefixPaddingMs: 300,
+    silenceDurationMs: 500,
+  },
+  
+  // Audio formats
+  inputAudioFormat: "pcm16",
+  outputAudioFormat: "pcm16",
+  
+  // Tools (function calling)
+  tools: [
+    {
+      type: "function",
+      name: "get_weather",
+      description: "Get current weather",
+      parameters: {
+        type: "object",
+        properties: {
+          location: { type: "string" }
+        },
+        required: ["location"]
+      }
+    }
+  ],
+  toolChoice: "auto",
+});
+```
+
+## Event Handling (Azure SDK Pattern)
+
+The SDK uses a subscription-based event handling pattern:
+
+```typescript
+const subscription = session.subscribe({
+  // Connection lifecycle
+  onConnected: async (args, context) => {
+    console.log("Connected:", args.connectionId);
+  },
+  onDisconnected: async (args, context) => {
+    console.log("Disconnected:", args.code, args.reason);
+  },
+  onError: async (args, context) => {
+    console.error("Error:", args.error.message);
+  },
+  
+  // Session events
+  onSessionCreated: async (event, context) => {
+    console.log("Session created:", context.sessionId);
+  },
+  onSessionUpdated: async (event, context) => {
+    console.log("Session updated");
+  },
+  
+  // Audio input events (VAD)
+  onInputAudioBufferSpeechStarted: async (event, context) => {
+    console.log("Speech started at:", event.audioStartMs);
+  },
+  onInputAudioBufferSpeechStopped: async (event, context) => {
+    console.log("Speech stopped at:", event.audioEndMs);
+  },
+  
+  // Transcription events
+  onConversationItemInputAudioTranscriptionCompleted: async (event, context) => {
+    console.log("User said:", event.transcript);
+  },
+  onConversationItemInputAudioTranscriptionDelta: async (event, context) => {
+    process.stdout.write(event.delta);
+  },
+  
+  // Response events
+  onResponseCreated: async (event, context) => {
+    console.log("Response started");
+  },
+  onResponseDone: async (event, context) => {
+    console.log("Response complete");
+  },
+  
+  // Streaming text
+  onResponseTextDelta: async (event, context) => {
+    process.stdout.write(event.delta);
+  },
+  onResponseTextDone: async (event, context) => {
+    console.log("\n--- Text complete ---");
+  },
+  
+  // Streaming audio
+  onResponseAudioDelta: async (event, context) => {
+    const audioData = event.delta;
+    playAudioChunk(audioData);
+  },
+  onResponseAudioDone: async (event, context) => {
+    console.log("Audio complete");
+  },
+  
+  // Audio transcript (what assistant said)
+  onResponseAudioTranscriptDelta: async (event, context) => {
+    process.stdout.write(event.delta);
+  },
+  
+  // Function calling
+  onResponseFunctionCallArgumentsDone: async (event, context) => {
+    if (event.name === "get_weather") {
+      const args = JSON.parse(event.arguments);
+      const result = await getWeather(args.location);
+      
+      await session.addConversationItem({
+        type: "function_call_output",
+        callId: event.callId,
+        output: JSON.stringify(result),
+      });
+      
+      await session.sendEvent({ type: "response.create" });
+    }
+  },
+  
+  // Catch-all for debugging
+  onServerEvent: async (event, context) => {
+    console.log("Event:", event.type);
+  },
+});
+
+// Clean up when done
+await subscription.close();
+```
+
+## Function Calling
+
+```typescript
+// Define tools in session config
+await session.updateSession({
+  modalities: ["audio", "text"],
+  instructions: "Help users with weather information.",
+  tools: [
+    {
+      type: "function",
+      name: "get_weather",
+      description: "Get current weather for a location",
+      parameters: {
+        type: "object",
+        properties: {
+          location: {
+            type: "string",
+            description: "City and state or country",
+          },
+        },
+        required: ["location"],
+      },
+    },
+  ],
+  toolChoice: "auto",
+});
+
+// Handle function calls
+const subscription = session.subscribe({
+  onResponseFunctionCallArgumentsDone: async (event, context) => {
+    if (event.name === "get_weather") {
+      const args = JSON.parse(event.arguments);
+      const weatherData = await fetchWeather(args.location);
+      
+      // Send function result
+      await session.addConversationItem({
+        type: "function_call_output",
+        callId: event.callId,
+        output: JSON.stringify(weatherData),
+      });
+      
+      // Trigger response generation
+      await session.sendEvent({ type: "response.create" });
+    }
+  },
+});
+```
+
+## Voice Options
+
+| Voice Type | Config | Example |
+|------------|--------|---------|
+| Azure Standard | `{ type: "azure-standard", name: "..." }` | `"en-US-AvaNeural"` |
+| Azure Custom | `{ type: "azure-custom", name: "...", endpointId: "..." }` | Custom voice endpoint |
+| Azure Personal | `{ type: "azure-personal", speakerProfileId: "..." }` | Personal voice clone |
+| OpenAI | `{ type: "openai", name: "..." }` | `"alloy"`, `"echo"`, `"shimmer"` |
+
+## Supported Models
+
+| Model | Description | Use Case |
+|-------|-------------|----------|
+| `gpt-4o-realtime-preview` | GPT-4o with real-time audio | High-quality conversational AI |
+| `gpt-4o-mini-realtime-preview` | Lightweight GPT-4o | Fast, efficient interactions |
+| `phi4-mm-realtime` | Phi multimodal | Cost-effective applications |
+
+## Turn Detection Options
+
+```typescript
+// Server VAD (default)
+turnDetection: {
+  type: "server_vad",
+  threshold: 0.5,
+  prefixPaddingMs: 300,
+  silenceDurationMs: 500,
+}
+
+// Azure Semantic VAD (smarter detection)
+turnDetection: {
+  type: "azure_semantic_vad",
+}
+
+// Azure Semantic VAD (English optimized)
+turnDetection: {
+  type: "azure_semantic_vad_en",
+}
+
+// Azure Semantic VAD (Multilingual)
+turnDetection: {
+  type: "azure_semantic_vad_multilingual",
+}
+```
+
+## Audio Formats
+
+| Format | Sample Rate | Use Case |
+|--------|-------------|----------|
+| `pcm16` | 24kHz | Default, high quality |
+| `pcm16-8000hz` | 8kHz | Telephony |
+| `pcm16-16000hz` | 16kHz | Voice assistants |
+| `g711_ulaw` | 8kHz | Telephony (US) |
+| `g711_alaw` | 8kHz | Telephony (EU) |
+
+## Key Types Reference
+
+| Type | Purpose |
+|------|---------|
+| `VoiceLiveClient` | Main client for creating sessions |
+| `VoiceLiveSession` | Active WebSocket session |
+| `VoiceLiveSessionHandlers` | Event handler interface |
+| `VoiceLiveSubscription` | Active event subscription |
+| `ConnectionContext` | Context for connection events |
+| `SessionContext` | Context for session events |
+| `ServerEventUnion` | Union of all server events |
+
+## Error Handling
+
+```typescript
+import {
+  VoiceLiveError,
+  VoiceLiveConnectionError,
+  VoiceLiveAuthenticationError,
+  VoiceLiveProtocolError,
+} from "@azure/ai-voicelive";
+
+const subscription = session.subscribe({
+  onError: async (args, context) => {
+    const { error } = args;
+    
+    if (error instanceof VoiceLiveConnectionError) {
+      console.error("Connection error:", error.message);
+    } else if (error instanceof VoiceLiveAuthenticationError) {
+      console.error("Auth error:", error.message);
+    } else if (error instanceof VoiceLiveProtocolError) {
+      console.error("Protocol error:", error.message);
+    }
+  },
+  
+  onServerError: async (event, context) => {
+    console.error("Server error:", event.error?.message);
+  },
+});
+```
+
+## Logging
+
+```typescript
+import { setLogLevel } from "@azure/logger";
+
+// Enable verbose logging
+setLogLevel("info");
+
+// Or via environment variable
+// AZURE_LOG_LEVEL=info
+```
+
+## Browser Usage
+
+```typescript
+// Browser requires bundler (Vite, webpack, etc.)
+import { VoiceLiveClient } from "@azure/ai-voicelive";
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+// Use browser-compatible credential
+const credential = new InteractiveBrowserCredential({
+  clientId: "your-client-id",
+  tenantId: "your-tenant-id",
+});
+
+const client = new VoiceLiveClient(endpoint, credential);
+
+// Request microphone access
+const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+const audioContext = new AudioContext({ sampleRate: 24000 });
+
+// Process audio and send to session
+// ... (see samples for full implementation)
+```
+
+## Best Practices
+
+1. **Always use `DefaultAzureCredential`** — Never hardcode API keys
+2. **Set both modalities** — Include `["text", "audio"]` for voice assistants
+3. **Use Azure Semantic VAD** — Better turn detection than basic server VAD
+4. **Handle all error types** — Connection, auth, and protocol errors
+5. **Clean up subscriptions** — Call `subscription.close()` when done
+6. **Use appropriate audio format** — PCM16 at 24kHz for best quality
+
+## Reference Links
+
+| Resource | URL |
+|----------|-----|
+| npm Package | https://www.npmjs.com/package/@azure/ai-voicelive |
+| GitHub Source | https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-voicelive |
+| Samples | https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-voicelive/samples |
+| API Reference | https://learn.microsoft.com/javascript/api/@azure/ai-voicelive |

--- a/skills/typescript/foundry/voicelive/references/audio-streaming.md
+++ b/skills/typescript/foundry/voicelive/references/audio-streaming.md
@@ -1,0 +1,435 @@
+# Audio Streaming Reference
+
+Real-time audio capture and playback patterns for Azure AI Voice Live using the @azure/ai-voicelive TypeScript SDK.
+
+## Overview
+
+Voice Live requires bidirectional audio streaming over WebSocket. This reference covers browser microphone capture, PCM format conversion, and audio playback patterns for voice assistants.
+
+## Audio Format Requirements
+
+| Property | Default Value | Options |
+|----------|---------------|---------|
+| `inputAudioFormat` | `"pcm16"` | `"pcm16"`, `"g711_alaw"`, `"g711_ulaw"` |
+| `outputAudioFormat` | `"pcm16"` | `"pcm16"` |
+| Sample Rate (pcm16) | 24000 Hz | 8000, 16000, 24000 |
+| Channels | Mono (1) | - |
+
+### Sample Rate Inference
+
+```typescript
+function inferPcmSampleRateFromOutputFormat(outputAudioFormat: string | undefined): number {
+  if (!outputAudioFormat) return 24000;
+  const fmt = outputAudioFormat.toLowerCase();
+  if (fmt === "pcm16") return 24000;
+  if (fmt === "pcm16-16000hz") return 16000;
+  if (fmt === "pcm16-8000hz") return 8000;
+  return 24000;
+}
+```
+
+## Browser Microphone Capture
+
+### Pattern A: ScriptProcessorNode (Simple)
+
+Simpler implementation but uses deprecated Web Audio API.
+
+```typescript
+export class SimpleAudioCapture {
+  private audioContext?: AudioContext;
+  private mediaStream?: MediaStream;
+  private scriptProcessor?: ScriptProcessorNode;
+  private dataCallback: (data: ArrayBuffer) => void;
+  
+  private readonly targetSampleRate = 24000;
+
+  constructor(onData: (data: ArrayBuffer) => void) {
+    this.dataCallback = onData;
+  }
+
+  async initialize(): Promise<void> {
+    // Request microphone access
+    this.mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        sampleRate: this.targetSampleRate,
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+    });
+
+    // Create audio context at target sample rate
+    this.audioContext = new AudioContext({ sampleRate: this.targetSampleRate });
+    
+    // Create processing chain
+    const source = this.audioContext.createMediaStreamSource(this.mediaStream);
+    this.scriptProcessor = this.audioContext.createScriptProcessor(4096, 1, 1);
+    
+    // Connect nodes
+    source.connect(this.scriptProcessor);
+    this.scriptProcessor.connect(this.audioContext.destination);
+    
+    // Process audio data
+    this.scriptProcessor.onaudioprocess = (event) => {
+      const inputData = event.inputBuffer.getChannelData(0);
+      const pcm16Data = this.convertToPCM16(inputData);
+      this.dataCallback(pcm16Data.buffer);
+    };
+  }
+
+  private convertToPCM16(floatData: Float32Array): Int16Array {
+    const pcm16 = new Int16Array(floatData.length);
+    for (let i = 0; i < floatData.length; i++) {
+      const sample = Math.max(-1, Math.min(1, floatData[i]));
+      pcm16[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+    }
+    return pcm16;
+  }
+
+  stop(): void {
+    this.scriptProcessor?.disconnect();
+    this.mediaStream?.getTracks().forEach((track) => track.stop());
+    this.audioContext?.close();
+  }
+}
+```
+
+### Pattern B: AudioWorklet (Modern, Recommended)
+
+Uses modern AudioWorklet API with better performance.
+
+```typescript
+// Main thread code
+export class AudioWorkletCapture {
+  private audioContext?: AudioContext;
+  private mediaStream?: MediaStream;
+  private workletNode?: AudioWorkletNode;
+  private onAudioData: (data: Uint8Array) => void;
+
+  constructor(onData: (data: Uint8Array) => void) {
+    this.onAudioData = onData;
+  }
+
+  async start(): Promise<void> {
+    const ac = new AudioContext();
+    this.audioContext = ac;
+
+    // Load AudioWorklet module
+    const workletUrl = new URL("worklets/pcm16-downsampler.js", document.baseURI).toString();
+    await ac.audioWorklet.addModule(workletUrl);
+
+    // Get microphone stream
+    // Disable browser processing - server handles VAD
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+    });
+    this.mediaStream = stream;
+
+    // Create processing chain
+    const source = ac.createMediaStreamSource(stream);
+    const worklet = new AudioWorkletNode(ac, "pcm16-downsampler");
+    this.workletNode = worklet;
+
+    // Receive processed PCM16 data from worklet
+    worklet.port.onmessage = (e) => {
+      const buffer = e.data as ArrayBuffer;
+      const pcm16Bytes = new Uint8Array(buffer);
+      this.onAudioData(pcm16Bytes);
+    };
+
+    // Connect with muted output to prevent feedback
+    const gain = ac.createGain();
+    gain.gain.value = 0;
+    source.connect(worklet);
+    worklet.connect(gain);
+    gain.connect(ac.destination);
+  }
+
+  stop(): void {
+    this.workletNode?.disconnect();
+    this.mediaStream?.getTracks().forEach((track) => track.stop());
+    this.audioContext?.close();
+  }
+}
+```
+
+### AudioWorklet Processor (pcm16-downsampler.js)
+
+Save this file in `/public/worklets/pcm16-downsampler.js`:
+
+```javascript
+class Pcm16DownsamplerProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._targetSampleRate = 24000;
+    this._inputSampleRate = sampleRate;  // Browser's native rate (e.g., 48000)
+    this._ratio = this._inputSampleRate / this._targetSampleRate;
+    this._carry = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+
+    const channel0 = input[0];
+    if (!channel0 || channel0.length === 0) return true;
+
+    // Downsample by averaging
+    const outLength = Math.max(0, Math.floor((channel0.length - this._carry) / this._ratio));
+    if (outLength === 0) return true;
+
+    const pcm16 = new Int16Array(outLength);
+    let outIndex = 0;
+    let i = this._carry;
+
+    while (outIndex < outLength) {
+      const start = Math.floor(i);
+      const end = Math.floor(i + this._ratio);
+
+      let sum = 0, count = 0;
+      for (let j = start; j < end && j < channel0.length; j++) {
+        sum += channel0[j];
+        count++;
+      }
+
+      const sample = count > 0 ? sum / count : 0;
+      const clamped = Math.max(-1, Math.min(1, sample));
+      pcm16[outIndex] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+
+      outIndex++;
+      i += this._ratio;
+    }
+
+    this._carry = i - channel0.length;
+    if (this._carry < 0) this._carry = 0;
+
+    // Transfer buffer to main thread
+    this.port.postMessage(pcm16.buffer, [pcm16.buffer]);
+    return true;
+  }
+}
+
+registerProcessor("pcm16-downsampler", Pcm16DownsamplerProcessor);
+```
+
+## Audio Playback
+
+### Pattern A: AudioBufferSourceNode Queue
+
+Simple queue-based playback using AudioBufferSourceNode.
+
+```typescript
+export class Pcm16Player {
+  private readonly audioContext: AudioContext;
+  private nextStartTime = 0;
+  private sources: AudioBufferSourceNode[] = [];
+  private sampleRate: number;
+
+  constructor(sampleRate = 24000) {
+    this.audioContext = new AudioContext();
+    this.sampleRate = sampleRate;
+  }
+
+  async resume(): Promise<void> {
+    if (this.audioContext.state !== "running") {
+      await this.audioContext.resume();
+    }
+  }
+
+  enqueuePcm16(bytes: Uint8Array): void {
+    // Convert PCM16 bytes to Float32 for Web Audio API
+    const floatData = this.pcm16BytesToFloat32(bytes);
+    
+    // Create audio buffer
+    const buffer = this.audioContext.createBuffer(1, floatData.length, this.sampleRate);
+    buffer.getChannelData(0).set(floatData);
+
+    // Create and schedule source
+    const src = this.audioContext.createBufferSource();
+    src.buffer = buffer;
+    src.connect(this.audioContext.destination);
+
+    // Schedule seamless playback
+    const now = this.audioContext.currentTime;
+    if (this.nextStartTime < now) {
+      this.nextStartTime = now;
+    }
+    const startAt = this.nextStartTime;
+    this.nextStartTime += buffer.duration;
+
+    // Track for cleanup
+    src.onended = () => {
+      this.sources = this.sources.filter((s) => s !== src);
+    };
+    this.sources.push(src);
+    src.start(startAt);
+  }
+
+  private pcm16BytesToFloat32(bytes: Uint8Array): Float32Array {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const sampleCount = Math.floor(bytes.byteLength / 2);
+    const out = new Float32Array(sampleCount);
+    for (let i = 0; i < sampleCount; i++) {
+      const s = view.getInt16(i * 2, true);  // Little-endian
+      out[i] = s / 0x8000;
+    }
+    return out;
+  }
+
+  stop(): void {
+    for (const s of this.sources) {
+      try {
+        s.stop();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.sources = [];
+    this.nextStartTime = 0;
+  }
+}
+```
+
+### Pattern B: AudioWorklet Playback
+
+Better for handling barge-in (user interrupts assistant).
+
+```javascript
+// audio-playback-worklet.js
+class AudioPlaybackWorklet extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.port.onmessage = this.handleMessage.bind(this);
+    this.buffer = [];
+  }
+
+  handleMessage(event) {
+    if (event.data === null) {
+      // Clear buffer on barge-in
+      this.buffer = [];
+      return;
+    }
+    // Append Int16 samples
+    this.buffer.push(...event.data);
+  }
+
+  process(inputs, outputs) {
+    const output = outputs[0];
+    const channel = output[0];
+
+    if (this.buffer.length > channel.length) {
+      const toProcess = this.buffer.slice(0, channel.length);
+      this.buffer = this.buffer.slice(channel.length);
+      channel.set(toProcess.map((v) => v / 32768));  // Int16 to Float32
+    } else {
+      channel.set(this.buffer.map((v) => v / 32768));
+      this.buffer = [];
+    }
+
+    return true;
+  }
+}
+
+registerProcessor("audio-playback-worklet", AudioPlaybackWorklet);
+```
+
+## PCM16 Conversion Utilities
+
+```typescript
+// Float32 to PCM16 (for sending to server)
+export function floatTo16BitPCM(input: Float32Array): Int16Array {
+  const output = new Int16Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i] ?? 0));
+    output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  return output;
+}
+
+// PCM16 bytes to Float32 (for playback)
+export function pcm16BytesToFloat32LE(bytes: Uint8Array): Float32Array {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const sampleCount = Math.floor(bytes.byteLength / 2);
+  const out = new Float32Array(sampleCount);
+  for (let i = 0; i < sampleCount; i++) {
+    const s = view.getInt16(i * 2, true);  // Little-endian
+    out[i] = s / 0x8000;
+  }
+  return out;
+}
+
+// Int16Array to Uint8Array (for sendAudio)
+export function int16ToUint8(int16Array: Int16Array): Uint8Array {
+  return new Uint8Array(int16Array.buffer);
+}
+```
+
+## Integration with VoiceLiveSession
+
+```typescript
+import { VoiceLiveClient } from "@azure/ai-voicelive";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new VoiceLiveClient(endpoint, new DefaultAzureCredential());
+const session = await client.startSession("gpt-4o-mini-realtime-preview");
+
+// Configure audio formats
+await session.updateSession({
+  modalities: ["audio", "text"],
+  inputAudioFormat: "pcm16",
+  outputAudioFormat: "pcm16",
+  turnDetection: {
+    type: "server_vad",
+    threshold: 0.5,
+    silenceDurationMs: 500,
+  },
+});
+
+// Initialize audio capture and playback
+const player = new Pcm16Player(24000);
+const capture = new AudioWorkletCapture((data) => {
+  session.sendAudio(data);
+});
+
+// Handle audio output from assistant
+const subscription = session.subscribe({
+  onResponseAudioDelta: async (event) => {
+    player.enqueuePcm16(event.delta);
+  },
+  onInputAudioBufferSpeechStarted: async () => {
+    // User started speaking - stop playback (barge-in)
+    player.stop();
+  },
+});
+
+// Start capture
+await capture.start();
+await player.resume();
+
+// Cleanup
+async function cleanup() {
+  capture.stop();
+  player.stop();
+  await subscription.close();
+  await session.close();
+}
+```
+
+## Best Practices
+
+1. **Use AudioWorklet over ScriptProcessorNode** - Better performance and officially supported
+2. **Disable browser audio processing** - Set `echoCancellation: false` when server handles VAD
+3. **Handle barge-in** - Clear playback buffer when user starts speaking
+4. **Match sample rates** - Ensure capture matches server expectation (usually 24kHz)
+5. **Use transferable objects** - Pass `ArrayBuffer` with transfer list for efficiency
+6. **Resume AudioContext on user gesture** - Browser policy requires user interaction
+
+## See Also
+
+- [Function Calling Reference](./function-calling.md)
+- [SKILL.md](../SKILL.md) - Main skill documentation
+- [Azure Voice Live Samples](https://github.com/microsoft-foundry/voicelive-samples)

--- a/skills/typescript/foundry/voicelive/references/function-calling.md
+++ b/skills/typescript/foundry/voicelive/references/function-calling.md
@@ -1,0 +1,500 @@
+# Function Calling Reference
+
+Tool definitions and function call handling patterns for Azure AI Voice Live using the @azure/ai-voicelive TypeScript SDK.
+
+## Overview
+
+Voice Live supports function calling (tools) that allow the voice assistant to execute actions and retrieve information during a conversation. This reference covers tool definitions, handling function call events, and sending function results.
+
+## Tool Definition Schema
+
+Tools are defined using JSON Schema in the session configuration:
+
+```typescript
+interface FunctionTool {
+  type: "function";
+  name: string;
+  description?: string;
+  parameters?: {
+    type: "object";
+    properties: Record<string, {
+      type: string;
+      description?: string;
+      enum?: string[];
+    }>;
+    required?: string[];
+  };
+}
+```
+
+## Session Configuration with Tools
+
+```typescript
+import { VoiceLiveClient } from "@azure/ai-voicelive";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new VoiceLiveClient(endpoint, new DefaultAzureCredential());
+const session = await client.startSession("gpt-4o-mini-realtime-preview");
+
+await session.updateSession({
+  modalities: ["audio", "text"],
+  instructions: "You are a helpful assistant with access to weather data.",
+  voice: {
+    type: "azure-standard",
+    name: "en-US-AvaNeural",
+  },
+  turnDetection: {
+    type: "server_vad",
+    threshold: 0.5,
+    silenceDurationMs: 500,
+  },
+  tools: [
+    {
+      type: "function",
+      name: "get_weather",
+      description: "Get the current weather for a location",
+      parameters: {
+        type: "object",
+        properties: {
+          location: {
+            type: "string",
+            description: "City and state, e.g., San Francisco, CA",
+          },
+          unit: {
+            type: "string",
+            enum: ["celsius", "fahrenheit"],
+            description: "Temperature unit",
+          },
+        },
+        required: ["location"],
+      },
+    },
+    {
+      type: "function",
+      name: "search_products",
+      description: "Search for products in the catalog",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query",
+          },
+          category: {
+            type: "string",
+            enum: ["electronics", "clothing", "home", "sports"],
+          },
+          max_results: {
+            type: "integer",
+            description: "Maximum number of results to return",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  ],
+  toolChoice: "auto",  // "auto", "none", "required", or { type: "function", name: "..." }
+});
+```
+
+## Handling Function Calls
+
+### Basic Pattern
+
+```typescript
+const subscription = session.subscribe({
+  onResponseFunctionCallArgumentsDone: async (event, context) => {
+    console.log(`Function called: ${event.name}`);
+    console.log(`Call ID: ${event.callId}`);
+    console.log(`Arguments: ${event.arguments}`);
+
+    // Parse arguments
+    const args = JSON.parse(event.arguments);
+
+    // Execute function based on name
+    let result: string;
+    
+    switch (event.name) {
+      case "get_weather":
+        result = await getWeather(args.location, args.unit ?? "celsius");
+        break;
+      case "search_products":
+        result = await searchProducts(args.query, args.category, args.max_results);
+        break;
+      default:
+        result = JSON.stringify({ error: `Unknown function: ${event.name}` });
+    }
+
+    // Send function result back
+    await session.addConversationItem({
+      type: "function_call_output",
+      callId: event.callId,
+      output: result,
+    });
+
+    // Trigger response generation
+    await session.sendEvent({ type: "response.create" });
+  },
+});
+```
+
+### Complete Example with Multiple Tools
+
+```typescript
+import { VoiceLiveClient, VoiceLiveSession } from "@azure/ai-voicelive";
+import { DefaultAzureCredential } from "@azure/identity";
+
+// Function implementations
+async function getWeather(location: string, unit: string): Promise<string> {
+  // In production, call actual weather API
+  const temp = unit === "celsius" ? "22°C" : "72°F";
+  return JSON.stringify({
+    location,
+    temperature: temp,
+    conditions: "Partly cloudy",
+    humidity: "45%",
+  });
+}
+
+async function searchProducts(
+  query: string,
+  category?: string,
+  maxResults = 5
+): Promise<string> {
+  // In production, query product database
+  const products = [
+    { id: "1", name: `${query} - Premium`, price: 99.99 },
+    { id: "2", name: `${query} - Standard`, price: 49.99 },
+  ];
+  return JSON.stringify({
+    query,
+    category: category ?? "all",
+    results: products.slice(0, maxResults),
+  });
+}
+
+async function bookAppointment(
+  date: string,
+  time: string,
+  service: string
+): Promise<string> {
+  // In production, book in calendar system
+  return JSON.stringify({
+    success: true,
+    confirmation: `APT-${Date.now()}`,
+    date,
+    time,
+    service,
+  });
+}
+
+// Function dispatcher
+async function handleFunctionCall(
+  name: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  switch (name) {
+    case "get_weather":
+      return getWeather(
+        args.location as string,
+        (args.unit as string) ?? "celsius"
+      );
+    case "search_products":
+      return searchProducts(
+        args.query as string,
+        args.category as string | undefined,
+        args.max_results as number | undefined
+      );
+    case "book_appointment":
+      return bookAppointment(
+        args.date as string,
+        args.time as string,
+        args.service as string
+      );
+    default:
+      return JSON.stringify({ error: `Unknown function: ${name}` });
+  }
+}
+
+// Main voice assistant
+async function startAssistant() {
+  const client = new VoiceLiveClient(endpoint, new DefaultAzureCredential());
+  const session = await client.startSession("gpt-4o-mini-realtime-preview");
+
+  await session.updateSession({
+    modalities: ["audio", "text"],
+    instructions: `You are a helpful assistant that can:
+      - Get weather information
+      - Search for products
+      - Book appointments
+      Always confirm details with the user before booking.`,
+    tools: [
+      {
+        type: "function",
+        name: "get_weather",
+        description: "Get current weather",
+        parameters: {
+          type: "object",
+          properties: {
+            location: { type: "string", description: "City name" },
+            unit: { type: "string", enum: ["celsius", "fahrenheit"] },
+          },
+          required: ["location"],
+        },
+      },
+      {
+        type: "function",
+        name: "search_products",
+        description: "Search product catalog",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+            category: { type: "string", enum: ["electronics", "clothing", "home"] },
+            max_results: { type: "integer" },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        type: "function",
+        name: "book_appointment",
+        description: "Book an appointment",
+        parameters: {
+          type: "object",
+          properties: {
+            date: { type: "string", description: "Date in YYYY-MM-DD format" },
+            time: { type: "string", description: "Time in HH:MM format" },
+            service: { type: "string", description: "Type of service" },
+          },
+          required: ["date", "time", "service"],
+        },
+      },
+    ],
+    toolChoice: "auto",
+  });
+
+  const subscription = session.subscribe({
+    onResponseFunctionCallArgumentsDone: async (event, context) => {
+      console.log(`Executing: ${event.name}`);
+      
+      try {
+        const args = JSON.parse(event.arguments);
+        const result = await handleFunctionCall(event.name, args);
+
+        await session.addConversationItem({
+          type: "function_call_output",
+          callId: event.callId,
+          output: result,
+        });
+
+        await session.sendEvent({ type: "response.create" });
+      } catch (error) {
+        // Send error as function output
+        await session.addConversationItem({
+          type: "function_call_output",
+          callId: event.callId,
+          output: JSON.stringify({ error: String(error) }),
+        });
+        await session.sendEvent({ type: "response.create" });
+      }
+    },
+
+    onResponseTextDelta: async (event) => {
+      process.stdout.write(event.delta);
+    },
+
+    onError: async (args) => {
+      console.error("Session error:", args.error);
+    },
+  });
+
+  return { session, subscription };
+}
+```
+
+## Streaming Function Arguments
+
+For long-running function calls, you can process arguments as they stream in:
+
+```typescript
+const pendingCalls = new Map<string, { name: string; arguments: string }>();
+
+const subscription = session.subscribe({
+  // Arguments arrive in chunks
+  onResponseFunctionCallArgumentsDelta: async (event, context) => {
+    const callId = event.callId;
+    
+    if (!pendingCalls.has(callId)) {
+      pendingCalls.set(callId, { name: event.name ?? "", arguments: "" });
+    }
+    
+    const pending = pendingCalls.get(callId)!;
+    if (event.name) {
+      pending.name = event.name;
+    }
+    if (event.delta) {
+      pending.arguments += event.delta;
+    }
+  },
+
+  // All arguments received
+  onResponseFunctionCallArgumentsDone: async (event, context) => {
+    const callId = event.callId;
+    const pending = pendingCalls.get(callId);
+    pendingCalls.delete(callId);
+
+    if (!pending) {
+      console.error("No pending call found for:", callId);
+      return;
+    }
+
+    // Now process the complete function call
+    const args = JSON.parse(pending.arguments || event.arguments);
+    const result = await handleFunctionCall(pending.name || event.name, args);
+
+    await session.addConversationItem({
+      type: "function_call_output",
+      callId,
+      output: result,
+    });
+
+    await session.sendEvent({ type: "response.create" });
+  },
+});
+```
+
+## Parallel Function Calls
+
+Voice Live may invoke multiple functions in parallel. Handle them all before triggering response:
+
+```typescript
+const pendingCalls = new Map<string, Promise<string>>();
+let pendingCount = 0;
+
+const subscription = session.subscribe({
+  onResponseFunctionCallArgumentsDone: async (event, context) => {
+    pendingCount++;
+    
+    // Start function execution (don't await)
+    const resultPromise = handleFunctionCall(
+      event.name,
+      JSON.parse(event.arguments)
+    );
+    pendingCalls.set(event.callId, resultPromise);
+  },
+
+  onResponseDone: async (event, context) => {
+    // Check if there are pending function calls
+    if (pendingCalls.size === 0) return;
+
+    // Wait for all functions to complete
+    for (const [callId, promise] of pendingCalls) {
+      const result = await promise;
+      await session.addConversationItem({
+        type: "function_call_output",
+        callId,
+        output: result,
+      });
+    }
+
+    pendingCalls.clear();
+    
+    // Trigger response generation after all results sent
+    await session.sendEvent({ type: "response.create" });
+  },
+});
+```
+
+## Error Handling
+
+```typescript
+const subscription = session.subscribe({
+  onResponseFunctionCallArgumentsDone: async (event, context) => {
+    try {
+      const args = JSON.parse(event.arguments);
+      const result = await handleFunctionCall(event.name, args);
+
+      await session.addConversationItem({
+        type: "function_call_output",
+        callId: event.callId,
+        output: result,
+      });
+    } catch (error) {
+      // Send error message so assistant can respond appropriately
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      
+      await session.addConversationItem({
+        type: "function_call_output",
+        callId: event.callId,
+        output: JSON.stringify({
+          error: true,
+          message: `Function execution failed: ${errorMessage}`,
+        }),
+      });
+    }
+
+    await session.sendEvent({ type: "response.create" });
+  },
+});
+```
+
+## Tool Choice Options
+
+Control how the model selects tools:
+
+```typescript
+// Auto - model decides when to use tools
+await session.updateSession({ toolChoice: "auto" });
+
+// None - disable tool usage
+await session.updateSession({ toolChoice: "none" });
+
+// Required - model must use a tool
+await session.updateSession({ toolChoice: "required" });
+
+// Force specific function
+await session.updateSession({
+  toolChoice: {
+    type: "function",
+    name: "get_weather",
+  },
+});
+```
+
+## Conversation Item Types
+
+```typescript
+// Add user message
+await session.addConversationItem({
+  type: "message",
+  role: "user",
+  content: [{ type: "text", text: "What's the weather in Seattle?" }],
+});
+
+// Add function call output
+await session.addConversationItem({
+  type: "function_call_output",
+  callId: "call_abc123",
+  output: JSON.stringify({ temperature: "72°F", conditions: "Sunny" }),
+});
+
+// Trigger response
+await session.sendEvent({ type: "response.create" });
+```
+
+## Best Practices
+
+1. **Return JSON from functions** - Structured data is easier for the model to interpret
+2. **Include error information** - Return `{ error: true, message: "..." }` on failure
+3. **Handle timeouts** - Set reasonable timeouts for external API calls
+4. **Validate arguments** - Check required fields before executing functions
+5. **Use descriptive names** - Function and parameter names help the model understand usage
+6. **Provide examples in description** - E.g., "City and state, e.g., San Francisco, CA"
+7. **Handle parallel calls** - Don't assume functions are called sequentially
+
+## See Also
+
+- [Audio Streaming Reference](./audio-streaming.md)
+- [SKILL.md](../SKILL.md) - Main skill documentation
+- [Azure Voice Live API Reference](https://learn.microsoft.com/javascript/api/@azure/ai-voicelive)

--- a/skills/typescript/identity/azure-identity/SKILL.md
+++ b/skills/typescript/identity/azure-identity/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: azure-identity-typescript
+description: Authenticate to Azure services using Azure Identity SDK for JavaScript (@azure/identity). Use when configuring authentication with DefaultAzureCredential, managed identity, service principals, or interactive browser login.
+---
+
+# Azure Identity SDK for TypeScript
+
+Authenticate to Azure services with various credential types.
+
+## Installation
+
+```bash
+npm install @azure/identity
+```
+
+## Environment Variables
+
+### Service Principal (Secret)
+
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+```
+
+### Service Principal (Certificate)
+
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_CERTIFICATE_PATH=/path/to/cert.pem
+AZURE_CLIENT_CERTIFICATE_PASSWORD=<optional-password>
+```
+
+### Workload Identity (Kubernetes)
+
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/tokens/azure-identity
+```
+
+## DefaultAzureCredential (Recommended)
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+
+// Use with any Azure SDK client
+import { BlobServiceClient } from "@azure/storage-blob";
+const blobClient = new BlobServiceClient(
+  "https://<account>.blob.core.windows.net",
+  credential
+);
+```
+
+**Credential Chain Order:**
+1. EnvironmentCredential
+2. WorkloadIdentityCredential
+3. ManagedIdentityCredential
+4. VisualStudioCodeCredential
+5. AzureCliCredential
+6. AzurePowerShellCredential
+7. AzureDeveloperCliCredential
+
+## Managed Identity
+
+### System-Assigned
+
+```typescript
+import { ManagedIdentityCredential } from "@azure/identity";
+
+const credential = new ManagedIdentityCredential();
+```
+
+### User-Assigned (by Client ID)
+
+```typescript
+const credential = new ManagedIdentityCredential({
+  clientId: "<user-assigned-client-id>"
+});
+```
+
+### User-Assigned (by Resource ID)
+
+```typescript
+const credential = new ManagedIdentityCredential({
+  resourceId: "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>"
+});
+```
+
+## Service Principal
+
+### Client Secret
+
+```typescript
+import { ClientSecretCredential } from "@azure/identity";
+
+const credential = new ClientSecretCredential(
+  "<tenant-id>",
+  "<client-id>",
+  "<client-secret>"
+);
+```
+
+### Client Certificate
+
+```typescript
+import { ClientCertificateCredential } from "@azure/identity";
+
+const credential = new ClientCertificateCredential(
+  "<tenant-id>",
+  "<client-id>",
+  { certificatePath: "/path/to/cert.pem" }
+);
+
+// With password
+const credentialWithPwd = new ClientCertificateCredential(
+  "<tenant-id>",
+  "<client-id>",
+  { 
+    certificatePath: "/path/to/cert.pem",
+    certificatePassword: "<password>"
+  }
+);
+```
+
+## Interactive Authentication
+
+### Browser-Based Login
+
+```typescript
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  loginHint: "user@example.com"
+});
+```
+
+### Device Code Flow
+
+```typescript
+import { DeviceCodeCredential } from "@azure/identity";
+
+const credential = new DeviceCodeCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  userPromptCallback: (info) => {
+    console.log(info.message);
+    // "To sign in, use a web browser to open..."
+  }
+});
+```
+
+## Custom Credential Chain
+
+```typescript
+import { 
+  ChainedTokenCredential,
+  ManagedIdentityCredential,
+  AzureCliCredential
+} from "@azure/identity";
+
+// Try managed identity first, fall back to CLI
+const credential = new ChainedTokenCredential(
+  new ManagedIdentityCredential(),
+  new AzureCliCredential()
+);
+```
+
+## Developer Credentials
+
+### Azure CLI
+
+```typescript
+import { AzureCliCredential } from "@azure/identity";
+
+const credential = new AzureCliCredential();
+// Uses: az login
+```
+
+### Azure Developer CLI
+
+```typescript
+import { AzureDeveloperCliCredential } from "@azure/identity";
+
+const credential = new AzureDeveloperCliCredential();
+// Uses: azd auth login
+```
+
+### Azure PowerShell
+
+```typescript
+import { AzurePowerShellCredential } from "@azure/identity";
+
+const credential = new AzurePowerShellCredential();
+// Uses: Connect-AzAccount
+```
+
+## Sovereign Clouds
+
+```typescript
+import { ClientSecretCredential, AzureAuthorityHosts } from "@azure/identity";
+
+// Azure Government
+const credential = new ClientSecretCredential(
+  "<tenant>", "<client>", "<secret>",
+  { authorityHost: AzureAuthorityHosts.AzureGovernment }
+);
+
+// Azure China
+const credentialChina = new ClientSecretCredential(
+  "<tenant>", "<client>", "<secret>",
+  { authorityHost: AzureAuthorityHosts.AzureChina }
+);
+```
+
+## Bearer Token Provider
+
+```typescript
+import { DefaultAzureCredential, getBearerTokenProvider } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+
+// Create a function that returns tokens
+const getAccessToken = getBearerTokenProvider(
+  credential,
+  "https://cognitiveservices.azure.com/.default"
+);
+
+// Use with APIs that need bearer tokens
+const token = await getAccessToken();
+```
+
+## Key Types
+
+```typescript
+import type { 
+  TokenCredential, 
+  AccessToken, 
+  GetTokenOptions 
+} from "@azure/core-auth";
+
+import {
+  DefaultAzureCredential,
+  DefaultAzureCredentialOptions,
+  ManagedIdentityCredential,
+  ClientSecretCredential,
+  ClientCertificateCredential,
+  InteractiveBrowserCredential,
+  ChainedTokenCredential,
+  AzureCliCredential,
+  AzurePowerShellCredential,
+  AzureDeveloperCliCredential,
+  DeviceCodeCredential,
+  AzureAuthorityHosts
+} from "@azure/identity";
+```
+
+## Custom Credential Implementation
+
+```typescript
+import type { TokenCredential, AccessToken, GetTokenOptions } from "@azure/core-auth";
+
+class CustomCredential implements TokenCredential {
+  async getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions
+  ): Promise<AccessToken | null> {
+    // Custom token acquisition logic
+    return {
+      token: "<access-token>",
+      expiresOnTimestamp: Date.now() + 3600000
+    };
+  }
+}
+```
+
+## Debugging
+
+```typescript
+import { setLogLevel, AzureLogger } from "@azure/logger";
+
+setLogLevel("verbose");
+
+// Custom log handler
+AzureLogger.log = (...args) => {
+  console.log("[Azure]", ...args);
+};
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** - Works in development (CLI) and production (managed identity)
+2. **Never hardcode credentials** - Use environment variables or managed identity
+3. **Prefer managed identity** - No secrets to manage in production
+4. **Scope credentials appropriately** - Use user-assigned identity for multi-tenant scenarios
+5. **Handle token refresh** - Azure SDK handles this automatically
+6. **Use ChainedTokenCredential** - For custom fallback scenarios

--- a/skills/typescript/identity/azure-identity/references/browser-auth.md
+++ b/skills/typescript/identity/azure-identity/references/browser-auth.md
@@ -1,0 +1,391 @@
+# Browser Authentication Reference
+
+Browser-based authentication for Azure services using the @azure/identity TypeScript SDK.
+
+## Overview
+
+Browser applications require special credential types that handle OAuth redirects and popup windows. This reference covers `InteractiveBrowserCredential`, `BrowserCustomizationOptions`, and SPA authentication patterns.
+
+## Installation
+
+```bash
+npm install @azure/identity
+```
+
+**Note:** Browser credentials require a bundler (Vite, webpack, etc.) and won't work in Node.js.
+
+## InteractiveBrowserCredential
+
+The primary credential for browser applications.
+
+```typescript
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+const credential = new InteractiveBrowserCredential({
+  clientId: "<your-app-client-id>",
+  tenantId: "<your-tenant-id>",
+});
+
+// Use with Azure SDK clients
+import { BlobServiceClient } from "@azure/storage-blob";
+const blobClient = new BlobServiceClient(
+  "https://myaccount.blob.core.windows.net",
+  credential
+);
+```
+
+## App Registration Requirements
+
+Your Azure AD app registration needs:
+
+1. **Platform:** Single-page application (SPA)
+2. **Redirect URIs:** 
+   - `http://localhost:3000` (development)
+   - `https://yourapp.com` (production)
+3. **API Permissions:** Configure based on services you're accessing
+4. **Implicit grant:** Access tokens (for MSAL.js implicit flow)
+
+## Authentication Modes
+
+### Popup Mode (Default)
+
+```typescript
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  // Popup is default - no loginStyle needed
+});
+
+// Triggers popup on first getToken call
+const token = await credential.getToken("https://storage.azure.com/.default");
+```
+
+### Redirect Mode
+
+```typescript
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  loginStyle: "redirect",
+  redirectUri: window.location.origin, // Must match app registration
+});
+
+// Redirects to Azure AD, then back to your app
+const token = await credential.getToken("https://storage.azure.com/.default");
+```
+
+### Handling Redirect Response
+
+```typescript
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+// On app load, check for redirect response
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  loginStyle: "redirect",
+  redirectUri: window.location.origin,
+});
+
+// This will handle the response if returning from redirect
+try {
+  const token = await credential.getToken("https://storage.azure.com/.default");
+  console.log("Authenticated successfully");
+} catch (error) {
+  console.error("Authentication failed:", error);
+}
+```
+
+## Configuration Options
+
+```typescript
+interface InteractiveBrowserCredentialNodeOptions {
+  /** Application client ID */
+  clientId: string;
+  
+  /** Azure AD tenant ID */
+  tenantId?: string;
+  
+  /** Redirect URI (must match app registration) */
+  redirectUri?: string;
+  
+  /** Login style: "popup" or "redirect" */
+  loginStyle?: "popup" | "redirect";
+  
+  /** Pre-fill username hint */
+  loginHint?: string;
+  
+  /** Force re-authentication */
+  disableAutomaticAuthentication?: boolean;
+  
+  /** Authority host for sovereign clouds */
+  authorityHost?: string;
+  
+  /** Custom browser customization */
+  browserCustomizationOptions?: BrowserCustomizationOptions;
+}
+```
+
+## Login Hint
+
+Pre-fill the username to skip account selection:
+
+```typescript
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  loginHint: "user@example.com", // Pre-fills email
+});
+```
+
+## Token Caching
+
+The credential automatically caches tokens in browser storage:
+
+```typescript
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+});
+
+// First call - triggers interactive login
+await credential.getToken("https://storage.azure.com/.default");
+
+// Subsequent calls - uses cached token (no prompt)
+await credential.getToken("https://storage.azure.com/.default");
+```
+
+## Silent Authentication
+
+Attempt silent auth first, fall back to interactive:
+
+```typescript
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  disableAutomaticAuthentication: true, // Don't auto-prompt
+});
+
+async function getTokenSilentlyOrInteractive(scope: string): Promise<string> {
+  try {
+    // Try silent first
+    const token = await credential.getToken(scope);
+    return token.token;
+  } catch (error) {
+    // Silent failed - trigger interactive
+    const token = await credential.authenticate(scope);
+    return token.token;
+  }
+}
+```
+
+## Multi-Tenant Applications
+
+```typescript
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "common", // Allow any Azure AD tenant
+  // Or "organizations" for work/school accounts only
+  // Or "consumers" for personal Microsoft accounts only
+});
+```
+
+## React Integration Example
+
+```typescript
+// auth.ts
+import { InteractiveBrowserCredential } from "@azure/identity";
+
+let credentialInstance: InteractiveBrowserCredential | null = null;
+
+export function getCredential(): InteractiveBrowserCredential {
+  if (!credentialInstance) {
+    credentialInstance = new InteractiveBrowserCredential({
+      clientId: import.meta.env.VITE_AZURE_CLIENT_ID,
+      tenantId: import.meta.env.VITE_AZURE_TENANT_ID,
+      redirectUri: window.location.origin,
+    });
+  }
+  return credentialInstance;
+}
+
+export async function login(): Promise<void> {
+  const credential = getCredential();
+  await credential.authenticate(["https://storage.azure.com/.default"]);
+}
+
+// App.tsx
+import { useState } from "react";
+import { BlobServiceClient } from "@azure/storage-blob";
+import { getCredential, login } from "./auth";
+
+function App() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  
+  const handleLogin = async () => {
+    try {
+      await login();
+      setIsAuthenticated(true);
+    } catch (error) {
+      console.error("Login failed:", error);
+    }
+  };
+  
+  const listBlobs = async () => {
+    const credential = getCredential();
+    const client = new BlobServiceClient(
+      "https://myaccount.blob.core.windows.net",
+      credential
+    );
+    
+    for await (const container of client.listContainers()) {
+      console.log(container.name);
+    }
+  };
+  
+  return (
+    <div>
+      {!isAuthenticated ? (
+        <button onClick={handleLogin}>Login with Azure</button>
+      ) : (
+        <button onClick={listBlobs}>List Blobs</button>
+      )}
+    </div>
+  );
+}
+```
+
+## Error Handling
+
+```typescript
+import { 
+  InteractiveBrowserCredential,
+  AuthenticationRequiredError,
+  CredentialUnavailableError
+} from "@azure/identity";
+
+const credential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+});
+
+try {
+  const token = await credential.getToken("https://storage.azure.com/.default");
+} catch (error) {
+  if (error instanceof AuthenticationRequiredError) {
+    // User needs to authenticate
+    console.log("Please sign in");
+    await credential.authenticate(["https://storage.azure.com/.default"]);
+  } else if (error instanceof CredentialUnavailableError) {
+    // Credential not usable in this environment
+    console.error("Browser authentication not available");
+  } else {
+    // Other error (network, consent denied, etc.)
+    console.error("Authentication error:", error);
+  }
+}
+```
+
+## Logout
+
+The credential doesn't provide direct logout. Use MSAL.js or redirect to logout URL:
+
+```typescript
+function logout() {
+  const logoutUrl = new URL(
+    `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/logout`
+  );
+  logoutUrl.searchParams.set("post_logout_redirect_uri", window.location.origin);
+  
+  window.location.href = logoutUrl.toString();
+}
+```
+
+## Sovereign Clouds
+
+```typescript
+import { 
+  InteractiveBrowserCredential, 
+  AzureAuthorityHosts 
+} from "@azure/identity";
+
+// Azure Government
+const govCredential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  authorityHost: AzureAuthorityHosts.AzureGovernment,
+});
+
+// Azure China
+const chinaCredential = new InteractiveBrowserCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  authorityHost: AzureAuthorityHosts.AzureChina,
+});
+```
+
+## DeviceCodeCredential (Alternative)
+
+For environments without browser capability (CLI tools, IoT):
+
+```typescript
+import { DeviceCodeCredential } from "@azure/identity";
+
+const credential = new DeviceCodeCredential({
+  clientId: "<client-id>",
+  tenantId: "<tenant-id>",
+  userPromptCallback: (info) => {
+    // Display to user
+    console.log(info.message);
+    // "To sign in, use a web browser to open the page
+    //  https://microsoft.com/devicelogin and enter the code ABC123"
+  },
+});
+
+const token = await credential.getToken("https://storage.azure.com/.default");
+```
+
+## CORS Configuration
+
+Azure services need CORS configured for browser access:
+
+**Azure Storage:**
+```typescript
+import { BlobServiceClient } from "@azure/storage-blob";
+
+// Configure CORS via Azure Portal or CLI:
+// az storage cors add --services b --methods GET,PUT,POST,DELETE,HEAD \
+//   --origins "http://localhost:3000" --allowed-headers "*" \
+//   --exposed-headers "*" --max-age 3600 --account-name <account>
+```
+
+## Best Practices
+
+1. **Use popup for UX** — Better user experience than redirect
+2. **Handle redirect on load** — Check for redirect response on app initialization
+3. **Cache the credential instance** — Don't create new instances repeatedly
+4. **Configure CORS** — Required for browser-to-Azure communication
+5. **Use environment variables** — Don't hardcode client IDs
+6. **Handle authentication errors** — Provide clear feedback to users
+7. **Implement logout** — Clear session and redirect to Azure logout
+8. **Test both flows** — Popup may be blocked; redirect is fallback
+
+## Security Considerations
+
+- Never expose client secrets in browser code
+- Use SPA platform type in app registration (PKCE)
+- Validate tokens server-side for sensitive operations
+- Configure appropriate redirect URIs
+- Use secure (HTTPS) redirect URIs in production
+
+## See Also
+
+- [Credential Types Reference](./credential-types.md)
+- [MSAL.js Documentation](https://learn.microsoft.com/azure/active-directory/develop/msal-js-initializing-client-applications)
+- [SPA Authentication](https://learn.microsoft.com/azure/active-directory/develop/scenario-spa-overview)

--- a/skills/typescript/identity/azure-identity/references/credential-types.md
+++ b/skills/typescript/identity/azure-identity/references/credential-types.md
@@ -1,0 +1,394 @@
+# Credential Types Reference
+
+Azure Identity credential types for authenticating to Azure services using the @azure/identity TypeScript SDK.
+
+## Overview
+
+The Azure Identity library provides various credential classes for different authentication scenarios. Choose the right credential based on your environment and security requirements.
+
+## Credential Selection Guide
+
+| Scenario | Recommended Credential |
+|----------|------------------------|
+| Production (any environment) | `DefaultAzureCredential` |
+| Azure VM/App Service | `ManagedIdentityCredential` |
+| Service Principal (secret) | `ClientSecretCredential` |
+| Service Principal (cert) | `ClientCertificateCredential` |
+| Local development | `AzureCliCredential` or `AzureDeveloperCliCredential` |
+| Browser application | `InteractiveBrowserCredential` |
+| CI/CD pipeline | `ClientSecretCredential` or `WorkloadIdentityCredential` |
+| Kubernetes (AKS) | `WorkloadIdentityCredential` |
+
+## DefaultAzureCredential (Recommended)
+
+The most versatile credential - automatically tries multiple authentication methods.
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+
+// Works in all environments - dev and production
+import { BlobServiceClient } from "@azure/storage-blob";
+const blobClient = new BlobServiceClient(
+  "https://myaccount.blob.core.windows.net",
+  credential
+);
+```
+
+**Credential Chain Order:**
+1. `EnvironmentCredential` — Service principal from env vars
+2. `WorkloadIdentityCredential` — Kubernetes workload identity
+3. `ManagedIdentityCredential` — Azure managed identity
+4. `AzureDeveloperCliCredential` — `azd auth login`
+5. `AzureCliCredential` — `az login`
+6. `AzurePowerShellCredential` — `Connect-AzAccount`
+
+### Customizing DefaultAzureCredential
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+
+const credential = new DefaultAzureCredential({
+  // Exclude specific credentials
+  excludeAzureCliCredential: true,
+  excludeAzurePowerShellCredential: true,
+  
+  // For user-assigned managed identity
+  managedIdentityClientId: "<client-id>",
+  
+  // Tenant hint for multi-tenant
+  tenantId: "<tenant-id>",
+});
+```
+
+## ManagedIdentityCredential
+
+For Azure-hosted resources (VMs, App Service, Functions, AKS).
+
+```typescript
+import { ManagedIdentityCredential } from "@azure/identity";
+
+// System-assigned managed identity
+const credential = new ManagedIdentityCredential();
+
+// User-assigned managed identity (by client ID)
+const credentialByClientId = new ManagedIdentityCredential({
+  clientId: "<user-assigned-client-id>"
+});
+
+// User-assigned managed identity (by resource ID)
+const credentialByResourceId = new ManagedIdentityCredential({
+  resourceId: "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>"
+});
+```
+
+## ClientSecretCredential
+
+For service principal authentication with a client secret.
+
+```typescript
+import { ClientSecretCredential } from "@azure/identity";
+
+const credential = new ClientSecretCredential(
+  "<tenant-id>",
+  "<client-id>",
+  "<client-secret>"
+);
+
+// From environment variables
+const credentialFromEnv = new ClientSecretCredential(
+  process.env.AZURE_TENANT_ID!,
+  process.env.AZURE_CLIENT_ID!,
+  process.env.AZURE_CLIENT_SECRET!
+);
+```
+
+**Required Environment Variables:**
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+```
+
+## ClientCertificateCredential
+
+For service principal authentication with a certificate (more secure than secret).
+
+```typescript
+import { ClientCertificateCredential } from "@azure/identity";
+
+// Certificate from file path
+const credential = new ClientCertificateCredential(
+  "<tenant-id>",
+  "<client-id>",
+  { certificatePath: "/path/to/cert.pem" }
+);
+
+// Certificate with password
+const credentialWithPassword = new ClientCertificateCredential(
+  "<tenant-id>",
+  "<client-id>",
+  {
+    certificatePath: "/path/to/cert.pfx",
+    certificatePassword: "<password>"
+  }
+);
+
+// Certificate from PEM string
+const credentialFromString = new ClientCertificateCredential(
+  "<tenant-id>",
+  "<client-id>",
+  { certificate: "-----BEGIN CERTIFICATE-----\n..." }
+);
+```
+
+## WorkloadIdentityCredential
+
+For Kubernetes workload identity (AKS, Azure Arc).
+
+```typescript
+import { WorkloadIdentityCredential } from "@azure/identity";
+
+// Uses environment variables automatically set by AKS
+const credential = new WorkloadIdentityCredential();
+
+// Explicit configuration
+const credentialExplicit = new WorkloadIdentityCredential({
+  tenantId: "<tenant-id>",
+  clientId: "<client-id>",
+  tokenFilePath: "/var/run/secrets/azure/tokens/azure-identity-token"
+});
+```
+
+**Required Environment Variables (set by AKS):**
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/tokens/azure-identity
+```
+
+## Developer Credentials
+
+### AzureCliCredential
+
+```typescript
+import { AzureCliCredential } from "@azure/identity";
+
+// Uses token from: az login
+const credential = new AzureCliCredential();
+
+// With tenant hint
+const credentialWithTenant = new AzureCliCredential({
+  tenantId: "<tenant-id>"
+});
+```
+
+### AzureDeveloperCliCredential
+
+```typescript
+import { AzureDeveloperCliCredential } from "@azure/identity";
+
+// Uses token from: azd auth login
+const credential = new AzureDeveloperCliCredential();
+```
+
+### AzurePowerShellCredential
+
+```typescript
+import { AzurePowerShellCredential } from "@azure/identity";
+
+// Uses token from: Connect-AzAccount
+const credential = new AzurePowerShellCredential();
+```
+
+### VisualStudioCodeCredential
+
+```typescript
+import { VisualStudioCodeCredential } from "@azure/identity";
+
+// Uses Azure Account extension in VS Code
+const credential = new VisualStudioCodeCredential();
+```
+
+## ChainedTokenCredential
+
+Create custom credential chains for specific scenarios.
+
+```typescript
+import {
+  ChainedTokenCredential,
+  ManagedIdentityCredential,
+  AzureCliCredential,
+  ClientSecretCredential
+} from "@azure/identity";
+
+// Try managed identity first, then CLI
+const credential = new ChainedTokenCredential(
+  new ManagedIdentityCredential(),
+  new AzureCliCredential()
+);
+
+// Production: managed identity → service principal fallback
+const productionCredential = new ChainedTokenCredential(
+  new ManagedIdentityCredential(),
+  new ClientSecretCredential(
+    process.env.AZURE_TENANT_ID!,
+    process.env.AZURE_CLIENT_ID!,
+    process.env.AZURE_CLIENT_SECRET!
+  )
+);
+```
+
+## EnvironmentCredential
+
+Automatically selects credential based on environment variables.
+
+```typescript
+import { EnvironmentCredential } from "@azure/identity";
+
+// Checks env vars and creates appropriate credential
+const credential = new EnvironmentCredential();
+```
+
+**Supported Environment Variable Sets:**
+
+Service Principal (Secret):
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_SECRET=<client-secret>
+```
+
+Service Principal (Certificate):
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_CLIENT_CERTIFICATE_PATH=/path/to/cert.pem
+AZURE_CLIENT_CERTIFICATE_PASSWORD=<optional>
+```
+
+Username/Password (not recommended):
+```bash
+AZURE_TENANT_ID=<tenant-id>
+AZURE_CLIENT_ID=<client-id>
+AZURE_USERNAME=<username>
+AZURE_PASSWORD=<password>
+```
+
+## TokenCredential Interface
+
+All credentials implement `TokenCredential`:
+
+```typescript
+import type { TokenCredential, AccessToken, GetTokenOptions } from "@azure/core-auth";
+
+interface TokenCredential {
+  getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions
+  ): Promise<AccessToken | null>;
+}
+
+interface AccessToken {
+  token: string;
+  expiresOnTimestamp: number;
+}
+```
+
+### Custom Credential Implementation
+
+```typescript
+import type { TokenCredential, AccessToken, GetTokenOptions } from "@azure/core-auth";
+
+class CustomCredential implements TokenCredential {
+  async getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions
+  ): Promise<AccessToken | null> {
+    // Custom token acquisition logic
+    const token = await fetchTokenFromCustomSource(scopes);
+    
+    return {
+      token: token.accessToken,
+      expiresOnTimestamp: token.expiresOn.getTime()
+    };
+  }
+}
+```
+
+## Sovereign Clouds
+
+```typescript
+import { 
+  ClientSecretCredential, 
+  AzureAuthorityHosts 
+} from "@azure/identity";
+
+// Azure Government
+const govCredential = new ClientSecretCredential(
+  "<tenant>", "<client>", "<secret>",
+  { authorityHost: AzureAuthorityHosts.AzureGovernment }
+);
+
+// Azure China (21Vianet)
+const chinaCredential = new ClientSecretCredential(
+  "<tenant>", "<client>", "<secret>",
+  { authorityHost: AzureAuthorityHosts.AzureChina }
+);
+
+// Available authority hosts
+// AzureAuthorityHosts.AzurePublicCloud (default)
+// AzureAuthorityHosts.AzureGovernment
+// AzureAuthorityHosts.AzureChina
+```
+
+## Bearer Token Provider
+
+For APIs that need raw tokens:
+
+```typescript
+import { DefaultAzureCredential, getBearerTokenProvider } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+
+// Create token provider for specific scope
+const getAccessToken = getBearerTokenProvider(
+  credential,
+  "https://cognitiveservices.azure.com/.default"
+);
+
+// Get token when needed
+const token = await getAccessToken();
+console.log(`Bearer ${token}`);
+```
+
+## Debugging
+
+```typescript
+import { setLogLevel, AzureLogger } from "@azure/logger";
+
+// Enable verbose logging
+setLogLevel("verbose");
+
+// Custom log handler
+AzureLogger.log = (...args) => {
+  console.log("[Azure Identity]", ...args);
+};
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** — Works across all environments
+2. **Never hardcode credentials** — Use environment variables or managed identity
+3. **Prefer managed identity** — No secrets to manage
+4. **Use certificates over secrets** — More secure, easier to rotate
+5. **Scope user-assigned identity** — Use for multi-tenant or specific permissions
+6. **Enable logging for debugging** — Helps diagnose auth issues
+7. **Handle token refresh** — Azure SDK handles this automatically
+
+## See Also
+
+- [Browser Authentication Reference](./browser-auth.md)
+- [Azure Identity Best Practices](https://learn.microsoft.com/azure/developer/javascript/sdk/authentication/)
+- [Managed Identity Overview](https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview)

--- a/skills/typescript/integration/appconfiguration/SKILL.md
+++ b/skills/typescript/integration/appconfiguration/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: azure-app-configuration-typescript
+description: Build applications using Azure App Configuration SDK for JavaScript (@azure/app-configuration). Use when working with configuration settings, feature flags, Key Vault references, dynamic refresh, or centralized configuration management.
+---
+
+# Azure App Configuration SDK for TypeScript
+
+Centralized configuration management with feature flags and dynamic refresh.
+
+## Installation
+
+```bash
+# Low-level CRUD SDK
+npm install @azure/app-configuration @azure/identity
+
+# High-level provider (recommended for apps)
+npm install @azure/app-configuration-provider @azure/identity
+
+# Feature flag management
+npm install @microsoft/feature-management
+```
+
+## Environment Variables
+
+```bash
+AZURE_APPCONFIG_ENDPOINT=https://<your-resource>.azconfig.io
+# OR
+AZURE_APPCONFIG_CONNECTION_STRING=Endpoint=https://...;Id=...;Secret=...
+```
+
+## Authentication
+
+```typescript
+import { AppConfigurationClient } from "@azure/app-configuration";
+import { DefaultAzureCredential } from "@azure/identity";
+
+// DefaultAzureCredential (recommended)
+const client = new AppConfigurationClient(
+  process.env.AZURE_APPCONFIG_ENDPOINT!,
+  new DefaultAzureCredential()
+);
+
+// Connection string
+const client2 = new AppConfigurationClient(
+  process.env.AZURE_APPCONFIG_CONNECTION_STRING!
+);
+```
+
+## CRUD Operations
+
+### Create/Update Settings
+
+```typescript
+// Add new (fails if exists)
+await client.addConfigurationSetting({
+  key: "app:settings:message",
+  value: "Hello World",
+  label: "production",
+  contentType: "text/plain",
+  tags: { environment: "prod" },
+});
+
+// Set (create or update)
+await client.setConfigurationSetting({
+  key: "app:settings:message",
+  value: "Updated value",
+  label: "production",
+});
+
+// Update with optimistic concurrency
+const existing = await client.getConfigurationSetting({ key: "myKey" });
+existing.value = "new value";
+await client.setConfigurationSetting(existing, { onlyIfUnchanged: true });
+```
+
+### Read Settings
+
+```typescript
+// Get single setting
+const setting = await client.getConfigurationSetting({
+  key: "app:settings:message",
+  label: "production",  // optional
+});
+console.log(setting.value);
+
+// List with filters
+const settings = client.listConfigurationSettings({
+  keyFilter: "app:*",
+  labelFilter: "production",
+});
+
+for await (const setting of settings) {
+  console.log(`${setting.key}: ${setting.value}`);
+}
+```
+
+### Delete Settings
+
+```typescript
+await client.deleteConfigurationSetting({
+  key: "app:settings:message",
+  label: "production",
+});
+```
+
+### Lock/Unlock (Read-Only)
+
+```typescript
+// Lock
+await client.setReadOnly({ key: "myKey", label: "prod" }, true);
+
+// Unlock
+await client.setReadOnly({ key: "myKey", label: "prod" }, false);
+```
+
+## App Configuration Provider
+
+### Load Configuration
+
+```typescript
+import { load } from "@azure/app-configuration-provider";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const appConfig = await load(
+  process.env.AZURE_APPCONFIG_ENDPOINT!,
+  new DefaultAzureCredential(),
+  {
+    selectors: [
+      { keyFilter: "app:*", labelFilter: "production" },
+    ],
+    trimKeyPrefixes: ["app:"],
+  }
+);
+
+// Map-style access
+const value = appConfig.get("settings:message");
+
+// Object-style access
+const config = appConfig.constructConfigurationObject({ separator: ":" });
+console.log(config.settings.message);
+```
+
+### Dynamic Refresh
+
+```typescript
+const appConfig = await load(endpoint, credential, {
+  selectors: [{ keyFilter: "app:*" }],
+  refreshOptions: {
+    enabled: true,
+    refreshIntervalInMs: 30_000,  // 30 seconds
+  },
+});
+
+// Trigger refresh (non-blocking)
+appConfig.refresh();
+
+// Listen for refresh events
+const disposer = appConfig.onRefresh(() => {
+  console.log("Configuration refreshed!");
+});
+
+// Express middleware pattern
+app.use((req, res, next) => {
+  appConfig.refresh();
+  next();
+});
+```
+
+### Key Vault References
+
+```typescript
+const appConfig = await load(endpoint, credential, {
+  selectors: [{ keyFilter: "app:*" }],
+  keyVaultOptions: {
+    credential: new DefaultAzureCredential(),
+    secretRefreshIntervalInMs: 7200_000,  // 2 hours
+  },
+});
+
+// Secrets are automatically resolved
+const dbPassword = appConfig.get("database:password");
+```
+
+## Feature Flags
+
+### Create Feature Flag (Low-Level)
+
+```typescript
+import {
+  featureFlagPrefix,
+  featureFlagContentType,
+  FeatureFlagValue,
+  ConfigurationSetting,
+} from "@azure/app-configuration";
+
+const flag: ConfigurationSetting<FeatureFlagValue> = {
+  key: `${featureFlagPrefix}Beta`,
+  contentType: featureFlagContentType,
+  value: {
+    id: "Beta",
+    enabled: true,
+    description: "Beta feature",
+    conditions: {
+      clientFilters: [
+        {
+          name: "Microsoft.Targeting",
+          parameters: {
+            Audience: {
+              Users: ["user@example.com"],
+              Groups: [{ Name: "beta-testers", RolloutPercentage: 50 }],
+              DefaultRolloutPercentage: 0,
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+await client.addConfigurationSetting(flag);
+```
+
+### Load and Evaluate Feature Flags
+
+```typescript
+import { load } from "@azure/app-configuration-provider";
+import {
+  ConfigurationMapFeatureFlagProvider,
+  FeatureManager,
+} from "@microsoft/feature-management";
+
+const appConfig = await load(endpoint, credential, {
+  featureFlagOptions: {
+    enabled: true,
+    selectors: [{ keyFilter: "*" }],
+    refresh: {
+      enabled: true,
+      refreshIntervalInMs: 30_000,
+    },
+  },
+});
+
+const featureProvider = new ConfigurationMapFeatureFlagProvider(appConfig);
+const featureManager = new FeatureManager(featureProvider);
+
+// Simple check
+const isEnabled = await featureManager.isEnabled("Beta");
+
+// With targeting context
+const isEnabledForUser = await featureManager.isEnabled("Beta", {
+  userId: "user@example.com",
+  groups: ["beta-testers"],
+});
+```
+
+## Snapshots
+
+```typescript
+// Create snapshot
+const snapshot = await client.beginCreateSnapshotAndWait({
+  name: "release-v1.0",
+  retentionPeriod: 2592000,  // 30 days
+  filters: [{ keyFilter: "app:*", labelFilter: "production" }],
+});
+
+// Get snapshot
+const snap = await client.getSnapshot("release-v1.0");
+
+// List settings in snapshot
+const settings = client.listConfigurationSettingsForSnapshot("release-v1.0");
+for await (const setting of settings) {
+  console.log(`${setting.key}: ${setting.value}`);
+}
+
+// Archive/recover
+await client.archiveSnapshot("release-v1.0");
+await client.recoverSnapshot("release-v1.0");
+
+// Load from snapshot (provider)
+const config = await load(endpoint, credential, {
+  selectors: [{ snapshotName: "release-v1.0" }],
+});
+```
+
+## Labels
+
+```typescript
+// Create settings with labels
+await client.setConfigurationSetting({
+  key: "database:host",
+  value: "dev-db.example.com",
+  label: "development",
+});
+
+await client.setConfigurationSetting({
+  key: "database:host",
+  value: "prod-db.example.com",
+  label: "production",
+});
+
+// Filter by label
+const prodSettings = client.listConfigurationSettings({
+  keyFilter: "*",
+  labelFilter: "production",
+});
+
+// No label (null label)
+const noLabelSettings = client.listConfigurationSettings({
+  labelFilter: "\0",
+});
+
+// List available labels
+for await (const label of client.listLabels()) {
+  console.log(label.name);
+}
+```
+
+## Key Types
+
+```typescript
+import {
+  AppConfigurationClient,
+  ConfigurationSetting,
+  FeatureFlagValue,
+  SecretReferenceValue,
+  featureFlagPrefix,
+  featureFlagContentType,
+  secretReferenceContentType,
+  ListConfigurationSettingsOptions,
+} from "@azure/app-configuration";
+
+import { load } from "@azure/app-configuration-provider";
+
+import {
+  FeatureManager,
+  ConfigurationMapFeatureFlagProvider,
+} from "@microsoft/feature-management";
+```
+
+## Best Practices
+
+1. **Use provider for apps** - `@azure/app-configuration-provider` for runtime config
+2. **Use low-level for management** - `@azure/app-configuration` for CRUD operations
+3. **Enable refresh** - For dynamic configuration updates
+4. **Use labels** - Separate configurations by environment
+5. **Use snapshots** - For immutable release configurations
+6. **Sentinel pattern** - Use a sentinel key to trigger full refresh
+7. **RBAC roles** - `App Configuration Data Reader` for read-only access

--- a/skills/typescript/messaging/eventhubs/SKILL.md
+++ b/skills/typescript/messaging/eventhubs/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: azure-eventhubs-typescript
+description: Build event streaming applications using Azure Event Hubs SDK for JavaScript (@azure/event-hubs). Use when implementing high-throughput event ingestion, real-time analytics, IoT telemetry, or event-driven architectures with partitioned consumers.
+---
+
+# Azure Event Hubs SDK for TypeScript
+
+High-throughput event streaming and real-time data ingestion.
+
+## Installation
+
+```bash
+npm install @azure/event-hubs @azure/identity
+```
+
+For checkpointing with consumer groups:
+```bash
+npm install @azure/eventhubs-checkpointstore-blob @azure/storage-blob
+```
+
+## Environment Variables
+
+```bash
+EVENTHUB_NAMESPACE=<namespace>.servicebus.windows.net
+EVENTHUB_NAME=my-eventhub
+STORAGE_ACCOUNT_NAME=<storage-account>
+STORAGE_CONTAINER_NAME=checkpoints
+```
+
+## Authentication
+
+```typescript
+import { EventHubProducerClient, EventHubConsumerClient } from "@azure/event-hubs";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const fullyQualifiedNamespace = process.env.EVENTHUB_NAMESPACE!;
+const eventHubName = process.env.EVENTHUB_NAME!;
+const credential = new DefaultAzureCredential();
+
+// Producer
+const producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential);
+
+// Consumer
+const consumer = new EventHubConsumerClient(
+  "$Default", // Consumer group
+  fullyQualifiedNamespace,
+  eventHubName,
+  credential
+);
+```
+
+## Core Workflow
+
+### Send Events
+
+```typescript
+const producer = new EventHubProducerClient(namespace, eventHubName, credential);
+
+// Create batch and add events
+const batch = await producer.createBatch();
+batch.tryAdd({ body: { temperature: 72.5, deviceId: "sensor-1" } });
+batch.tryAdd({ body: { temperature: 68.2, deviceId: "sensor-2" } });
+
+await producer.sendBatch(batch);
+await producer.close();
+```
+
+### Send to Specific Partition
+
+```typescript
+// By partition ID
+const batch = await producer.createBatch({ partitionId: "0" });
+
+// By partition key (consistent hashing)
+const batch = await producer.createBatch({ partitionKey: "device-123" });
+```
+
+### Receive Events (Simple)
+
+```typescript
+const consumer = new EventHubConsumerClient("$Default", namespace, eventHubName, credential);
+
+const subscription = consumer.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      console.log(`Partition: ${context.partitionId}, Body: ${JSON.stringify(event.body)}`);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(`Error on partition ${context.partitionId}: ${err.message}`);
+  },
+});
+
+// Stop after some time
+setTimeout(async () => {
+  await subscription.close();
+  await consumer.close();
+}, 60000);
+```
+
+### Receive with Checkpointing (Production)
+
+```typescript
+import { EventHubConsumerClient } from "@azure/event-hubs";
+import { ContainerClient } from "@azure/storage-blob";
+import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
+
+const containerClient = new ContainerClient(
+  `https://${storageAccount}.blob.core.windows.net/${containerName}`,
+  credential
+);
+
+const checkpointStore = new BlobCheckpointStore(containerClient);
+
+const consumer = new EventHubConsumerClient(
+  "$Default",
+  namespace,
+  eventHubName,
+  credential,
+  checkpointStore
+);
+
+const subscription = consumer.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      console.log(`Processing: ${JSON.stringify(event.body)}`);
+    }
+    // Checkpoint after processing batch
+    if (events.length > 0) {
+      await context.updateCheckpoint(events[events.length - 1]);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(`Error: ${err.message}`);
+  },
+});
+```
+
+### Receive from Specific Position
+
+```typescript
+const subscription = consumer.subscribe({
+  processEvents: async (events, context) => { /* ... */ },
+  processError: async (err, context) => { /* ... */ },
+}, {
+  startPosition: {
+    // Start from beginning
+    "0": { offset: "@earliest" },
+    // Start from end (new events only)
+    "1": { offset: "@latest" },
+    // Start from specific offset
+    "2": { offset: "12345" },
+    // Start from specific time
+    "3": { enqueuedOn: new Date("2024-01-01") },
+  },
+});
+```
+
+## Event Hub Properties
+
+```typescript
+// Get hub info
+const hubProperties = await producer.getEventHubProperties();
+console.log(`Partitions: ${hubProperties.partitionIds}`);
+
+// Get partition info
+const partitionProperties = await producer.getPartitionProperties("0");
+console.log(`Last sequence: ${partitionProperties.lastEnqueuedSequenceNumber}`);
+```
+
+## Batch Processing Options
+
+```typescript
+const subscription = consumer.subscribe(
+  {
+    processEvents: async (events, context) => { /* ... */ },
+    processError: async (err, context) => { /* ... */ },
+  },
+  {
+    maxBatchSize: 100,           // Max events per batch
+    maxWaitTimeInSeconds: 30,    // Max wait for batch
+  }
+);
+```
+
+## Key Types
+
+```typescript
+import {
+  EventHubProducerClient,
+  EventHubConsumerClient,
+  EventData,
+  ReceivedEventData,
+  PartitionContext,
+  Subscription,
+  SubscriptionEventHandlers,
+  CreateBatchOptions,
+  EventPosition,
+} from "@azure/event-hubs";
+
+import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
+```
+
+## Event Properties
+
+```typescript
+// Send with properties
+const batch = await producer.createBatch();
+batch.tryAdd({
+  body: { data: "payload" },
+  properties: {
+    eventType: "telemetry",
+    deviceId: "sensor-1",
+  },
+  contentType: "application/json",
+  correlationId: "request-123",
+});
+
+// Access in receiver
+consumer.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      console.log(`Type: ${event.properties?.eventType}`);
+      console.log(`Sequence: ${event.sequenceNumber}`);
+      console.log(`Enqueued: ${event.enqueuedTimeUtc}`);
+      console.log(`Offset: ${event.offset}`);
+    }
+  },
+});
+```
+
+## Error Handling
+
+```typescript
+consumer.subscribe({
+  processEvents: async (events, context) => {
+    try {
+      for (const event of events) {
+        await processEvent(event);
+      }
+      await context.updateCheckpoint(events[events.length - 1]);
+    } catch (error) {
+      // Don't checkpoint on error - events will be reprocessed
+      console.error("Processing failed:", error);
+    }
+  },
+  processError: async (err, context) => {
+    if (err.name === "MessagingError") {
+      // Transient error - SDK will retry
+      console.warn("Transient error:", err.message);
+    } else {
+      // Fatal error
+      console.error("Fatal error:", err);
+    }
+  },
+});
+```
+
+## Best Practices
+
+1. **Use checkpointing** - Always checkpoint in production for exactly-once processing
+2. **Batch sends** - Use `createBatch()` for efficient sending
+3. **Partition keys** - Use partition keys to ensure ordering for related events
+4. **Consumer groups** - Use separate consumer groups for different processing pipelines
+5. **Handle errors gracefully** - Don't checkpoint on processing failures
+6. **Close clients** - Always close producer/consumer when done
+7. **Monitor lag** - Track `lastEnqueuedSequenceNumber` vs processed sequence

--- a/skills/typescript/messaging/eventhubs/references/checkpointing.md
+++ b/skills/typescript/messaging/eventhubs/references/checkpointing.md
@@ -1,0 +1,425 @@
+# Checkpointing Reference
+
+Persistent checkpointing with BlobCheckpointStore for Azure Event Hubs consumer applications.
+
+## Overview
+
+Checkpointing tracks the last successfully processed event position per partition. This enables:
+- **Resumption** — Continue from where you left off after restart
+- **Load balancing** — Distribute partitions across multiple consumers
+- **Exactly-once processing** — When combined with idempotent downstream operations
+
+## Installation
+
+```bash
+npm install @azure/event-hubs @azure/eventhubs-checkpointstore-blob @azure/storage-blob @azure/identity
+```
+
+## Key Interfaces
+
+```typescript
+import { CheckpointStore, Checkpoint, PartitionOwnership } from "@azure/event-hubs";
+
+// CheckpointStore interface (implemented by BlobCheckpointStore)
+interface CheckpointStore {
+  listCheckpoints(
+    fullyQualifiedNamespace: string,
+    eventHubName: string,
+    consumerGroup: string
+  ): Promise<Checkpoint[]>;
+
+  updateCheckpoint(checkpoint: Checkpoint): Promise<void>;
+
+  listOwnership(
+    fullyQualifiedNamespace: string,
+    eventHubName: string,
+    consumerGroup: string
+  ): Promise<PartitionOwnership[]>;
+
+  claimOwnership(
+    partitionOwnership: PartitionOwnership[]
+  ): Promise<PartitionOwnership[]>;
+}
+
+// Checkpoint structure
+interface Checkpoint {
+  fullyQualifiedNamespace: string;
+  eventHubName: string;
+  consumerGroup: string;
+  partitionId: string;
+  sequenceNumber: number;
+  offset: string;
+}
+
+// Partition ownership (for load balancing)
+interface PartitionOwnership {
+  fullyQualifiedNamespace: string;
+  eventHubName: string;
+  consumerGroup: string;
+  partitionId: string;
+  ownerId: string;
+  lastModifiedTimeInMs?: number;
+  etag?: string;
+}
+```
+
+## Basic Checkpointing Setup
+
+```typescript
+import { EventHubConsumerClient } from "@azure/event-hubs";
+import { ContainerClient } from "@azure/storage-blob";
+import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+
+// Storage for checkpoints
+const storageAccountName = process.env.STORAGE_ACCOUNT_NAME!;
+const containerName = "eventhub-checkpoints";
+
+const containerClient = new ContainerClient(
+  `https://${storageAccountName}.blob.core.windows.net/${containerName}`,
+  credential
+);
+
+// Ensure container exists
+await containerClient.createIfNotExists();
+
+// Create checkpoint store
+const checkpointStore = new BlobCheckpointStore(containerClient);
+
+// Create consumer with checkpoint store
+const consumerClient = new EventHubConsumerClient(
+  "$Default",
+  "my-namespace.servicebus.windows.net",
+  "my-event-hub",
+  credential,
+  checkpointStore  // Pass checkpoint store here
+);
+
+const subscription = consumerClient.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      await processEvent(event);
+    }
+    
+    // Checkpoint after successful processing
+    if (events.length > 0) {
+      await context.updateCheckpoint(events[events.length - 1]);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(`Error: ${err.message}`);
+  }
+});
+```
+
+## Connection String Authentication
+
+```typescript
+import { EventHubConsumerClient } from "@azure/event-hubs";
+import { ContainerClient } from "@azure/storage-blob";
+import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
+
+// Storage connection string
+const storageConnectionString = process.env.STORAGE_CONNECTION_STRING!;
+const containerName = "checkpoints";
+
+const containerClient = new ContainerClient(
+  storageConnectionString,
+  containerName
+);
+
+await containerClient.createIfNotExists();
+
+const checkpointStore = new BlobCheckpointStore(containerClient);
+
+// Event Hub connection string
+const eventHubConnectionString = process.env.EVENTHUB_CONNECTION_STRING!;
+const eventHubName = process.env.EVENTHUB_NAME!;
+
+const consumerClient = new EventHubConsumerClient(
+  "$Default",
+  eventHubConnectionString,
+  eventHubName,
+  checkpointStore
+);
+```
+
+## Checkpointing Strategies
+
+### Checkpoint Every Batch (Default)
+
+```typescript
+const subscription = consumerClient.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      await processEvent(event);
+    }
+    
+    // Checkpoint after every batch
+    if (events.length > 0) {
+      await context.updateCheckpoint(events[events.length - 1]);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+### Checkpoint Every N Events
+
+```typescript
+let processedCount = 0;
+const checkpointInterval = 100;
+
+const subscription = consumerClient.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      await processEvent(event);
+      processedCount++;
+      
+      // Checkpoint every N events
+      if (processedCount % checkpointInterval === 0) {
+        await context.updateCheckpoint(event);
+        console.log(`Checkpointed at ${event.sequenceNumber}`);
+      }
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+### Checkpoint on Time Interval
+
+```typescript
+let lastCheckpointTime = Date.now();
+let lastEvent: ReceivedEventData | null = null;
+const checkpointIntervalMs = 30000; // 30 seconds
+
+const subscription = consumerClient.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      await processEvent(event);
+      lastEvent = event;
+    }
+    
+    // Checkpoint based on time
+    const now = Date.now();
+    if (lastEvent && (now - lastCheckpointTime) >= checkpointIntervalMs) {
+      await context.updateCheckpoint(lastEvent);
+      lastCheckpointTime = now;
+      console.log(`Time-based checkpoint at ${lastEvent.sequenceNumber}`);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+### Checkpoint Only on Success
+
+```typescript
+const subscription = consumerClient.subscribe({
+  processEvents: async (events, context) => {
+    const results = await Promise.allSettled(
+      events.map(event => processEvent(event))
+    );
+    
+    // Find last successfully processed event
+    let lastSuccessIndex = -1;
+    for (let i = results.length - 1; i >= 0; i--) {
+      if (results[i].status === "fulfilled") {
+        lastSuccessIndex = i;
+        break;
+      }
+    }
+    
+    // Only checkpoint up to last success
+    if (lastSuccessIndex >= 0) {
+      await context.updateCheckpoint(events[lastSuccessIndex]);
+    }
+    
+    // Log failures
+    const failures = results.filter(r => r.status === "rejected");
+    if (failures.length > 0) {
+      console.error(`${failures.length} events failed processing`);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+## Load Balancing Across Consumers
+
+Multiple consumers with the same consumer group automatically balance partitions:
+
+```typescript
+// Consumer Instance 1
+const consumer1 = new EventHubConsumerClient(
+  "my-consumer-group",
+  namespace,
+  eventHubName,
+  credential,
+  checkpointStore
+);
+
+// Consumer Instance 2 (separate process)
+const consumer2 = new EventHubConsumerClient(
+  "my-consumer-group",  // Same consumer group
+  namespace,
+  eventHubName,
+  credential,
+  checkpointStore       // Same checkpoint store
+);
+
+// Both subscribe - partitions automatically distributed
+consumer1.subscribe({ /* handlers */ });
+consumer2.subscribe({ /* handlers */ });
+```
+
+## Checkpoint Store Blob Structure
+
+The BlobCheckpointStore creates blobs in this structure:
+
+```
+<container>/
+├── <namespace>/<eventhub>/<consumergroup>/checkpoint/
+│   ├── 0    (checkpoint for partition 0)
+│   ├── 1    (checkpoint for partition 1)
+│   └── ...
+└── <namespace>/<eventhub>/<consumergroup>/ownership/
+    ├── 0    (ownership for partition 0)
+    ├── 1    (ownership for partition 1)
+    └── ...
+```
+
+## Inspecting Checkpoints
+
+```typescript
+import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
+
+const checkpointStore = new BlobCheckpointStore(containerClient);
+
+// List all checkpoints
+const checkpoints = await checkpointStore.listCheckpoints(
+  "my-namespace.servicebus.windows.net",
+  "my-event-hub",
+  "$Default"
+);
+
+for (const cp of checkpoints) {
+  console.log(`Partition ${cp.partitionId}:`);
+  console.log(`  Sequence: ${cp.sequenceNumber}`);
+  console.log(`  Offset: ${cp.offset}`);
+}
+
+// List partition ownership
+const ownerships = await checkpointStore.listOwnership(
+  "my-namespace.servicebus.windows.net",
+  "my-event-hub",
+  "$Default"
+);
+
+for (const own of ownerships) {
+  console.log(`Partition ${own.partitionId}: owned by ${own.ownerId}`);
+}
+```
+
+## Error Handling
+
+```typescript
+const subscription = consumerClient.subscribe({
+  processEvents: async (events, context) => {
+    try {
+      for (const event of events) {
+        await processEvent(event);
+      }
+      
+      if (events.length > 0) {
+        await context.updateCheckpoint(events[events.length - 1]);
+      }
+    } catch (processingError) {
+      // Don't checkpoint on error - events will be reprocessed
+      console.error("Processing failed:", processingError);
+      // Optionally: send to dead letter, alert, etc.
+    }
+  },
+  
+  processError: async (err, context) => {
+    // SDK-level errors (connection, auth, etc.)
+    console.error(`SDK error on partition ${context.partitionId}:`, err.message);
+    
+    // The SDK handles reconnection automatically
+    // Consider alerting for persistent errors
+  }
+});
+```
+
+## Graceful Shutdown with Final Checkpoint
+
+```typescript
+let lastProcessedEvent: Map<string, ReceivedEventData> = new Map();
+
+const subscription = consumerClient.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      await processEvent(event);
+      lastProcessedEvent.set(context.partitionId, event);
+    }
+    
+    // Regular checkpointing
+    if (events.length > 0) {
+      await context.updateCheckpoint(events[events.length - 1]);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+
+// Graceful shutdown
+process.on("SIGTERM", async () => {
+  console.log("Shutting down gracefully...");
+  
+  // Close subscription (stops receiving)
+  await subscription.close();
+  
+  // Close consumer client
+  await consumerClient.close();
+  
+  console.log("Shutdown complete");
+  process.exit(0);
+});
+```
+
+## Best Practices
+
+1. **Checkpoint after processing** — Never before, to avoid data loss
+2. **Balance checkpoint frequency** — Too often = high storage costs; too rare = more reprocessing on restart
+3. **Use same checkpoint store** — All consumers in a group must share the same store
+4. **Create container before use** — Call `createIfNotExists()` on startup
+5. **Handle checkpoint failures** — Log and alert if `updateCheckpoint` fails repeatedly
+6. **Use consumer groups** — Separate groups for different processing pipelines
+7. **Design for reprocessing** — Make downstream operations idempotent
+
+## Checkpoint Frequency Trade-offs
+
+| Frequency | Pros | Cons |
+|-----------|------|------|
+| Every event | Minimal reprocessing | High storage I/O |
+| Every batch | Good balance | Some reprocessing possible |
+| Time-based | Predictable I/O | Variable reprocessing |
+| Every N events | Controlled I/O | May miss some on crash |
+
+## See Also
+
+- [Event Processing Reference](./event-processing.md)
+- [Azure Blob Storage](https://learn.microsoft.com/azure/storage/blobs/)
+- [Event Hubs Consumer Groups](https://learn.microsoft.com/azure/event-hubs/event-hubs-features#consumer-groups)

--- a/skills/typescript/messaging/eventhubs/references/event-processing.md
+++ b/skills/typescript/messaging/eventhubs/references/event-processing.md
@@ -1,0 +1,433 @@
+# Event Processing Reference
+
+Receiving and processing events with Azure Event Hubs using the @azure/event-hubs TypeScript SDK.
+
+## Overview
+
+Event Hubs provides high-throughput event streaming. This reference covers the EventHubConsumerClient, subscription patterns, event handlers, and processing strategies.
+
+## Key Interfaces
+
+```typescript
+import {
+  EventHubConsumerClient,
+  ReceivedEventData,
+  PartitionContext,
+  SubscriptionEventHandlers,
+  SubscribeOptions,
+  Subscription
+} from "@azure/event-hubs";
+
+// ReceivedEventData - structure of received events
+interface ReceivedEventData {
+  body: any;
+  contentType?: string;
+  correlationId?: string | number | Buffer;
+  enqueuedTimeUtc: Date;
+  messageId?: string | number | Buffer;
+  offset: string;
+  partitionKey: string | null;
+  properties?: Record<string, any>;
+  sequenceNumber: number;
+  systemProperties?: Record<string, any>;
+}
+
+// PartitionContext - context for event handlers
+interface PartitionContext {
+  readonly consumerGroup: string;
+  readonly eventHubName: string;
+  readonly fullyQualifiedNamespace: string;
+  readonly partitionId: string;
+  readonly lastEnqueuedEventProperties?: LastEnqueuedEventProperties;
+  updateCheckpoint(eventData: ReceivedEventData): Promise<void>;
+}
+
+// Handler types
+type ProcessEventsHandler = (
+  events: ReceivedEventData[],
+  context: PartitionContext
+) => Promise<void>;
+
+type ProcessErrorHandler = (
+  error: Error,
+  context: PartitionContext
+) => Promise<void>;
+
+type ProcessInitializeHandler = (
+  context: PartitionContext
+) => Promise<void>;
+
+type ProcessCloseHandler = (
+  reason: CloseReason,
+  context: PartitionContext
+) => Promise<void>;
+```
+
+## Basic Subscribe Pattern
+
+```typescript
+import { EventHubConsumerClient, earliestEventPosition } from "@azure/event-hubs";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const fullyQualifiedNamespace = "my-namespace.servicebus.windows.net";
+const eventHubName = "my-event-hub";
+const consumerGroup = "$Default";
+
+const client = new EventHubConsumerClient(
+  consumerGroup,
+  fullyQualifiedNamespace,
+  eventHubName,
+  new DefaultAzureCredential()
+);
+
+const subscription = client.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      console.log(`Partition: ${context.partitionId}`);
+      console.log(`Body: ${JSON.stringify(event.body)}`);
+      console.log(`Sequence: ${event.sequenceNumber}`);
+      console.log(`Enqueued: ${event.enqueuedTimeUtc}`);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(`Error on partition ${context.partitionId}: ${err.message}`);
+  }
+}, {
+  startPosition: earliestEventPosition
+});
+
+// Stop after some time
+setTimeout(async () => {
+  await subscription.close();
+  await client.close();
+}, 60000);
+```
+
+## Full Subscription with All Handlers
+
+```typescript
+import {
+  EventHubConsumerClient,
+  ReceivedEventData,
+  PartitionContext,
+  CloseReason,
+  earliestEventPosition,
+  latestEventPosition
+} from "@azure/event-hubs";
+
+const client = new EventHubConsumerClient(
+  "$Default",
+  connectionString,
+  eventHubName
+);
+
+const subscription = client.subscribe({
+  processInitialize: async (context: PartitionContext) => {
+    console.log(`Started receiving from partition ${context.partitionId}`);
+  },
+
+  processEvents: async (events: ReceivedEventData[], context: PartitionContext) => {
+    if (events.length === 0) {
+      console.log(`No events received. Waiting...`);
+      return;
+    }
+
+    console.log(`Received ${events.length} events from partition ${context.partitionId}`);
+    
+    for (const event of events) {
+      // Process each event
+      await processEvent(event, context);
+    }
+
+    // Checkpoint after processing batch
+    const lastEvent = events[events.length - 1];
+    await context.updateCheckpoint(lastEvent);
+  },
+
+  processError: async (err: Error, context: PartitionContext) => {
+    console.error(`Error on partition ${context.partitionId}:`);
+    console.error(err.message);
+  },
+
+  processClose: async (reason: CloseReason, context: PartitionContext) => {
+    console.log(`Stopped receiving from partition ${context.partitionId}`);
+    console.log(`Reason: ${reason}`);
+  }
+}, {
+  startPosition: earliestEventPosition,
+  maxBatchSize: 100,
+  maxWaitTimeInSeconds: 30
+});
+```
+
+## Subscribe to Specific Partition
+
+```typescript
+const client = new EventHubConsumerClient(
+  "$Default",
+  connectionString,
+  eventHubName
+);
+
+// Get partition IDs
+const partitionIds = await client.getPartitionIds();
+console.log(`Partitions: ${partitionIds.join(", ")}`);
+
+// Subscribe to specific partition
+const subscription = client.subscribe(
+  partitionIds[0], // First partition only
+  {
+    processEvents: async (events, context) => {
+      console.log(`Partition ${context.partitionId}: ${events.length} events`);
+    },
+    processError: async (err, context) => {
+      console.error(err);
+    }
+  },
+  { startPosition: earliestEventPosition }
+);
+```
+
+## Start Position Options
+
+```typescript
+import { 
+  earliestEventPosition, 
+  latestEventPosition,
+  EventPosition 
+} from "@azure/event-hubs";
+
+// Start from beginning (all historical events)
+const fromBeginning = { startPosition: earliestEventPosition };
+
+// Start from end (new events only)
+const fromEnd = { startPosition: latestEventPosition };
+
+// Start from specific offset
+const fromOffset: SubscribeOptions = {
+  startPosition: { offset: "12345" }
+};
+
+// Start from specific sequence number
+const fromSequence: SubscribeOptions = {
+  startPosition: { sequenceNumber: 1000 }
+};
+
+// Start from specific time
+const fromTime: SubscribeOptions = {
+  startPosition: { enqueuedOn: new Date("2024-01-01T00:00:00Z") }
+};
+
+// Different positions per partition
+const perPartition: SubscribeOptions = {
+  startPosition: {
+    "0": earliestEventPosition,
+    "1": latestEventPosition,
+    "2": { offset: "5000" }
+  }
+};
+```
+
+## SubscribeOptions Reference
+
+```typescript
+interface SubscribeOptions {
+  /** Starting position for reading events */
+  startPosition?: EventPosition | Record<string, EventPosition>;
+  
+  /** Max events per batch (default: varies) */
+  maxBatchSize?: number;
+  
+  /** Max wait time in seconds for a batch */
+  maxWaitTimeInSeconds?: number;
+  
+  /** Track last enqueued event info (for lag monitoring) */
+  trackLastEnqueuedEventProperties?: boolean;
+  
+  /** Owner level for exclusive access */
+  ownerLevel?: number;
+}
+```
+
+## Event Processing Patterns
+
+### Sequential Processing
+
+```typescript
+const subscription = client.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      await processEventSequentially(event);
+    }
+    await context.updateCheckpoint(events[events.length - 1]);
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+### Parallel Processing within Batch
+
+```typescript
+const subscription = client.subscribe({
+  processEvents: async (events, context) => {
+    // Process events in parallel
+    await Promise.all(
+      events.map(event => processEventAsync(event))
+    );
+    
+    // Checkpoint after all complete
+    if (events.length > 0) {
+      await context.updateCheckpoint(events[events.length - 1]);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+### With Error Handling per Event
+
+```typescript
+const subscription = client.subscribe({
+  processEvents: async (events, context) => {
+    const results = await Promise.allSettled(
+      events.map(event => processEvent(event))
+    );
+    
+    const failures = results.filter(r => r.status === "rejected");
+    if (failures.length > 0) {
+      console.error(`${failures.length} events failed processing`);
+      // Decide: checkpoint anyway or skip?
+    }
+    
+    // Checkpoint even with some failures (at-least-once)
+    if (events.length > 0) {
+      await context.updateCheckpoint(events[events.length - 1]);
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+## Monitoring Consumer Lag
+
+```typescript
+const subscription = client.subscribe({
+  processEvents: async (events, context) => {
+    // Check lag if tracking enabled
+    if (context.lastEnqueuedEventProperties) {
+      const lastEnqueued = context.lastEnqueuedEventProperties.sequenceNumber;
+      const lastProcessed = events.length > 0 
+        ? events[events.length - 1].sequenceNumber 
+        : 0;
+      
+      const lag = lastEnqueued - lastProcessed;
+      console.log(`Partition ${context.partitionId} lag: ${lag} events`);
+    }
+    
+    // Process events...
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+}, {
+  trackLastEnqueuedEventProperties: true
+});
+```
+
+## Event Properties Access
+
+```typescript
+const subscription = client.subscribe({
+  processEvents: async (events, context) => {
+    for (const event of events) {
+      // Standard properties
+      console.log(`Body: ${event.body}`);
+      console.log(`Partition Key: ${event.partitionKey}`);
+      console.log(`Sequence Number: ${event.sequenceNumber}`);
+      console.log(`Offset: ${event.offset}`);
+      console.log(`Enqueued Time: ${event.enqueuedTimeUtc}`);
+      
+      // Custom properties (set by producer)
+      if (event.properties) {
+        console.log(`Event Type: ${event.properties.eventType}`);
+        console.log(`Device ID: ${event.properties.deviceId}`);
+      }
+      
+      // System properties
+      if (event.systemProperties) {
+        console.log(`System Props: ${JSON.stringify(event.systemProperties)}`);
+      }
+      
+      // Content type
+      if (event.contentType) {
+        console.log(`Content Type: ${event.contentType}`);
+      }
+    }
+  },
+  processError: async (err, context) => {
+    console.error(err);
+  }
+});
+```
+
+## Graceful Shutdown
+
+```typescript
+let subscription: Subscription;
+
+async function start() {
+  const client = new EventHubConsumerClient(
+    "$Default",
+    connectionString,
+    eventHubName
+  );
+
+  subscription = client.subscribe({
+    processEvents: async (events, context) => {
+      // Process events...
+    },
+    processError: async (err, context) => {
+      console.error(err);
+    }
+  });
+
+  // Handle shutdown signals
+  process.on("SIGINT", async () => {
+    console.log("Shutting down...");
+    await subscription.close();
+    await client.close();
+    process.exit(0);
+  });
+
+  process.on("SIGTERM", async () => {
+    console.log("Shutting down...");
+    await subscription.close();
+    await client.close();
+    process.exit(0);
+  });
+}
+
+start().catch(console.error);
+```
+
+## Best Practices
+
+1. **Always handle empty batches** — `processEvents` may receive empty arrays
+2. **Checkpoint after processing** — Not before, to avoid data loss
+3. **Use consumer groups** — Separate groups for different processing pipelines
+4. **Monitor lag** — Enable `trackLastEnqueuedEventProperties`
+5. **Handle errors gracefully** — Don't crash on individual event failures
+6. **Close resources** — Always close subscription and client on shutdown
+7. **Set appropriate batch size** — Balance throughput vs latency
+
+## See Also
+
+- [Checkpointing Reference](./checkpointing.md)
+- [Azure Event Hubs Documentation](https://learn.microsoft.com/azure/event-hubs/)
+- [Event Hubs Quotas](https://learn.microsoft.com/azure/event-hubs/event-hubs-quotas)

--- a/skills/typescript/messaging/servicebus/SKILL.md
+++ b/skills/typescript/messaging/servicebus/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: azure-servicebus-typescript
+description: Build messaging applications using Azure Service Bus SDK for JavaScript (@azure/service-bus). Use when implementing queues, topics/subscriptions, message sessions, dead-letter handling, or enterprise messaging patterns.
+---
+
+# Azure Service Bus SDK for TypeScript
+
+Enterprise messaging with queues, topics, and subscriptions.
+
+## Installation
+
+```bash
+npm install @azure/service-bus @azure/identity
+```
+
+## Environment Variables
+
+```bash
+SERVICEBUS_NAMESPACE=<namespace>.servicebus.windows.net
+SERVICEBUS_QUEUE_NAME=my-queue
+SERVICEBUS_TOPIC_NAME=my-topic
+SERVICEBUS_SUBSCRIPTION_NAME=my-subscription
+```
+
+## Authentication
+
+```typescript
+import { ServiceBusClient } from "@azure/service-bus";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const fullyQualifiedNamespace = process.env.SERVICEBUS_NAMESPACE!;
+const client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+```
+
+## Core Workflow
+
+### Send Messages to Queue
+
+```typescript
+const sender = client.createSender("my-queue");
+
+// Single message
+await sender.sendMessages({
+  body: { orderId: "12345", amount: 99.99 },
+  contentType: "application/json",
+});
+
+// Batch messages
+const batch = await sender.createMessageBatch();
+batch.tryAddMessage({ body: "Message 1" });
+batch.tryAddMessage({ body: "Message 2" });
+await sender.sendMessages(batch);
+
+await sender.close();
+```
+
+### Receive Messages from Queue
+
+```typescript
+const receiver = client.createReceiver("my-queue");
+
+// Receive batch
+const messages = await receiver.receiveMessages(10, { maxWaitTimeInMs: 5000 });
+for (const message of messages) {
+  console.log(`Received: ${message.body}`);
+  await receiver.completeMessage(message);
+}
+
+await receiver.close();
+```
+
+### Subscribe to Messages (Event-Driven)
+
+```typescript
+const receiver = client.createReceiver("my-queue");
+
+const subscription = receiver.subscribe({
+  processMessage: async (message) => {
+    console.log(`Processing: ${message.body}`);
+    // Message auto-completed on success
+  },
+  processError: async (args) => {
+    console.error(`Error: ${args.error}`);
+  },
+});
+
+// Stop after some time
+setTimeout(async () => {
+  await subscription.close();
+  await receiver.close();
+}, 60000);
+```
+
+### Topics and Subscriptions
+
+```typescript
+// Send to topic
+const topicSender = client.createSender("my-topic");
+await topicSender.sendMessages({
+  body: { event: "order.created", data: { orderId: "123" } },
+  applicationProperties: { eventType: "order.created" },
+});
+
+// Receive from subscription
+const subscriptionReceiver = client.createReceiver("my-topic", "my-subscription");
+const messages = await subscriptionReceiver.receiveMessages(10);
+```
+
+## Message Sessions
+
+```typescript
+// Send session message
+const sender = client.createSender("session-queue");
+await sender.sendMessages({
+  body: { step: 1, data: "First step" },
+  sessionId: "workflow-123",
+});
+
+// Receive session messages
+const sessionReceiver = await client.acceptSession("session-queue", "workflow-123");
+const messages = await sessionReceiver.receiveMessages(10);
+
+// Get/set session state
+const state = await sessionReceiver.getSessionState();
+await sessionReceiver.setSessionState(Buffer.from(JSON.stringify({ progress: 50 })));
+
+await sessionReceiver.close();
+```
+
+## Dead-Letter Handling
+
+```typescript
+// Move to dead-letter
+await receiver.deadLetterMessage(message, {
+  deadLetterReason: "Validation failed",
+  deadLetterErrorDescription: "Missing required field: orderId",
+});
+
+// Process dead-letter queue
+const dlqReceiver = client.createReceiver("my-queue", { subQueueType: "deadLetter" });
+const dlqMessages = await dlqReceiver.receiveMessages(10);
+for (const msg of dlqMessages) {
+  console.log(`DLQ Reason: ${msg.deadLetterReason}`);
+  // Reprocess or log
+  await dlqReceiver.completeMessage(msg);
+}
+```
+
+## Scheduled Messages
+
+```typescript
+const sender = client.createSender("my-queue");
+
+// Schedule for future delivery
+const scheduledTime = new Date(Date.now() + 60000); // 1 minute from now
+const sequenceNumber = await sender.scheduleMessages(
+  { body: "Delayed message" },
+  scheduledTime
+);
+
+// Cancel scheduled message
+await sender.cancelScheduledMessages(sequenceNumber);
+```
+
+## Message Deferral
+
+```typescript
+// Defer message for later
+await receiver.deferMessage(message);
+
+// Receive deferred message by sequence number
+const deferredMessage = await receiver.receiveDeferredMessages(message.sequenceNumber!);
+await receiver.completeMessage(deferredMessage[0]);
+```
+
+## Peek Messages (Non-Destructive)
+
+```typescript
+const receiver = client.createReceiver("my-queue");
+
+// Peek without removing
+const peekedMessages = await receiver.peekMessages(10);
+for (const msg of peekedMessages) {
+  console.log(`Peeked: ${msg.body}`);
+}
+```
+
+## Key Types
+
+```typescript
+import {
+  ServiceBusClient,
+  ServiceBusSender,
+  ServiceBusReceiver,
+  ServiceBusSessionReceiver,
+  ServiceBusMessage,
+  ServiceBusReceivedMessage,
+  ProcessMessageCallback,
+  ProcessErrorCallback,
+} from "@azure/service-bus";
+```
+
+## Receive Modes
+
+```typescript
+// Peek-Lock (default) - message locked until completed/abandoned
+const receiver = client.createReceiver("my-queue", { receiveMode: "peekLock" });
+await receiver.completeMessage(message);   // Remove from queue
+await receiver.abandonMessage(message);    // Return to queue
+await receiver.deferMessage(message);      // Defer for later
+await receiver.deadLetterMessage(message); // Move to DLQ
+
+// Receive-and-Delete - message removed immediately
+const receiver = client.createReceiver("my-queue", { receiveMode: "receiveAndDelete" });
+```
+
+## Best Practices
+
+1. **Use Entra ID auth** - Avoid connection strings in production
+2. **Reuse clients** - Create `ServiceBusClient` once, share across senders/receivers
+3. **Close resources** - Always close senders/receivers when done
+4. **Handle errors** - Implement `processError` callback for subscription receivers
+5. **Use sessions for ordering** - When message order matters within a group
+6. **Configure dead-letter** - Always handle DLQ messages
+7. **Batch sends** - Use `createMessageBatch()` for multiple messages
+
+## Reference Documentation
+
+For detailed patterns, see:
+
+- [Queues vs Topics Patterns](references/queues-topics.md) - Queue/topic patterns, sessions, receive modes, message settlement
+- [Error Handling and Reliability](references/error-handling.md) - ServiceBusError codes, DLQ handling, lock renewal, graceful shutdown

--- a/skills/typescript/messaging/servicebus/references/error-handling.md
+++ b/skills/typescript/messaging/servicebus/references/error-handling.md
@@ -1,0 +1,399 @@
+# Error Handling and Reliability
+
+Comprehensive error handling patterns for @azure/service-bus.
+
+## ServiceBusError
+
+All Service Bus errors extend `ServiceBusError` with a `code` property:
+
+```typescript
+import { ServiceBusError } from "@azure/service-bus";
+
+try {
+  await sender.sendMessages(message);
+} catch (error) {
+  if (error instanceof ServiceBusError) {
+    console.log(`Code: ${error.code}`);
+    console.log(`Message: ${error.message}`);
+    console.log(`Retryable: ${error.retryable}`);
+    
+    handleServiceBusError(error);
+  }
+}
+```
+
+## Error Codes Reference
+
+| Code | Description | Retryable | Action |
+|------|-------------|-----------|--------|
+| `GeneralError` | Unspecified error | Maybe | Log and investigate |
+| `MessagingEntityNotFound` | Queue/topic/subscription doesn't exist | No | Check entity name, create entity |
+| `MessageLockLost` | Lock expired before settlement | No | Message will be redelivered |
+| `MessageNotFound` | Message no longer available | No | Already processed or expired |
+| `MessageSizeExceeded` | Message too large (>256KB standard, >100MB premium) | No | Reduce message size or use claim check |
+| `MessagingEntityAlreadyExists` | Entity already exists | No | Use existing entity |
+| `MessagingEntityDisabled` | Entity is disabled | No | Enable entity in portal |
+| `QuotaExceeded` | Namespace quota exceeded | No | Delete messages, upgrade tier |
+| `ServiceBusy` | Service temporarily overloaded | Yes | Retry with backoff |
+| `ServiceTimeout` | Operation timed out | Yes | Retry with backoff |
+| `ServiceCommunicationProblem` | Network/connection issue | Yes | Retry with backoff |
+| `SessionCannotBeLocked` | Session locked by another receiver | Yes | Retry or use different session |
+| `SessionLockLost` | Session lock expired | No | Re-accept session |
+| `UnauthorizedAccess` | Authentication/authorization failed | No | Check credentials/permissions |
+
+## Error Handling by Code
+
+```typescript
+function handleServiceBusError(error: ServiceBusError): void {
+  switch (error.code) {
+    case "MessagingEntityNotFound":
+      console.error(`Entity not found: ${error.message}`);
+      // Create entity or fix configuration
+      break;
+      
+    case "MessageLockLost":
+      console.warn("Message lock lost - will be redelivered");
+      // No action needed, message returns to queue
+      break;
+      
+    case "MessageSizeExceeded":
+      console.error("Message too large - use claim check pattern");
+      // Store payload in blob, send reference
+      break;
+      
+    case "QuotaExceeded":
+      console.error("Quota exceeded - namespace is full");
+      // Alert ops team, consider cleanup or upgrade
+      break;
+      
+    case "ServiceBusy":
+    case "ServiceTimeout":
+    case "ServiceCommunicationProblem":
+      if (error.retryable) {
+        console.warn(`Transient error: ${error.code} - will retry`);
+        // SDK handles retry automatically
+      }
+      break;
+      
+    case "SessionCannotBeLocked":
+      console.warn("Session busy - trying another session");
+      // Use acceptNextSession() instead
+      break;
+      
+    case "SessionLockLost":
+      console.warn("Session lock lost - re-accepting session");
+      // Re-accept the session
+      break;
+      
+    case "UnauthorizedAccess":
+      console.error("Authorization failed - check credentials");
+      // Verify RBAC roles or connection string
+      break;
+      
+    default:
+      console.error(`Unexpected error: ${error.code} - ${error.message}`);
+  }
+}
+```
+
+## ProcessErrorArgs in Subscribe
+
+When using `receiver.subscribe()`, errors are delivered via `processError`:
+
+```typescript
+import { ProcessErrorArgs } from "@azure/service-bus";
+
+receiver.subscribe({
+  processMessage: async (message) => {
+    // Process message
+  },
+  processError: async (args: ProcessErrorArgs) => {
+    console.error(`Error source: ${args.errorSource}`);
+    console.error(`Entity path: ${args.entityPath}`);
+    console.error(`Namespace: ${args.fullyQualifiedNamespace}`);
+    
+    if (args.error instanceof ServiceBusError) {
+      console.error(`Code: ${args.error.code}`);
+      console.error(`Retryable: ${args.error.retryable}`);
+    }
+    
+    // Error sources:
+    // - "receive" - Error receiving messages
+    // - "processMessageCallback" - Error in your processMessage handler
+    // - "renewLock" - Error renewing message lock
+    // - "complete" / "abandon" / "deadLetter" - Settlement errors
+    
+    switch (args.errorSource) {
+      case "receive":
+        console.log("Connection issue - SDK will reconnect");
+        break;
+      case "processMessageCallback":
+        console.log("Bug in message handler - fix code");
+        break;
+      case "renewLock":
+        console.log("Lock renewal failed - message may be redelivered");
+        break;
+    }
+  },
+});
+```
+
+## Dead Letter Queue Handling
+
+Messages that can't be processed go to the dead letter queue (DLQ):
+
+```typescript
+// Create DLQ receiver
+const dlqReceiver = client.createReceiver("my-queue", {
+  subQueueType: "deadLetter",
+});
+
+// Process dead letters
+const deadLetters = await dlqReceiver.receiveMessages(10);
+
+for (const message of deadLetters) {
+  console.log(`Dead letter reason: ${message.deadLetterReason}`);
+  console.log(`Error description: ${message.deadLetterErrorDescription}`);
+  console.log(`Original body: ${JSON.stringify(message.body)}`);
+  console.log(`Delivery count: ${message.deliveryCount}`);
+  console.log(`Enqueued time: ${message.enqueuedTimeUtc}`);
+  
+  // Analyze and fix the issue
+  if (canReprocess(message)) {
+    // Resend to main queue
+    const sender = client.createSender("my-queue");
+    await sender.sendMessages({ body: message.body });
+    await sender.close();
+  }
+  
+  // Remove from DLQ
+  await dlqReceiver.completeMessage(message);
+}
+
+await dlqReceiver.close();
+```
+
+### DLQ for Topics
+
+```typescript
+// DLQ receiver for topic subscription
+const dlqReceiver = client.createReceiver(
+  "my-topic",
+  "my-subscription",
+  { subQueueType: "deadLetter" }
+);
+```
+
+### Automatic Dead Lettering
+
+Messages are automatically dead-lettered when:
+- `deliveryCount` exceeds `maxDeliveryCount` (default: 10)
+- Message TTL expires (if `deadLetteringOnMessageExpiration` is enabled)
+- Subscription filter evaluation fails
+
+## Graceful Shutdown
+
+Always close resources in the correct order:
+
+```typescript
+const client = new ServiceBusClient(namespace, credential);
+const sender = client.createSender("my-queue");
+const receiver = client.createReceiver("my-queue");
+
+// Subscribe to messages
+const subscription = receiver.subscribe({
+  processMessage: async (msg) => { /* ... */ },
+  processError: async (args) => { /* ... */ },
+});
+
+// Graceful shutdown handler
+async function shutdown(): Promise<void> {
+  console.log("Shutting down...");
+  
+  // 1. Stop receiving new messages
+  await subscription.close();
+  
+  // 2. Close receiver (waits for in-flight messages)
+  await receiver.close();
+  
+  // 3. Close sender (waits for pending sends)
+  await sender.close();
+  
+  // 4. Close client last
+  await client.close();
+  
+  console.log("Shutdown complete");
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+```
+
+## Lock Renewal
+
+### Automatic Lock Renewal (Subscribe)
+
+```typescript
+// subscribe() automatically renews locks
+receiver.subscribe({
+  processMessage: async (message) => {
+    // Lock is auto-renewed while processing
+    await longRunningOperation(message.body);
+  },
+  processError: async (args) => { /* ... */ },
+}, {
+  // Max time to auto-renew (default: 5 minutes)
+  maxAutoLockRenewalDurationInMs: 10 * 60 * 1000, // 10 minutes
+});
+```
+
+### Manual Lock Renewal (receiveMessages)
+
+```typescript
+const [message] = await receiver.receiveMessages(1);
+
+// For long processing, manually renew lock
+const renewalInterval = setInterval(async () => {
+  try {
+    await receiver.renewMessageLock(message);
+    console.log("Lock renewed");
+  } catch (error) {
+    console.error("Lock renewal failed:", error);
+    clearInterval(renewalInterval);
+  }
+}, 30000); // Renew every 30 seconds
+
+try {
+  await longRunningOperation(message.body);
+  await receiver.completeMessage(message);
+} finally {
+  clearInterval(renewalInterval);
+}
+```
+
+### Session Lock Renewal
+
+```typescript
+const sessionReceiver = await client.acceptSession("my-queue", "session-123");
+
+// Auto-renewal for sessions
+const sessionReceiver = await client.acceptSession("my-queue", "session-123", {
+  maxAutoLockRenewalDurationInMs: 10 * 60 * 1000,
+});
+
+// Manual renewal
+await sessionReceiver.renewSessionLock();
+```
+
+## Connection Recovery
+
+The SDK automatically handles connection recovery:
+
+```typescript
+// SDK reconnects automatically on transient failures
+// No manual reconnection code needed
+
+receiver.subscribe({
+  processMessage: async (message) => {
+    // Processing continues after reconnection
+  },
+  processError: async (args) => {
+    if (args.errorSource === "receive") {
+      // Connection issue - SDK is reconnecting
+      console.log("Connection lost, SDK reconnecting...");
+    }
+  },
+});
+```
+
+## Retry Configuration
+
+Configure retry behavior at client level:
+
+```typescript
+import { ServiceBusClient } from "@azure/service-bus";
+
+const client = new ServiceBusClient(namespace, credential, {
+  retryOptions: {
+    maxRetries: 3,
+    retryDelayInMs: 1000,
+    maxRetryDelayInMs: 30000,
+    mode: "Exponential", // or "Fixed"
+  },
+});
+```
+
+## Idempotent Processing
+
+Design for at-least-once delivery:
+
+```typescript
+receiver.subscribe({
+  processMessage: async (message) => {
+    const messageId = message.messageId;
+    
+    // Check if already processed (use database, Redis, etc.)
+    if (await isAlreadyProcessed(messageId)) {
+      console.log(`Duplicate message: ${messageId}`);
+      return; // Message will be completed
+    }
+    
+    // Process message
+    await processOrder(message.body);
+    
+    // Mark as processed
+    await markAsProcessed(messageId);
+  },
+  processError: async (args) => { /* ... */ },
+});
+```
+
+## Poison Message Handling
+
+Handle messages that repeatedly fail:
+
+```typescript
+receiver.subscribe({
+  processMessage: async (message) => {
+    // Check delivery count
+    if (message.deliveryCount > 5) {
+      console.warn(`Message ${message.messageId} failed ${message.deliveryCount} times`);
+      
+      // Dead letter with reason
+      await receiver.deadLetterMessage(message, {
+        deadLetterReason: "MaxRetriesExceeded",
+        deadLetterErrorDescription: `Failed after ${message.deliveryCount} attempts`,
+      });
+      return;
+    }
+    
+    try {
+      await processMessage(message.body);
+    } catch (error) {
+      // Abandon to retry
+      await receiver.abandonMessage(message, {
+        propertiesToModify: {
+          lastError: error.message,
+          lastAttempt: new Date().toISOString(),
+        },
+      });
+    }
+  },
+  processError: async (args) => { /* ... */ },
+}, {
+  autoCompleteMessages: false, // Manual settlement
+});
+```
+
+## Best Practices Summary
+
+1. **Always handle errors** - Implement `processError` callback
+2. **Use peek-lock mode** - Ensures at-least-once delivery
+3. **Design for idempotency** - Messages may be delivered multiple times
+4. **Monitor dead letter queues** - Set up alerts for DLQ messages
+5. **Configure appropriate lock duration** - Match to processing time
+6. **Use auto-lock renewal** - For long-running operations
+7. **Graceful shutdown** - Close resources in correct order
+8. **Log error codes** - Helps diagnose issues
+9. **Set maxDeliveryCount** - Prevent infinite retry loops
+10. **Handle poison messages** - Dead letter after max retries

--- a/skills/typescript/messaging/servicebus/references/queues-topics.md
+++ b/skills/typescript/messaging/servicebus/references/queues-topics.md
@@ -1,0 +1,370 @@
+# Queues vs Topics Patterns
+
+Detailed patterns for Azure Service Bus queues and topics with @azure/service-bus.
+
+## Queue Patterns (Point-to-Point)
+
+Queues deliver each message to exactly one consumer. Use for work distribution.
+
+### Basic Queue Sender
+
+```typescript
+import { ServiceBusClient, ServiceBusMessage } from "@azure/service-bus";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const client = new ServiceBusClient(
+  process.env.SERVICEBUS_NAMESPACE!,
+  new DefaultAzureCredential()
+);
+
+const sender = client.createSender("order-queue");
+
+// Send single message
+const message: ServiceBusMessage = {
+  body: { orderId: "12345", amount: 99.99 },
+  contentType: "application/json",
+  messageId: "unique-id-12345",
+  correlationId: "request-abc",
+  applicationProperties: {
+    priority: "high",
+    source: "web-app",
+  },
+};
+
+await sender.sendMessages(message);
+await sender.close();
+```
+
+### Batch Sending (Recommended for Multiple Messages)
+
+```typescript
+const sender = client.createSender("order-queue");
+
+// Create batch with size limits
+const batch = await sender.createMessageBatch();
+
+const orders = [
+  { orderId: "001", amount: 50 },
+  { orderId: "002", amount: 75 },
+  { orderId: "003", amount: 100 },
+];
+
+for (const order of orders) {
+  const added = batch.tryAddMessage({ body: order });
+  if (!added) {
+    // Batch is full - send current batch and create new one
+    await sender.sendMessages(batch);
+    const newBatch = await sender.createMessageBatch();
+    newBatch.tryAddMessage({ body: order });
+  }
+}
+
+// Send remaining messages
+if (batch.count > 0) {
+  await sender.sendMessages(batch);
+}
+
+await sender.close();
+```
+
+### Queue Receiver (Pull Model)
+
+```typescript
+const receiver = client.createReceiver("order-queue", {
+  receiveMode: "peekLock", // Default - message locked until settled
+});
+
+// Receive batch of messages
+const messages = await receiver.receiveMessages(10, {
+  maxWaitTimeInMs: 5000,
+});
+
+for (const message of messages) {
+  try {
+    const order = message.body;
+    console.log(`Processing order: ${order.orderId}`);
+    
+    // Process successfully - remove from queue
+    await receiver.completeMessage(message);
+  } catch (error) {
+    // Processing failed - return to queue for retry
+    await receiver.abandonMessage(message);
+  }
+}
+
+await receiver.close();
+```
+
+### Queue Subscriber (Push Model - Event-Driven)
+
+```typescript
+const receiver = client.createReceiver("order-queue");
+
+const subscription = receiver.subscribe({
+  processMessage: async (message) => {
+    console.log(`Received: ${JSON.stringify(message.body)}`);
+    // Message auto-completed on success when using subscribe()
+  },
+  processError: async (args) => {
+    console.error(`Error source: ${args.errorSource}`);
+    console.error(`Error: ${args.error.message}`);
+    
+    if (args.error.code === "MessageLockLost") {
+      console.log("Message lock expired - will be redelivered");
+    }
+  },
+}, {
+  autoCompleteMessages: true, // Default
+  maxConcurrentCalls: 5,
+});
+
+// Graceful shutdown
+process.on("SIGTERM", async () => {
+  await subscription.close();
+  await receiver.close();
+  await client.close();
+});
+```
+
+## Topic Patterns (Publish-Subscribe)
+
+Topics deliver messages to multiple subscriptions. Use for fan-out scenarios.
+
+### Topic Publisher
+
+```typescript
+// Sending to a topic is identical to sending to a queue
+const sender = client.createSender("order-events");
+
+await sender.sendMessages({
+  body: { event: "order.created", orderId: "12345" },
+  applicationProperties: {
+    eventType: "order.created",
+    region: "us-west",
+  },
+  subject: "orders/created", // Can be used for filtering
+});
+
+await sender.close();
+```
+
+### Subscription Receiver
+
+```typescript
+// Receive from a specific subscription
+const receiver = client.createReceiver(
+  "order-events",      // Topic name
+  "billing-service"    // Subscription name
+);
+
+const messages = await receiver.receiveMessages(10);
+
+for (const message of messages) {
+  console.log(`Billing received: ${message.body.event}`);
+  await receiver.completeMessage(message);
+}
+```
+
+### Multiple Subscriptions (Fan-Out)
+
+```typescript
+// Each subscription gets a copy of every message
+// Create receivers for different services
+
+const billingReceiver = client.createReceiver("order-events", "billing");
+const inventoryReceiver = client.createReceiver("order-events", "inventory");
+const notificationReceiver = client.createReceiver("order-events", "notifications");
+
+// Each processes independently
+billingReceiver.subscribe({
+  processMessage: async (msg) => {
+    await processBilling(msg.body);
+  },
+  processError: async (args) => console.error(args.error),
+});
+
+inventoryReceiver.subscribe({
+  processMessage: async (msg) => {
+    await updateInventory(msg.body);
+  },
+  processError: async (args) => console.error(args.error),
+});
+```
+
+## Session-Enabled Queues (Ordered Processing)
+
+Sessions guarantee FIFO ordering within a session and enable stateful processing.
+
+### Send Session Messages
+
+```typescript
+const sender = client.createSender("workflow-queue");
+
+// All messages with same sessionId processed in order by same receiver
+await sender.sendMessages([
+  { body: { step: 1, action: "validate" }, sessionId: "order-123" },
+  { body: { step: 2, action: "charge" }, sessionId: "order-123" },
+  { body: { step: 3, action: "fulfill" }, sessionId: "order-123" },
+]);
+```
+
+### Accept Specific Session
+
+```typescript
+// Lock a specific session
+const sessionReceiver = await client.acceptSession(
+  "workflow-queue",
+  "order-123"
+);
+
+// Process all messages for this session in order
+const messages = await sessionReceiver.receiveMessages(10);
+
+for (const message of messages) {
+  console.log(`Step ${message.body.step}: ${message.body.action}`);
+  await sessionReceiver.completeMessage(message);
+}
+
+await sessionReceiver.close();
+```
+
+### Accept Next Available Session
+
+```typescript
+// Accept any available session (load balancing)
+const sessionReceiver = await client.acceptNextSession("workflow-queue", {
+  maxAutoLockRenewalDurationInMs: 300000, // 5 minutes
+});
+
+console.log(`Processing session: ${sessionReceiver.sessionId}`);
+
+// Get/set session state for checkpointing
+const state = await sessionReceiver.getSessionState();
+if (state) {
+  const checkpoint = JSON.parse(state.toString());
+  console.log(`Resuming from step: ${checkpoint.lastStep}`);
+}
+
+// Process messages...
+
+// Save checkpoint
+await sessionReceiver.setSessionState(
+  Buffer.from(JSON.stringify({ lastStep: 3, status: "complete" }))
+);
+
+await sessionReceiver.close();
+```
+
+## Receive Modes
+
+### Peek-Lock (Default - At-Least-Once)
+
+```typescript
+const receiver = client.createReceiver("my-queue", {
+  receiveMode: "peekLock",
+});
+
+const [message] = await receiver.receiveMessages(1);
+
+// Message is locked - other receivers can't see it
+// You MUST settle the message:
+
+await receiver.completeMessage(message);   // Success - remove from queue
+await receiver.abandonMessage(message);    // Failure - return to queue
+await receiver.deferMessage(message);      // Defer - retrieve by sequence number
+await receiver.deadLetterMessage(message); // Move to DLQ
+```
+
+### Receive-and-Delete (At-Most-Once)
+
+```typescript
+const receiver = client.createReceiver("my-queue", {
+  receiveMode: "receiveAndDelete",
+});
+
+const [message] = await receiver.receiveMessages(1);
+
+// Message is immediately deleted - no settlement needed
+// If processing fails, message is lost
+console.log(`Received and deleted: ${message.body}`);
+```
+
+## Message Settlement Actions
+
+```typescript
+const receiver = client.createReceiver("my-queue");
+const [message] = await receiver.receiveMessages(1);
+
+// COMPLETE: Processing succeeded, remove message
+await receiver.completeMessage(message);
+
+// ABANDON: Processing failed, return to queue for retry
+// Increments deliveryCount
+await receiver.abandonMessage(message, {
+  propertiesToModify: { retryReason: "timeout" },
+});
+
+// DEFER: Can't process now, retrieve later by sequence number
+await receiver.deferMessage(message);
+// Later: await receiver.receiveDeferredMessages([message.sequenceNumber!]);
+
+// DEAD LETTER: Poison message, move to DLQ
+await receiver.deadLetterMessage(message, {
+  deadLetterReason: "ValidationFailed",
+  deadLetterErrorDescription: "Missing required field: customerId",
+});
+```
+
+## Scheduled Messages
+
+```typescript
+const sender = client.createSender("my-queue");
+
+// Schedule for future delivery
+const scheduledTime = new Date(Date.now() + 60 * 60 * 1000); // 1 hour from now
+
+const sequenceNumbers = await sender.scheduleMessages(
+  [
+    { body: "Reminder: Complete your order" },
+    { body: "Your cart is waiting" },
+  ],
+  scheduledTime
+);
+
+console.log(`Scheduled messages: ${sequenceNumbers}`);
+
+// Cancel scheduled messages if needed
+await sender.cancelScheduledMessages(sequenceNumbers);
+```
+
+## Peek Messages (Non-Destructive)
+
+```typescript
+const receiver = client.createReceiver("my-queue");
+
+// Peek without removing or locking
+const peekedMessages = await receiver.peekMessages(10);
+
+for (const msg of peekedMessages) {
+  console.log(`Peeked: ${msg.body}`);
+  console.log(`Sequence: ${msg.sequenceNumber}`);
+  console.log(`Enqueued: ${msg.enqueuedTimeUtc}`);
+}
+
+// Peek from specific sequence number
+const moreMessages = await receiver.peekMessages(10, {
+  fromSequenceNumber: 100n,
+});
+```
+
+## When to Use Queues vs Topics
+
+| Scenario | Use |
+|----------|-----|
+| Work distribution (one consumer per message) | Queue |
+| Fan-out (multiple consumers per message) | Topic |
+| Competing consumers (load balancing) | Queue |
+| Event broadcasting | Topic |
+| Request-reply pattern | Queue with reply-to |
+| Ordered processing | Session-enabled Queue |
+| Filtered delivery | Topic with subscription filters |

--- a/skills/typescript/messaging/webpubsub/SKILL.md
+++ b/skills/typescript/messaging/webpubsub/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: azure-web-pubsub-typescript
+description: Build real-time messaging applications using Azure Web PubSub SDKs for JavaScript (@azure/web-pubsub, @azure/web-pubsub-client). Use when implementing WebSocket-based real-time features, pub/sub messaging, group chat, or live notifications.
+---
+
+# Azure Web PubSub SDKs for TypeScript
+
+Real-time messaging with WebSocket connections and pub/sub patterns.
+
+## Installation
+
+```bash
+# Server-side management
+npm install @azure/web-pubsub @azure/identity
+
+# Client-side real-time messaging
+npm install @azure/web-pubsub-client
+
+# Express middleware for event handlers
+npm install @azure/web-pubsub-express
+```
+
+## Environment Variables
+
+```bash
+WEBPUBSUB_CONNECTION_STRING=Endpoint=https://<resource>.webpubsub.azure.com;AccessKey=<key>;Version=1.0;
+WEBPUBSUB_ENDPOINT=https://<resource>.webpubsub.azure.com
+```
+
+## Server-Side: WebPubSubServiceClient
+
+### Authentication
+
+```typescript
+import { WebPubSubServiceClient, AzureKeyCredential } from "@azure/web-pubsub";
+import { DefaultAzureCredential } from "@azure/identity";
+
+// Connection string
+const client = new WebPubSubServiceClient(
+  process.env.WEBPUBSUB_CONNECTION_STRING!,
+  "chat"  // hub name
+);
+
+// DefaultAzureCredential (recommended)
+const client2 = new WebPubSubServiceClient(
+  process.env.WEBPUBSUB_ENDPOINT!,
+  new DefaultAzureCredential(),
+  "chat"
+);
+
+// AzureKeyCredential
+const client3 = new WebPubSubServiceClient(
+  process.env.WEBPUBSUB_ENDPOINT!,
+  new AzureKeyCredential("<access-key>"),
+  "chat"
+);
+```
+
+### Generate Client Access Token
+
+```typescript
+// Basic token
+const token = await client.getClientAccessToken();
+console.log(token.url);  // wss://...?access_token=...
+
+// Token with user ID
+const userToken = await client.getClientAccessToken({
+  userId: "user123",
+});
+
+// Token with permissions
+const permToken = await client.getClientAccessToken({
+  userId: "user123",
+  roles: [
+    "webpubsub.joinLeaveGroup",
+    "webpubsub.sendToGroup",
+    "webpubsub.sendToGroup.chat-room",  // specific group
+  ],
+  groups: ["chat-room"],  // auto-join on connect
+  expirationTimeInMinutes: 60,
+});
+```
+
+### Send Messages
+
+```typescript
+// Broadcast to all connections in hub
+await client.sendToAll({ message: "Hello everyone!" });
+await client.sendToAll("Plain text", { contentType: "text/plain" });
+
+// Send to specific user (all their connections)
+await client.sendToUser("user123", { message: "Hello!" });
+
+// Send to specific connection
+await client.sendToConnection("connectionId", { data: "Direct message" });
+
+// Send with filter (OData syntax)
+await client.sendToAll({ message: "Filtered" }, {
+  filter: "userId ne 'admin'",
+});
+```
+
+### Group Management
+
+```typescript
+const group = client.group("chat-room");
+
+// Add user/connection to group
+await group.addUser("user123");
+await group.addConnection("connectionId");
+
+// Remove from group
+await group.removeUser("user123");
+
+// Send to group
+await group.sendToAll({ message: "Group message" });
+
+// Close all connections in group
+await group.closeAllConnections({ reason: "Maintenance" });
+```
+
+### Connection Management
+
+```typescript
+// Check existence
+const userExists = await client.userExists("user123");
+const connExists = await client.connectionExists("connectionId");
+
+// Close connections
+await client.closeConnection("connectionId", { reason: "Kicked" });
+await client.closeUserConnections("user123");
+await client.closeAllConnections();
+
+// Permissions
+await client.grantPermission("connectionId", "sendToGroup", { targetName: "chat" });
+await client.revokePermission("connectionId", "sendToGroup", { targetName: "chat" });
+```
+
+## Client-Side: WebPubSubClient
+
+### Connect
+
+```typescript
+import { WebPubSubClient } from "@azure/web-pubsub-client";
+
+// Direct URL
+const client = new WebPubSubClient("<client-access-url>");
+
+// Dynamic URL from negotiate endpoint
+const client2 = new WebPubSubClient({
+  getClientAccessUrl: async () => {
+    const response = await fetch("/negotiate");
+    const { url } = await response.json();
+    return url;
+  },
+});
+
+// Register handlers BEFORE starting
+client.on("connected", (e) => {
+  console.log(`Connected: ${e.connectionId}`);
+});
+
+client.on("group-message", (e) => {
+  console.log(`${e.message.group}: ${e.message.data}`);
+});
+
+await client.start();
+```
+
+### Send Messages
+
+```typescript
+// Join group first
+await client.joinGroup("chat-room");
+
+// Send to group
+await client.sendToGroup("chat-room", "Hello!", "text");
+await client.sendToGroup("chat-room", { type: "message", content: "Hi" }, "json");
+
+// Send options
+await client.sendToGroup("chat-room", "Hello", "text", {
+  noEcho: true,        // Don't echo back to sender
+  fireAndForget: true, // Don't wait for ack
+});
+
+// Send event to server
+await client.sendEvent("userAction", { action: "typing" }, "json");
+```
+
+### Event Handlers
+
+```typescript
+// Connection lifecycle
+client.on("connected", (e) => {
+  console.log(`Connected: ${e.connectionId}, User: ${e.userId}`);
+});
+
+client.on("disconnected", (e) => {
+  console.log(`Disconnected: ${e.message}`);
+});
+
+client.on("stopped", () => {
+  console.log("Client stopped");
+});
+
+// Messages
+client.on("group-message", (e) => {
+  console.log(`[${e.message.group}] ${e.message.fromUserId}: ${e.message.data}`);
+});
+
+client.on("server-message", (e) => {
+  console.log(`Server: ${e.message.data}`);
+});
+
+// Rejoin failure
+client.on("rejoin-group-failed", (e) => {
+  console.log(`Failed to rejoin ${e.group}: ${e.error}`);
+});
+```
+
+## Express Event Handler
+
+```typescript
+import express from "express";
+import { WebPubSubEventHandler } from "@azure/web-pubsub-express";
+
+const app = express();
+
+const handler = new WebPubSubEventHandler("chat", {
+  path: "/api/webpubsub/hubs/chat/",
+  
+  // Blocking: approve/reject connection
+  handleConnect: (req, res) => {
+    if (!req.claims?.sub) {
+      res.fail(401, "Authentication required");
+      return;
+    }
+    res.success({
+      userId: req.claims.sub[0],
+      groups: ["general"],
+      roles: ["webpubsub.sendToGroup"],
+    });
+  },
+  
+  // Blocking: handle custom events
+  handleUserEvent: (req, res) => {
+    console.log(`Event from ${req.context.userId}:`, req.data);
+    res.success(`Received: ${req.data}`, "text");
+  },
+  
+  // Non-blocking
+  onConnected: (req) => {
+    console.log(`Client connected: ${req.context.connectionId}`);
+  },
+  
+  onDisconnected: (req) => {
+    console.log(`Client disconnected: ${req.context.connectionId}`);
+  },
+});
+
+app.use(handler.getMiddleware());
+
+// Negotiate endpoint
+app.get("/negotiate", async (req, res) => {
+  const token = await serviceClient.getClientAccessToken({
+    userId: req.user?.id,
+  });
+  res.json({ url: token.url });
+});
+
+app.listen(8080);
+```
+
+## Key Types
+
+```typescript
+// Server
+import {
+  WebPubSubServiceClient,
+  WebPubSubGroup,
+  GenerateClientTokenOptions,
+  HubSendToAllOptions,
+} from "@azure/web-pubsub";
+
+// Client
+import {
+  WebPubSubClient,
+  WebPubSubClientOptions,
+  OnConnectedArgs,
+  OnGroupDataMessageArgs,
+} from "@azure/web-pubsub-client";
+
+// Express
+import {
+  WebPubSubEventHandler,
+  ConnectRequest,
+  UserEventRequest,
+  ConnectResponseHandler,
+} from "@azure/web-pubsub-express";
+```
+
+## Best Practices
+
+1. **Use Entra ID auth** - `DefaultAzureCredential` for production
+2. **Register handlers before start** - Don't miss initial events
+3. **Use groups for channels** - Organize messages by topic/room
+4. **Handle reconnection** - Client auto-reconnects by default
+5. **Validate in handleConnect** - Reject unauthorized connections early
+6. **Use noEcho** - Prevent message echo back to sender when needed

--- a/skills/typescript/monitoring/opentelemetry/SKILL.md
+++ b/skills/typescript/monitoring/opentelemetry/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: azure-monitor-opentelemetry-typescript
+description: Instrument applications with Azure Monitor and OpenTelemetry for JavaScript (@azure/monitor-opentelemetry). Use when adding distributed tracing, metrics, and logs to Node.js applications with Application Insights.
+---
+
+# Azure Monitor OpenTelemetry SDK for TypeScript
+
+Auto-instrument Node.js applications with distributed tracing, metrics, and logs.
+
+## Installation
+
+```bash
+# Distro (recommended - auto-instrumentation)
+npm install @azure/monitor-opentelemetry
+
+# Low-level exporters (custom OpenTelemetry setup)
+npm install @azure/monitor-opentelemetry-exporter
+
+# Custom logs ingestion
+npm install @azure/monitor-ingestion
+```
+
+## Environment Variables
+
+```bash
+APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...;IngestionEndpoint=...
+```
+
+## Quick Start (Auto-Instrumentation)
+
+**IMPORTANT:** Call `useAzureMonitor()` BEFORE importing other modules.
+
+```typescript
+import { useAzureMonitor } from "@azure/monitor-opentelemetry";
+
+useAzureMonitor({
+  azureMonitorExporterOptions: {
+    connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
+  }
+});
+
+// Now import your application
+import express from "express";
+const app = express();
+```
+
+## ESM Support (Node.js 18.19+)
+
+```bash
+node --import @azure/monitor-opentelemetry/loader ./dist/index.js
+```
+
+**package.json:**
+```json
+{
+  "scripts": {
+    "start": "node --import @azure/monitor-opentelemetry/loader ./dist/index.js"
+  }
+}
+```
+
+## Full Configuration
+
+```typescript
+import { useAzureMonitor, AzureMonitorOpenTelemetryOptions } from "@azure/monitor-opentelemetry";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+
+const options: AzureMonitorOpenTelemetryOptions = {
+  azureMonitorExporterOptions: {
+    connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
+    storageDirectory: "/path/to/offline/storage",
+    disableOfflineStorage: false
+  },
+  
+  // Sampling
+  samplingRatio: 1.0,  // 0-1, percentage of traces
+  
+  // Features
+  enableLiveMetrics: true,
+  enableStandardMetrics: true,
+  enablePerformanceCounters: true,
+  
+  // Instrumentation libraries
+  instrumentationOptions: {
+    azureSdk: { enabled: true },
+    http: { enabled: true },
+    mongoDb: { enabled: true },
+    mySql: { enabled: true },
+    postgreSql: { enabled: true },
+    redis: { enabled: true },
+    bunyan: { enabled: false },
+    winston: { enabled: false }
+  },
+  
+  // Custom resource
+  resource: resourceFromAttributes({ "service.name": "my-service" })
+};
+
+useAzureMonitor(options);
+```
+
+## Custom Traces
+
+```typescript
+import { trace } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("my-tracer");
+
+const span = tracer.startSpan("doWork");
+try {
+  span.setAttribute("component", "worker");
+  span.setAttribute("operation.id", "42");
+  span.addEvent("processing started");
+  
+  // Your work here
+  
+} catch (error) {
+  span.recordException(error as Error);
+  span.setStatus({ code: 2, message: (error as Error).message });
+} finally {
+  span.end();
+}
+```
+
+## Custom Metrics
+
+```typescript
+import { metrics } from "@opentelemetry/api";
+
+const meter = metrics.getMeter("my-meter");
+
+// Counter
+const counter = meter.createCounter("requests_total");
+counter.add(1, { route: "/api/users", method: "GET" });
+
+// Histogram
+const histogram = meter.createHistogram("request_duration_ms");
+histogram.record(150, { route: "/api/users" });
+
+// Observable Gauge
+const gauge = meter.createObservableGauge("active_connections");
+gauge.addCallback((result) => {
+  result.observe(getActiveConnections(), { pool: "main" });
+});
+```
+
+## Manual Exporter Setup
+
+### Trace Exporter
+
+```typescript
+import { AzureMonitorTraceExporter } from "@azure/monitor-opentelemetry-exporter";
+import { NodeTracerProvider, BatchSpanProcessor } from "@opentelemetry/sdk-trace-node";
+
+const exporter = new AzureMonitorTraceExporter({
+  connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
+});
+
+const provider = new NodeTracerProvider({
+  spanProcessors: [new BatchSpanProcessor(exporter)]
+});
+
+provider.register();
+```
+
+### Metric Exporter
+
+```typescript
+import { AzureMonitorMetricExporter } from "@azure/monitor-opentelemetry-exporter";
+import { PeriodicExportingMetricReader, MeterProvider } from "@opentelemetry/sdk-metrics";
+import { metrics } from "@opentelemetry/api";
+
+const exporter = new AzureMonitorMetricExporter({
+  connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
+});
+
+const meterProvider = new MeterProvider({
+  readers: [new PeriodicExportingMetricReader({ exporter })]
+});
+
+metrics.setGlobalMeterProvider(meterProvider);
+```
+
+### Log Exporter
+
+```typescript
+import { AzureMonitorLogExporter } from "@azure/monitor-opentelemetry-exporter";
+import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+import { logs } from "@opentelemetry/api-logs";
+
+const exporter = new AzureMonitorLogExporter({
+  connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
+});
+
+const loggerProvider = new LoggerProvider();
+loggerProvider.addLogRecordProcessor(new BatchLogRecordProcessor(exporter));
+
+logs.setGlobalLoggerProvider(loggerProvider);
+```
+
+## Custom Logs Ingestion
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { LogsIngestionClient, isAggregateLogsUploadError } from "@azure/monitor-ingestion";
+
+const endpoint = "https://<dce>.ingest.monitor.azure.com";
+const ruleId = "<data-collection-rule-id>";
+const streamName = "Custom-MyTable_CL";
+
+const client = new LogsIngestionClient(endpoint, new DefaultAzureCredential());
+
+const logs = [
+  {
+    Time: new Date().toISOString(),
+    Computer: "Server1",
+    Message: "Application started",
+    Level: "Information"
+  }
+];
+
+try {
+  await client.upload(ruleId, streamName, logs);
+} catch (error) {
+  if (isAggregateLogsUploadError(error)) {
+    for (const uploadError of error.errors) {
+      console.error("Failed logs:", uploadError.failedLogs);
+    }
+  }
+}
+```
+
+## Custom Span Processor
+
+```typescript
+import { SpanProcessor, ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { Span, Context, SpanKind, TraceFlags } from "@opentelemetry/api";
+import { useAzureMonitor } from "@azure/monitor-opentelemetry";
+
+class FilteringSpanProcessor implements SpanProcessor {
+  forceFlush(): Promise<void> { return Promise.resolve(); }
+  shutdown(): Promise<void> { return Promise.resolve(); }
+  onStart(span: Span, context: Context): void {}
+  
+  onEnd(span: ReadableSpan): void {
+    // Add custom attributes
+    span.attributes["CustomDimension"] = "value";
+    
+    // Filter out internal spans
+    if (span.kind === SpanKind.INTERNAL) {
+      span.spanContext().traceFlags = TraceFlags.NONE;
+    }
+  }
+}
+
+useAzureMonitor({
+  spanProcessors: [new FilteringSpanProcessor()]
+});
+```
+
+## Sampling
+
+```typescript
+import { ApplicationInsightsSampler } from "@azure/monitor-opentelemetry-exporter";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+// Sample 75% of traces
+const sampler = new ApplicationInsightsSampler(0.75);
+
+const provider = new NodeTracerProvider({ sampler });
+```
+
+## Shutdown
+
+```typescript
+import { useAzureMonitor, shutdownAzureMonitor } from "@azure/monitor-opentelemetry";
+
+useAzureMonitor();
+
+// On application shutdown
+process.on("SIGTERM", async () => {
+  await shutdownAzureMonitor();
+  process.exit(0);
+});
+```
+
+## Key Types
+
+```typescript
+import {
+  useAzureMonitor,
+  shutdownAzureMonitor,
+  AzureMonitorOpenTelemetryOptions,
+  InstrumentationOptions
+} from "@azure/monitor-opentelemetry";
+
+import {
+  AzureMonitorTraceExporter,
+  AzureMonitorMetricExporter,
+  AzureMonitorLogExporter,
+  ApplicationInsightsSampler,
+  AzureMonitorExporterOptions
+} from "@azure/monitor-opentelemetry-exporter";
+
+import {
+  LogsIngestionClient,
+  isAggregateLogsUploadError
+} from "@azure/monitor-ingestion";
+```
+
+## Best Practices
+
+1. **Call useAzureMonitor() first** - Before importing other modules
+2. **Use ESM loader for ESM projects** - `--import @azure/monitor-opentelemetry/loader`
+3. **Enable offline storage** - For reliable telemetry in disconnected scenarios
+4. **Set sampling ratio** - For high-traffic applications
+5. **Add custom dimensions** - Use span processors for enrichment
+6. **Graceful shutdown** - Call `shutdownAzureMonitor()` to flush telemetry

--- a/skills/typescript/search/documents/SKILL.md
+++ b/skills/typescript/search/documents/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: azure-search-documents-typescript
+description: Build search applications using Azure AI Search SDK for JavaScript (@azure/search-documents). Use when creating/managing indexes, implementing vector/hybrid search, semantic ranking, or building agentic retrieval with knowledge bases.
+---
+
+# Azure AI Search SDK for TypeScript
+
+Build search applications with vector, hybrid, and semantic search capabilities.
+
+## Installation
+
+```bash
+npm install @azure/search-documents @azure/identity
+```
+
+## Environment Variables
+
+```bash
+AZURE_SEARCH_ENDPOINT=https://<service-name>.search.windows.net
+AZURE_SEARCH_INDEX_NAME=my-index
+AZURE_SEARCH_ADMIN_KEY=<admin-key>  # Optional if using Entra ID
+```
+
+## Authentication
+
+```typescript
+import { SearchClient, SearchIndexClient } from "@azure/search-documents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const endpoint = process.env.AZURE_SEARCH_ENDPOINT!;
+const indexName = process.env.AZURE_SEARCH_INDEX_NAME!;
+const credential = new DefaultAzureCredential();
+
+// For searching
+const searchClient = new SearchClient(endpoint, indexName, credential);
+
+// For index management
+const indexClient = new SearchIndexClient(endpoint, credential);
+```
+
+## Core Workflow
+
+### Create Index with Vector Field
+
+```typescript
+import { SearchIndex, SearchField, VectorSearch } from "@azure/search-documents";
+
+const index: SearchIndex = {
+  name: "products",
+  fields: [
+    { name: "id", type: "Edm.String", key: true },
+    { name: "title", type: "Edm.String", searchable: true },
+    { name: "description", type: "Edm.String", searchable: true },
+    { name: "category", type: "Edm.String", filterable: true, facetable: true },
+    {
+      name: "embedding",
+      type: "Collection(Edm.Single)",
+      searchable: true,
+      vectorSearchDimensions: 1536,
+      vectorSearchProfileName: "vector-profile",
+    },
+  ],
+  vectorSearch: {
+    algorithms: [
+      { name: "hnsw-algorithm", kind: "hnsw" },
+    ],
+    profiles: [
+      { name: "vector-profile", algorithmConfigurationName: "hnsw-algorithm" },
+    ],
+  },
+};
+
+await indexClient.createOrUpdateIndex(index);
+```
+
+### Index Documents
+
+```typescript
+const documents = [
+  { id: "1", title: "Widget", description: "A useful widget", category: "Tools", embedding: [...] },
+  { id: "2", title: "Gadget", description: "A cool gadget", category: "Electronics", embedding: [...] },
+];
+
+const result = await searchClient.uploadDocuments(documents);
+console.log(`Indexed ${result.results.length} documents`);
+```
+
+### Full-Text Search
+
+```typescript
+const results = await searchClient.search("widget", {
+  select: ["id", "title", "description"],
+  filter: "category eq 'Tools'",
+  orderBy: ["title asc"],
+  top: 10,
+});
+
+for await (const result of results.results) {
+  console.log(`${result.document.title}: ${result.score}`);
+}
+```
+
+### Vector Search
+
+```typescript
+const queryVector = await getEmbedding("useful tool"); // Your embedding function
+
+const results = await searchClient.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["embedding"],
+        kNearestNeighborsCount: 10,
+      },
+    ],
+  },
+  select: ["id", "title", "description"],
+});
+
+for await (const result of results.results) {
+  console.log(`${result.document.title}: ${result.score}`);
+}
+```
+
+### Hybrid Search (Text + Vector)
+
+```typescript
+const queryVector = await getEmbedding("useful tool");
+
+const results = await searchClient.search("tool", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        fields: ["embedding"],
+        kNearestNeighborsCount: 50,
+      },
+    ],
+  },
+  select: ["id", "title", "description"],
+  top: 10,
+});
+```
+
+### Semantic Search
+
+```typescript
+// Index must have semantic configuration
+const index: SearchIndex = {
+  name: "products",
+  fields: [...],
+  semanticSearch: {
+    configurations: [
+      {
+        name: "semantic-config",
+        prioritizedFields: {
+          titleField: { name: "title" },
+          contentFields: [{ name: "description" }],
+        },
+      },
+    ],
+  },
+};
+
+// Search with semantic ranking
+const results = await searchClient.search("best tool for the job", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "semantic-config",
+    captions: { captionType: "extractive" },
+    answers: { answerType: "extractive", count: 3 },
+  },
+  select: ["id", "title", "description"],
+});
+
+for await (const result of results.results) {
+  console.log(`${result.document.title}`);
+  console.log(`  Caption: ${result.captions?.[0]?.text}`);
+  console.log(`  Reranker Score: ${result.rerankerScore}`);
+}
+```
+
+## Filtering and Facets
+
+```typescript
+// Filter syntax
+const results = await searchClient.search("*", {
+  filter: "category eq 'Electronics' and price lt 100",
+  facets: ["category,count:10", "brand"],
+});
+
+// Access facets
+for (const [facetName, facetResults] of Object.entries(results.facets || {})) {
+  console.log(`${facetName}:`);
+  for (const facet of facetResults) {
+    console.log(`  ${facet.value}: ${facet.count}`);
+  }
+}
+```
+
+## Autocomplete and Suggestions
+
+```typescript
+// Create suggester in index
+const index: SearchIndex = {
+  name: "products",
+  fields: [...],
+  suggesters: [
+    { name: "sg", sourceFields: ["title", "description"] },
+  ],
+};
+
+// Autocomplete
+const autocomplete = await searchClient.autocomplete("wid", "sg", {
+  mode: "twoTerms",
+  top: 5,
+});
+
+// Suggestions
+const suggestions = await searchClient.suggest("wid", "sg", {
+  select: ["title"],
+  top: 5,
+});
+```
+
+## Batch Operations
+
+```typescript
+// Batch upload, merge, delete
+const batch = [
+  { upload: { id: "1", title: "New Item" } },
+  { merge: { id: "2", title: "Updated Title" } },
+  { delete: { id: "3" } },
+];
+
+const result = await searchClient.indexDocuments({ actions: batch });
+```
+
+## Key Types
+
+```typescript
+import {
+  SearchClient,
+  SearchIndexClient,
+  SearchIndexerClient,
+  SearchIndex,
+  SearchField,
+  SearchOptions,
+  VectorSearch,
+  SemanticSearch,
+  SearchIterator,
+} from "@azure/search-documents";
+```
+
+## Best Practices
+
+1. **Use hybrid search** - Combine vector + text for best results
+2. **Enable semantic ranking** - Improves relevance for natural language queries
+3. **Batch document uploads** - Use `uploadDocuments` with arrays, not single docs
+4. **Use filters for security** - Implement document-level security with filters
+5. **Index incrementally** - Use `mergeOrUploadDocuments` for updates
+6. **Monitor query performance** - Use `includeTotalCount: true` sparingly in production

--- a/skills/typescript/search/documents/references/semantic-ranking.md
+++ b/skills/typescript/search/documents/references/semantic-ranking.md
@@ -1,0 +1,468 @@
+# @azure/search-documents - Semantic Ranking Patterns
+
+Reference documentation for semantic search and ranking in the Azure AI Search TypeScript SDK.
+
+**Source**: [Azure SDK for JS - search-documents](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/search-documents @azure/identity
+```
+
+---
+
+## SemanticSearchOptions Interface
+
+```typescript
+interface SemanticSearchOptions {
+  /** Name of the semantic configuration to use */
+  configurationName?: string;
+  
+  /** Error handling mode: "partial" or "fail" */
+  errorMode?: SemanticErrorMode;
+  
+  /** Max wait time for semantic processing (ms) */
+  maxWaitInMilliseconds?: number;
+  
+  /** Extract answers from documents */
+  answers?: QueryAnswer;
+  
+  /** Extract captions with highlighting */
+  captions?: QueryCaption;
+  
+  /** AI-generated query rewrites */
+  queryRewrites?: QueryRewrites;
+  
+  /** Separate query for semantic reranking */
+  semanticQuery?: string;
+  
+  /** Fields for semantic search */
+  semanticFields?: string[];
+  
+  /** Enable debug info */
+  debugMode?: QueryDebugMode;
+}
+```
+
+---
+
+## Basic Semantic Search
+
+Enable semantic ranking with `queryType: "semantic"`:
+
+```typescript
+import { SearchClient } from "@azure/search-documents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+interface Article {
+  id: string;
+  title: string;
+  content: string;
+  category: string;
+}
+
+const client = new SearchClient<Article>(
+  process.env["AZURE_SEARCH_ENDPOINT"]!,
+  "articles",
+  new DefaultAzureCredential()
+);
+
+const results = await client.search("what causes climate change", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+  },
+  select: ["id", "title", "content"],
+  top: 10,
+});
+
+for await (const result of results.results) {
+  console.log(`${result.document.title}`);
+  console.log(`Reranker Score: ${result.rerankerScore}`);
+}
+```
+
+---
+
+## Extractive Captions
+
+Extract representative passages with keyword highlighting:
+
+```typescript
+const results = await client.search("renewable energy benefits", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-semantic-config",
+    captions: {
+      captionType: "extractive",
+      highlight: true,
+    },
+  },
+});
+
+for await (const result of results.results) {
+  console.log(`Title: ${result.document.title}`);
+  
+  // Access captions
+  result.captions?.forEach((caption) => {
+    console.log(`Caption: ${caption.text}`);
+    console.log(`Highlighted: ${caption.highlights}`); // With <em> tags
+  });
+}
+```
+
+### Caption Options
+
+```typescript
+interface QueryCaption {
+  /** Caption type: "extractive" | "none" */
+  captionType: QueryCaptionType;
+  
+  /** Include highlighting with <em> tags */
+  highlight?: boolean;
+}
+```
+
+---
+
+## Extractive Answers
+
+Extract direct answers for Q&A-style queries:
+
+```typescript
+const results = await client.search("what is the speed of light", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "science-config",
+    answers: {
+      answerType: "extractive",
+      count: 3,           // Number of answers to extract
+      threshold: 0.7,     // Minimum confidence threshold
+    },
+  },
+});
+
+// Access answers at the result set level
+if (results.answers && results.answers.length > 0) {
+  console.log("Top Answers:");
+  results.answers.forEach((answer, i) => {
+    console.log(`${i + 1}. ${answer.text}`);
+    console.log(`   Highlights: ${answer.highlights}`);
+    console.log(`   Score: ${answer.score}`);
+    console.log(`   Document: ${answer.key}`);
+  });
+}
+```
+
+### Answer Options
+
+```typescript
+interface QueryAnswer {
+  /** Answer type: "extractive" | "none" */
+  answerType: QueryAnswerType;
+  
+  /** Number of answers to return (1-10) */
+  count?: number;
+  
+  /** Minimum confidence threshold (0-1) */
+  threshold?: number;
+}
+```
+
+---
+
+## Query Rewrites
+
+Enable AI-generated query rewrites for better recall:
+
+```typescript
+const results = await client.search("ML algorithms", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "tech-config",
+    queryRewrites: {
+      rewritesType: "generative",
+      count: 3, // Number of rewrites to generate
+    },
+  },
+});
+
+// Access generated rewrites
+if (results.queryRewrites && results.queryRewrites.length > 0) {
+  console.log("Query Rewrites:");
+  results.queryRewrites.forEach((rewrite) => {
+    console.log(`- ${rewrite}`);
+  });
+}
+```
+
+---
+
+## Semantic + Hybrid Search
+
+Combine semantic ranking with vector search for best results:
+
+```typescript
+const results = await client.search("climate change solutions", {
+  // Enable semantic reranking
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "articles-semantic",
+    captions: { captionType: "extractive", highlight: true },
+    answers: { answerType: "extractive", count: 3 },
+  },
+  
+  // Add vector search
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "text",
+        text: "climate change solutions",
+        kNearestNeighborsCount: 50,
+        fields: ["contentVector"],
+      },
+    ],
+  },
+  
+  // Keyword search fields
+  searchFields: ["title", "content"],
+  
+  top: 10,
+  select: ["id", "title", "content", "category"],
+});
+
+// Results are:
+// 1. Retrieved via hybrid (keyword + vector)
+// 2. Reranked by semantic model
+// 3. Enriched with captions and answers
+```
+
+---
+
+## Semantic Query Override
+
+Use different queries for retrieval vs. semantic reranking:
+
+```typescript
+const results = await client.search("ML", {
+  // "ML" used for keyword matching
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "tech-config",
+    // Full question used for semantic reranking
+    semanticQuery: "What are the best machine learning algorithms for classification?",
+    captions: { captionType: "extractive" },
+  },
+});
+```
+
+---
+
+## Debug Mode
+
+Get detailed information about semantic processing:
+
+```typescript
+const results = await client.search("quantum computing applications", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "science-config",
+    debugMode: "semantic", // "disabled" | "speller" | "semantic" | "all"
+  },
+});
+
+for await (const result of results.results) {
+  // Access debug info per document
+  console.log(`Document: ${result.document.title}`);
+  console.log(`Debug Info:`, result.documentDebugInfo);
+}
+```
+
+---
+
+## Error Handling
+
+Control behavior when semantic processing fails:
+
+```typescript
+const results = await client.search("complex query here", {
+  queryType: "semantic",
+  semanticSearchOptions: {
+    configurationName: "my-config",
+    
+    // "partial" - Return results without semantic enrichment on failure
+    // "fail" - Return error if semantic processing fails
+    errorMode: "partial",
+    
+    // Timeout for semantic processing
+    maxWaitInMilliseconds: 5000,
+  },
+});
+```
+
+---
+
+## Index Semantic Configuration
+
+Define semantic configuration in your index:
+
+```typescript
+import { SearchIndexClient, SearchIndex } from "@azure/search-documents";
+
+const indexClient = new SearchIndexClient(endpoint, credential);
+
+const index: SearchIndex = {
+  name: "articles",
+  fields: [
+    { name: "id", type: "Edm.String", key: true },
+    { name: "title", type: "Edm.String", searchable: true },
+    { name: "content", type: "Edm.String", searchable: true },
+    { name: "summary", type: "Edm.String", searchable: true },
+    { name: "category", type: "Edm.String", filterable: true },
+  ],
+  semanticSearch: {
+    configurations: [
+      {
+        name: "articles-semantic",
+        prioritizedFields: {
+          // Title field (highest priority for reranking)
+          titleField: {
+            fieldName: "title",
+          },
+          // Content fields (used for caption/answer extraction)
+          contentFields: [
+            { fieldName: "content" },
+            { fieldName: "summary" },
+          ],
+          // Keyword fields (boost exact matches)
+          keywordsFields: [
+            { fieldName: "category" },
+          ],
+        },
+      },
+    ],
+    defaultConfiguration: "articles-semantic",
+  },
+};
+
+await indexClient.createOrUpdateIndex(index);
+```
+
+---
+
+## Complete Example
+
+```typescript
+import { SearchClient } from "@azure/search-documents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+interface Document {
+  id: string;
+  title: string;
+  content: string;
+  contentVector: number[];
+  category: string;
+}
+
+async function semanticHybridSearch(query: string) {
+  const client = new SearchClient<Document>(
+    process.env["AZURE_SEARCH_ENDPOINT"]!,
+    "knowledge-base",
+    new DefaultAzureCredential()
+  );
+
+  const results = await client.search(query, {
+    queryType: "semantic",
+    semanticSearchOptions: {
+      configurationName: "default-semantic",
+      captions: { captionType: "extractive", highlight: true },
+      answers: { answerType: "extractive", count: 3, threshold: 0.7 },
+    },
+    vectorSearchOptions: {
+      queries: [
+        {
+          kind: "text",
+          text: query,
+          kNearestNeighborsCount: 50,
+          fields: ["contentVector"],
+        },
+      ],
+    },
+    searchFields: ["title", "content"],
+    top: 10,
+    select: ["id", "title", "content", "category"],
+  });
+
+  // Process answers first (highest quality extracts)
+  const response: {
+    answers: Array<{ text: string; score: number; documentId: string }>;
+    results: Array<{
+      document: Document;
+      score: number;
+      rerankerScore: number;
+      captions: string[];
+    }>;
+  } = {
+    answers: [],
+    results: [],
+  };
+
+  // Extract answers
+  if (results.answers) {
+    response.answers = results.answers.map((a) => ({
+      text: a.highlights || a.text || "",
+      score: a.score ?? 0,
+      documentId: a.key || "",
+    }));
+  }
+
+  // Extract results with captions
+  for await (const result of results.results) {
+    response.results.push({
+      document: result.document,
+      score: result.score ?? 0,
+      rerankerScore: result.rerankerScore ?? 0,
+      captions: result.captions?.map((c) => c.highlights || c.text || "") ?? [],
+    });
+  }
+
+  return response;
+}
+
+// Usage
+const response = await semanticHybridSearch("how does photosynthesis work");
+
+console.log("=== Direct Answers ===");
+response.answers.forEach((a, i) => {
+  console.log(`${i + 1}. ${a.text} (score: ${a.score})`);
+});
+
+console.log("\n=== Search Results ===");
+response.results.forEach((r, i) => {
+  console.log(`${i + 1}. ${r.document.title}`);
+  console.log(`   Reranker Score: ${r.rerankerScore}`);
+  console.log(`   Caption: ${r.captions[0] || "N/A"}`);
+});
+```
+
+---
+
+## Best Practices
+
+1. **Use extractive answers** - For Q&A scenarios, answers provide direct responses
+2. **Enable captions** - They provide relevant snippets without returning full content
+3. **Combine with hybrid search** - Semantic + vector + keyword yields best results
+4. **Set appropriate thresholds** - Filter low-confidence answers
+5. **Configure semantic fields** - Prioritize title > content > keywords
+6. **Use partial error mode** - Gracefully degrade when semantic processing fails
+7. **Monitor latency** - Semantic processing adds ~100-300ms latency
+
+---
+
+## See Also
+
+- [Vector Search Patterns](./vector-search.md) - Combine with vector search
+- [Official Documentation](https://learn.microsoft.com/azure/search/semantic-search-overview)

--- a/skills/typescript/search/documents/references/vector-search.md
+++ b/skills/typescript/search/documents/references/vector-search.md
@@ -1,0 +1,438 @@
+# @azure/search-documents - Vector Search Patterns
+
+Reference documentation for vector search in the Azure AI Search TypeScript SDK.
+
+**Source**: [Azure SDK for JS - search-documents](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents)
+
+---
+
+## Installation
+
+```bash
+npm install @azure/search-documents @azure/identity
+```
+
+---
+
+## Client Setup
+
+```typescript
+import { SearchClient, SearchIndexClient } from "@azure/search-documents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const credential = new DefaultAzureCredential();
+const endpoint = process.env["AZURE_SEARCH_ENDPOINT"]!;
+
+// For searching
+const searchClient = new SearchClient<MyDocument>(
+  endpoint,
+  "my-index",
+  credential
+);
+
+// For index management
+const indexClient = new SearchIndexClient(endpoint, credential);
+```
+
+---
+
+## VectorSearchOptions Interface
+
+```typescript
+interface VectorSearchOptions {
+  /** Vector queries to execute */
+  queries?: VectorQuery[];
+  
+  /** Filter mode for vector queries */
+  filterMode?: VectorFilterMode; // "preFilter" | "postFilter"
+}
+
+type VectorQuery = 
+  | VectorizedQuery      // Pre-computed vector
+  | VectorizableTextQuery // Text to be vectorized
+  | VectorizableImageUrlQuery
+  | VectorizableImageBinaryQuery;
+```
+
+---
+
+## Basic Vector Search
+
+Search using a pre-computed embedding vector:
+
+```typescript
+import { SearchClient } from "@azure/search-documents";
+
+interface Product {
+  id: string;
+  name: string;
+  description: string;
+  descriptionVector: number[];
+}
+
+const searchClient = new SearchClient<Product>(endpoint, "products", credential);
+
+// Your embedding (e.g., from OpenAI, Azure OpenAI, etc.)
+const queryVector = await getEmbedding("comfortable running shoes");
+
+const results = await searchClient.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "vector",
+        vector: queryVector,
+        kNearestNeighborsCount: 10,
+        fields: ["descriptionVector"],
+      },
+    ],
+  },
+  select: ["id", "name", "description"],
+});
+
+for await (const result of results.results) {
+  console.log(`${result.document.name} (score: ${result.score})`);
+}
+```
+
+---
+
+## Integrated Vectorization (Text)
+
+Let Azure AI Search vectorize the query text automatically:
+
+```typescript
+const results = await searchClient.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "text",
+        text: "comfortable running shoes",
+        kNearestNeighborsCount: 10,
+        fields: ["descriptionVector"],
+      },
+    ],
+  },
+});
+```
+
+> **Note**: Requires a vectorizer configured on the index.
+
+---
+
+## Hybrid Search (Text + Vector)
+
+Combine keyword search with vector search for better results:
+
+```typescript
+const results = await searchClient.search("running shoes", {
+  // Keyword search component
+  searchFields: ["name", "description"],
+  
+  // Vector search component
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "text",
+        text: "comfortable running shoes",
+        kNearestNeighborsCount: 50,
+        fields: ["descriptionVector"],
+      },
+    ],
+  },
+  
+  // Return top 10 after RRF fusion
+  top: 10,
+  select: ["id", "name", "description"],
+});
+```
+
+---
+
+## Multi-Vector Search
+
+Search across multiple vector fields simultaneously:
+
+```typescript
+const results = await searchClient.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      // Search title embeddings
+      {
+        kind: "text",
+        text: "machine learning",
+        kNearestNeighborsCount: 50,
+        fields: ["titleVector"],
+        weight: 2.0, // Boost title matches
+      },
+      // Search content embeddings
+      {
+        kind: "text",
+        text: "machine learning",
+        kNearestNeighborsCount: 50,
+        fields: ["contentVector"],
+        weight: 1.0,
+      },
+    ],
+  },
+  top: 10,
+});
+```
+
+---
+
+## Vector Filtering
+
+### Pre-Filter (Default)
+
+Apply filters before vector search - smaller search space, faster:
+
+```typescript
+const results = await searchClient.search("*", {
+  filter: "category eq 'Electronics' and price lt 500",
+  vectorSearchOptions: {
+    filterMode: "preFilter", // Default
+    queries: [
+      {
+        kind: "text",
+        text: "wireless headphones",
+        kNearestNeighborsCount: 10,
+        fields: ["descriptionVector"],
+      },
+    ],
+  },
+});
+```
+
+### Post-Filter
+
+Apply filters after vector search - ensures k results are found first:
+
+```typescript
+const results = await searchClient.search("*", {
+  filter: "category eq 'Electronics'",
+  vectorSearchOptions: {
+    filterMode: "postFilter",
+    queries: [
+      {
+        kind: "text",
+        text: "wireless headphones",
+        kNearestNeighborsCount: 50, // Get more, then filter
+        fields: ["descriptionVector"],
+      },
+    ],
+  },
+  top: 10,
+});
+```
+
+### Per-Query Filter Override
+
+Apply different filters to different vector queries:
+
+```typescript
+const results = await searchClient.search("*", {
+  filter: "inStock eq true", // Global filter
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "text",
+        text: "premium headphones",
+        kNearestNeighborsCount: 20,
+        fields: ["descriptionVector"],
+        filterOverride: "category eq 'Audio' and price gt 200", // Override for this query
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Vector Thresholds
+
+Set minimum similarity thresholds:
+
+```typescript
+const results = await searchClient.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "text",
+        text: "wireless headphones",
+        kNearestNeighborsCount: 50,
+        fields: ["descriptionVector"],
+        threshold: {
+          kind: "vectorSimilarity",
+          value: 0.8, // Only results with similarity >= 0.8
+        },
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Exhaustive Search
+
+Force brute-force search instead of approximate (HNSW):
+
+```typescript
+const results = await searchClient.search("*", {
+  vectorSearchOptions: {
+    queries: [
+      {
+        kind: "text",
+        text: "specific product query",
+        kNearestNeighborsCount: 10,
+        fields: ["descriptionVector"],
+        exhaustive: true, // Slower but more accurate
+      },
+    ],
+  },
+});
+```
+
+---
+
+## Index Configuration for Vector Search
+
+Create an index with vector search capabilities:
+
+```typescript
+import { SearchIndexClient, SearchIndex } from "@azure/search-documents";
+
+const indexClient = new SearchIndexClient(endpoint, credential);
+
+const index: SearchIndex = {
+  name: "products",
+  fields: [
+    { name: "id", type: "Edm.String", key: true },
+    { name: "name", type: "Edm.String", searchable: true },
+    { name: "description", type: "Edm.String", searchable: true },
+    { name: "category", type: "Edm.String", filterable: true, facetable: true },
+    { name: "price", type: "Edm.Double", filterable: true, sortable: true },
+    {
+      name: "descriptionVector",
+      type: "Collection(Edm.Single)",
+      searchable: true,
+      vectorSearchDimensions: 1536,
+      vectorSearchProfileName: "vector-profile",
+    },
+  ],
+  vectorSearch: {
+    algorithms: [
+      {
+        name: "hnsw-algorithm",
+        kind: "hnsw",
+        parameters: {
+          m: 4,
+          efConstruction: 400,
+          efSearch: 500,
+          metric: "cosine",
+        },
+      },
+    ],
+    profiles: [
+      {
+        name: "vector-profile",
+        algorithmConfigurationName: "hnsw-algorithm",
+        vectorizerName: "openai-vectorizer", // Optional: for integrated vectorization
+      },
+    ],
+    vectorizers: [
+      {
+        name: "openai-vectorizer",
+        kind: "azureOpenAI",
+        azureOpenAIParameters: {
+          resourceUri: process.env["AZURE_OPENAI_ENDPOINT"]!,
+          deploymentId: "text-embedding-ada-002",
+          modelName: "text-embedding-ada-002",
+        },
+      },
+    ],
+  },
+};
+
+await indexClient.createOrUpdateIndex(index);
+```
+
+---
+
+## Complete Hybrid Search Example
+
+```typescript
+import { SearchClient } from "@azure/search-documents";
+import { DefaultAzureCredential } from "@azure/identity";
+
+interface Product {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  price: number;
+}
+
+async function hybridSearch(query: string, category?: string) {
+  const client = new SearchClient<Product>(
+    process.env["AZURE_SEARCH_ENDPOINT"]!,
+    "products",
+    new DefaultAzureCredential()
+  );
+
+  const filter = category ? `category eq '${category}'` : undefined;
+
+  const results = await client.search(query, {
+    filter,
+    searchFields: ["name", "description"],
+    vectorSearchOptions: {
+      queries: [
+        {
+          kind: "text",
+          text: query,
+          kNearestNeighborsCount: 50,
+          fields: ["descriptionVector"],
+        },
+      ],
+    },
+    top: 10,
+    select: ["id", "name", "description", "category", "price"],
+  });
+
+  const items: Array<{ document: Product; score: number }> = [];
+  
+  for await (const result of results.results) {
+    items.push({
+      document: result.document,
+      score: result.score ?? 0,
+    });
+  }
+
+  return items;
+}
+
+// Usage
+const results = await hybridSearch("wireless noise canceling", "Electronics");
+results.forEach((r) => {
+  console.log(`${r.document.name}: $${r.document.price} (score: ${r.score})`);
+});
+```
+
+---
+
+## Best Practices
+
+1. **Use hybrid search** - Combining keyword + vector typically outperforms either alone
+2. **Tune kNearestNeighborsCount** - Higher values increase recall but slow down search
+3. **Use pre-filtering** - When filter selectivity is high (filters out most documents)
+4. **Use post-filtering** - When you need exactly k vector matches, then filter
+5. **Set appropriate thresholds** - Filter out low-quality matches
+6. **Weight vector queries** - Boost more relevant vector fields
+7. **Monitor index metrics** - Track search latency and recall
+
+---
+
+## See Also
+
+- [Semantic Ranking](./semantic-ranking.md) - Combine with semantic reranking
+- [Official Samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents/samples)

--- a/skills/typescript/security/keyvault/SKILL.md
+++ b/skills/typescript/security/keyvault/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: azure-keyvault-typescript
+description: Manage cryptographic keys and secrets using Azure Key Vault SDKs for JavaScript (@azure/keyvault-keys, @azure/keyvault-secrets). Use when storing secrets, encrypting data, managing certificates, or implementing key rotation.
+---
+
+# Azure Key Vault SDK for TypeScript
+
+Manage cryptographic keys and secrets with Azure Key Vault.
+
+## Installation
+
+```bash
+# Keys SDK
+npm install @azure/keyvault-keys
+
+# Secrets SDK  
+npm install @azure/keyvault-secrets
+
+# Authentication
+npm install @azure/identity
+```
+
+## Environment Variables
+
+```bash
+KEY_VAULT_URL=https://<vault-name>.vault.azure.net
+# Or
+AZURE_KEYVAULT_NAME=<vault-name>
+```
+
+## Authentication
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { KeyClient, CryptographyClient } from "@azure/keyvault-keys";
+import { SecretClient } from "@azure/keyvault-secrets";
+
+const credential = new DefaultAzureCredential();
+const vaultUrl = `https://${process.env.AZURE_KEYVAULT_NAME}.vault.azure.net`;
+
+const keyClient = new KeyClient(vaultUrl, credential);
+const secretClient = new SecretClient(vaultUrl, credential);
+```
+
+## Secrets Operations
+
+### Create/Set Secret
+
+```typescript
+const secret = await secretClient.setSecret("MySecret", "secret-value");
+
+// With attributes
+const secretWithAttrs = await secretClient.setSecret("MySecret", "value", {
+  enabled: true,
+  expiresOn: new Date("2025-12-31"),
+  contentType: "application/json",
+  tags: { environment: "production" }
+});
+```
+
+### Get Secret
+
+```typescript
+// Get latest version
+const secret = await secretClient.getSecret("MySecret");
+console.log(secret.value);
+
+// Get specific version
+const specificSecret = await secretClient.getSecret("MySecret", {
+  version: secret.properties.version
+});
+```
+
+### List Secrets
+
+```typescript
+for await (const secretProperties of secretClient.listPropertiesOfSecrets()) {
+  console.log(secretProperties.name);
+}
+
+// List versions
+for await (const version of secretClient.listPropertiesOfSecretVersions("MySecret")) {
+  console.log(version.version);
+}
+```
+
+### Delete Secret
+
+```typescript
+// Soft delete
+const deletePoller = await secretClient.beginDeleteSecret("MySecret");
+await deletePoller.pollUntilDone();
+
+// Purge (permanent)
+await secretClient.purgeDeletedSecret("MySecret");
+
+// Recover
+const recoverPoller = await secretClient.beginRecoverDeletedSecret("MySecret");
+await recoverPoller.pollUntilDone();
+```
+
+## Keys Operations
+
+### Create Keys
+
+```typescript
+// Generic key
+const key = await keyClient.createKey("MyKey", "RSA");
+
+// RSA key with size
+const rsaKey = await keyClient.createRsaKey("MyRsaKey", { keySize: 2048 });
+
+// Elliptic Curve key
+const ecKey = await keyClient.createEcKey("MyEcKey", { curve: "P-256" });
+
+// With attributes
+const keyWithAttrs = await keyClient.createKey("MyKey", "RSA", {
+  enabled: true,
+  expiresOn: new Date("2025-12-31"),
+  tags: { purpose: "encryption" },
+  keyOps: ["encrypt", "decrypt", "sign", "verify"]
+});
+```
+
+### Get Key
+
+```typescript
+const key = await keyClient.getKey("MyKey");
+console.log(key.name, key.keyType);
+```
+
+### List Keys
+
+```typescript
+for await (const keyProperties of keyClient.listPropertiesOfKeys()) {
+  console.log(keyProperties.name);
+}
+```
+
+### Rotate Key
+
+```typescript
+// Manual rotation
+const rotatedKey = await keyClient.rotateKey("MyKey");
+
+// Set rotation policy
+await keyClient.updateKeyRotationPolicy("MyKey", {
+  lifetimeActions: [{ action: "Rotate", timeBeforeExpiry: "P30D" }],
+  expiresIn: "P90D"
+});
+```
+
+### Delete Key
+
+```typescript
+const deletePoller = await keyClient.beginDeleteKey("MyKey");
+await deletePoller.pollUntilDone();
+
+// Purge
+await keyClient.purgeDeletedKey("MyKey");
+```
+
+## Cryptographic Operations
+
+### Create CryptographyClient
+
+```typescript
+import { CryptographyClient } from "@azure/keyvault-keys";
+
+// From key object
+const cryptoClient = new CryptographyClient(key, credential);
+
+// From key ID
+const cryptoClient = new CryptographyClient(key.id!, credential);
+```
+
+### Encrypt/Decrypt
+
+```typescript
+// Encrypt
+const encryptResult = await cryptoClient.encrypt({
+  algorithm: "RSA-OAEP",
+  plaintext: Buffer.from("My secret message")
+});
+
+// Decrypt
+const decryptResult = await cryptoClient.decrypt({
+  algorithm: "RSA-OAEP",
+  ciphertext: encryptResult.result
+});
+
+console.log(decryptResult.result.toString());
+```
+
+### Sign/Verify
+
+```typescript
+import { createHash } from "node:crypto";
+
+// Create digest
+const hash = createHash("sha256").update("My message").digest();
+
+// Sign
+const signResult = await cryptoClient.sign("RS256", hash);
+
+// Verify
+const verifyResult = await cryptoClient.verify("RS256", hash, signResult.result);
+console.log("Valid:", verifyResult.result);
+```
+
+### Wrap/Unwrap Keys
+
+```typescript
+// Wrap a key (encrypt it for storage)
+const wrapResult = await cryptoClient.wrapKey("RSA-OAEP", Buffer.from("key-material"));
+
+// Unwrap
+const unwrapResult = await cryptoClient.unwrapKey("RSA-OAEP", wrapResult.result);
+```
+
+## Backup and Restore
+
+```typescript
+// Backup
+const keyBackup = await keyClient.backupKey("MyKey");
+const secretBackup = await secretClient.backupSecret("MySecret");
+
+// Restore (can restore to different vault)
+const restoredKey = await keyClient.restoreKeyBackup(keyBackup!);
+const restoredSecret = await secretClient.restoreSecretBackup(secretBackup!);
+```
+
+## Key Types
+
+```typescript
+import {
+  KeyClient,
+  KeyVaultKey,
+  KeyProperties,
+  DeletedKey,
+  CryptographyClient,
+  KnownEncryptionAlgorithms,
+  KnownSignatureAlgorithms
+} from "@azure/keyvault-keys";
+
+import {
+  SecretClient,
+  KeyVaultSecret,
+  SecretProperties,
+  DeletedSecret
+} from "@azure/keyvault-secrets";
+```
+
+## Error Handling
+
+```typescript
+try {
+  const secret = await secretClient.getSecret("NonExistent");
+} catch (error: any) {
+  if (error.code === "SecretNotFound") {
+    console.log("Secret does not exist");
+  } else {
+    throw error;
+  }
+}
+```
+
+## Best Practices
+
+1. **Use DefaultAzureCredential** - Works across dev and production
+2. **Enable soft-delete** - Required for production vaults
+3. **Set expiration dates** - On both keys and secrets
+4. **Use key rotation policies** - Automate key rotation
+5. **Limit key operations** - Only grant needed operations (encrypt, sign, etc.)
+6. **Browser not supported** - These SDKs are Node.js only

--- a/skills/typescript/security/keyvault/references/keys.md
+++ b/skills/typescript/security/keyvault/references/keys.md
@@ -1,0 +1,457 @@
+# Keys Reference
+
+Cryptographic key management and operations using @azure/keyvault-keys SDK.
+
+## Overview
+
+The Key Vault Keys SDK provides two main clients:
+- **KeyClient** - CRUD operations for keys (create, get, list, rotate, delete)
+- **CryptographyClient** - Cryptographic operations using keys (encrypt, decrypt, sign, verify, wrap, unwrap)
+
+## Core Types
+
+```typescript
+import {
+  KeyClient,
+  CryptographyClient,
+  KeyVaultKey,
+  KeyProperties,
+  DeletedKey,
+  KeyRotationPolicy,
+  KeyRotationPolicyProperties,
+  KeyRotationLifetimeAction,
+  CreateKeyOptions,
+  CreateRsaKeyOptions,
+  CreateEcKeyOptions,
+  EncryptParameters,
+  DecryptParameters,
+  SignResult,
+  VerifyResult,
+  WrapResult,
+  UnwrapResult,
+  KnownEncryptionAlgorithms,
+  KnownSignatureAlgorithms,
+  KnownKeyTypes,
+  KnownKeyCurveNames
+} from "@azure/keyvault-keys";
+```
+
+## KeyClient Initialization
+
+```typescript
+import { KeyClient } from "@azure/keyvault-keys";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const vaultUrl = `https://${process.env.AZURE_KEYVAULT_NAME}.vault.azure.net`;
+const credential = new DefaultAzureCredential();
+
+const keyClient = new KeyClient(vaultUrl, credential);
+```
+
+## Creating Keys
+
+### RSA Keys
+
+```typescript
+// Basic RSA key (default 2048-bit)
+const rsaKey = await keyClient.createRsaKey("my-rsa-key");
+
+// RSA key with specific size
+const rsaKey2048 = await keyClient.createRsaKey("my-rsa-2048", {
+  keySize: 2048
+});
+
+const rsaKey4096 = await keyClient.createRsaKey("my-rsa-4096", {
+  keySize: 4096
+});
+
+// RSA-HSM (Hardware Security Module backed)
+const rsaHsmKey = await keyClient.createRsaKey("my-rsa-hsm", {
+  keySize: 2048,
+  hsm: true  // Requires Premium vault
+});
+```
+
+### Elliptic Curve Keys
+
+```typescript
+// P-256 curve (default)
+const ecKey = await keyClient.createEcKey("my-ec-key");
+
+// Specific curves
+const ecKeyP256 = await keyClient.createEcKey("my-ec-p256", {
+  curve: "P-256"
+});
+
+const ecKeyP384 = await keyClient.createEcKey("my-ec-p384", {
+  curve: "P-384"
+});
+
+const ecKeyP521 = await keyClient.createEcKey("my-ec-p521", {
+  curve: "P-521"
+});
+
+// EC-HSM
+const ecHsmKey = await keyClient.createEcKey("my-ec-hsm", {
+  curve: "P-256",
+  hsm: true
+});
+```
+
+### Oct Keys (Symmetric)
+
+```typescript
+// Symmetric key for wrap/unwrap operations
+const octKey = await keyClient.createOctKey("my-oct-key", {
+  keySize: 256  // 128, 192, or 256 bits
+});
+
+// Oct-HSM
+const octHsmKey = await keyClient.createOctKey("my-oct-hsm", {
+  keySize: 256,
+  hsm: true
+});
+```
+
+### Generic Create with Options
+
+```typescript
+const key = await keyClient.createKey("my-key", "RSA", {
+  keySize: 2048,
+  enabled: true,
+  expiresOn: new Date("2025-12-31"),
+  notBefore: new Date("2024-01-01"),
+  tags: {
+    environment: "production",
+    application: "my-app"
+  },
+  keyOps: ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
+  exportable: false,
+  releasePolicy: undefined  // For Managed HSM key release
+});
+```
+
+## Key Operations
+
+### Get Key
+
+```typescript
+// Get latest version
+const key = await keyClient.getKey("my-key");
+console.log(`Key: ${key.name}, Type: ${key.keyType}, ID: ${key.id}`);
+
+// Get specific version
+const keyVersion = await keyClient.getKey("my-key", {
+  version: "abc123..."
+});
+```
+
+### List Keys
+
+```typescript
+// List all keys (properties only, not key material)
+for await (const keyProperties of keyClient.listPropertiesOfKeys()) {
+  console.log(`Key: ${keyProperties.name}, Created: ${keyProperties.createdOn}`);
+}
+
+// List all versions of a key
+for await (const version of keyClient.listPropertiesOfKeyVersions("my-key")) {
+  console.log(`Version: ${version.version}, Enabled: ${version.enabled}`);
+}
+
+// List deleted keys (soft-delete enabled vaults)
+for await (const deletedKey of keyClient.listDeletedKeys()) {
+  console.log(`Deleted: ${deletedKey.name}, Scheduled purge: ${deletedKey.scheduledPurgeDate}`);
+}
+```
+
+### Update Key Properties
+
+```typescript
+const updated = await keyClient.updateKeyProperties("my-key", {
+  enabled: false,
+  expiresOn: new Date("2026-12-31"),
+  tags: { status: "deprecated" }
+});
+
+// Update specific version
+const updatedVersion = await keyClient.updateKeyProperties("my-key", "version-id", {
+  enabled: true
+});
+```
+
+### Import Key
+
+```typescript
+import { JsonWebKey } from "@azure/keyvault-keys";
+
+// Import existing key material
+const jwk: JsonWebKey = {
+  kty: "RSA",
+  n: Buffer.from("...modulus..."),
+  e: Buffer.from("...exponent..."),
+  d: Buffer.from("...private exponent..."),  // Optional for public key
+  // ... other RSA parameters
+};
+
+const importedKey = await keyClient.importKey("imported-key", jwk, {
+  hardwareProtected: false  // true for HSM
+});
+```
+
+## Key Rotation
+
+### Manual Rotation
+
+```typescript
+// Creates new version, previous versions remain valid
+const rotatedKey = await keyClient.rotateKey("my-key");
+console.log(`New version: ${rotatedKey.properties.version}`);
+```
+
+### Rotation Policy
+
+```typescript
+// Get current policy
+const policy = await keyClient.getKeyRotationPolicy("my-key");
+
+// Update rotation policy
+const updatedPolicy = await keyClient.updateKeyRotationPolicy("my-key", {
+  expiresIn: "P90D",  // ISO 8601 duration - key expires 90 days after creation
+  lifetimeActions: [
+    {
+      action: "Rotate",
+      timeAfterCreate: "P30D"  // Auto-rotate 30 days after creation
+    },
+    {
+      action: "Notify",
+      timeBeforeExpiry: "P7D"  // Notify 7 days before expiry
+    }
+  ]
+});
+
+// Rotation policy with multiple actions
+const complexPolicy = await keyClient.updateKeyRotationPolicy("my-key", {
+  expiresIn: "P1Y",  // 1 year
+  lifetimeActions: [
+    { action: "Rotate", timeAfterCreate: "P90D" },  // Rotate every 90 days
+    { action: "Notify", timeBeforeExpiry: "P30D" }  // Notify 30 days before expiry
+  ]
+});
+```
+
+### ISO 8601 Duration Format
+
+| Duration | Meaning |
+|----------|---------|
+| `P30D` | 30 days |
+| `P90D` | 90 days |
+| `P1Y` | 1 year |
+| `P6M` | 6 months |
+| `P1Y6M` | 1 year 6 months |
+
+## Key Deletion and Recovery
+
+### Soft Delete (Default)
+
+```typescript
+// Begin delete (returns poller for long-running operation)
+const deletePoller = await keyClient.beginDeleteKey("my-key");
+
+// Wait for deletion to complete
+const deletedKey = await deletePoller.pollUntilDone();
+console.log(`Deleted: ${deletedKey.name}, Recovery ID: ${deletedKey.recoveryId}`);
+
+// Get deleted key info
+const deleted = await keyClient.getDeletedKey("my-key");
+
+// Recover deleted key
+const recoverPoller = await keyClient.beginRecoverDeletedKey("my-key");
+const recoveredKey = await recoverPoller.pollUntilDone();
+
+// Permanently delete (purge) - irreversible
+await keyClient.purgeDeletedKey("my-key");
+```
+
+### Immediate Deletion (Non-blocking)
+
+```typescript
+// Start deletion without waiting
+const poller = await keyClient.beginDeleteKey("my-key");
+
+// Check status periodically
+while (!poller.isDone()) {
+  await poller.poll();
+  console.log(`State: ${poller.getOperationState().status}`);
+  await new Promise(resolve => setTimeout(resolve, 1000));
+}
+```
+
+## CryptographyClient
+
+### Initialization
+
+```typescript
+import { CryptographyClient } from "@azure/keyvault-keys";
+
+// From KeyVaultKey object
+const key = await keyClient.getKey("my-key");
+const cryptoClient = new CryptographyClient(key, credential);
+
+// From key ID (URL)
+const cryptoClientFromId = new CryptographyClient(
+  "https://my-vault.vault.azure.net/keys/my-key/version",
+  credential
+);
+
+// From key ID without version (uses latest)
+const cryptoClientLatest = new CryptographyClient(
+  "https://my-vault.vault.azure.net/keys/my-key",
+  credential
+);
+```
+
+### Encrypt / Decrypt
+
+```typescript
+// RSA encryption
+const plaintext = Buffer.from("Secret message");
+
+// Encrypt with RSA-OAEP
+const encryptResult = await cryptoClient.encrypt({
+  algorithm: "RSA-OAEP",
+  plaintext
+});
+
+console.log(`Encrypted (${encryptResult.result.length} bytes)`);
+
+// Decrypt
+const decryptResult = await cryptoClient.decrypt({
+  algorithm: "RSA-OAEP",
+  ciphertext: encryptResult.result
+});
+
+console.log(`Decrypted: ${decryptResult.result.toString()}`);
+```
+
+### Encryption Algorithms
+
+| Algorithm | Key Type | Description |
+|-----------|----------|-------------|
+| `RSA1_5` | RSA | RSA with PKCS#1 v1.5 padding |
+| `RSA-OAEP` | RSA | RSA with OAEP padding (SHA-1) |
+| `RSA-OAEP-256` | RSA | RSA with OAEP padding (SHA-256) |
+| `A128GCM` | oct | AES-128-GCM |
+| `A192GCM` | oct | AES-192-GCM |
+| `A256GCM` | oct | AES-256-GCM |
+| `A128CBC` | oct | AES-128-CBC |
+| `A192CBC` | oct | AES-192-CBC |
+| `A256CBC` | oct | AES-256-CBC |
+
+### Sign / Verify
+
+```typescript
+import { createHash } from "node:crypto";
+
+// Create SHA-256 hash of data to sign
+const data = Buffer.from("Data to sign");
+const hash = createHash("sha256").update(data).digest();
+
+// Sign with RSA key
+const signResult = await cryptoClient.sign("RS256", hash);
+console.log(`Signature (${signResult.result.length} bytes)`);
+
+// Verify signature
+const verifyResult = await cryptoClient.verify("RS256", hash, signResult.result);
+console.log(`Valid: ${verifyResult.result}`);
+
+// Sign data directly (SDK computes hash)
+const signDataResult = await cryptoClient.signData("RS256", data);
+const verifyDataResult = await cryptoClient.verifyData("RS256", data, signDataResult.result);
+```
+
+### Signature Algorithms
+
+| Algorithm | Key Type | Hash | Description |
+|-----------|----------|------|-------------|
+| `RS256` | RSA | SHA-256 | RSASSA-PKCS1-v1_5 |
+| `RS384` | RSA | SHA-384 | RSASSA-PKCS1-v1_5 |
+| `RS512` | RSA | SHA-512 | RSASSA-PKCS1-v1_5 |
+| `PS256` | RSA | SHA-256 | RSASSA-PSS |
+| `PS384` | RSA | SHA-384 | RSASSA-PSS |
+| `PS512` | RSA | SHA-512 | RSASSA-PSS |
+| `ES256` | EC P-256 | SHA-256 | ECDSA |
+| `ES384` | EC P-384 | SHA-384 | ECDSA |
+| `ES512` | EC P-521 | SHA-512 | ECDSA |
+
+### Wrap / Unwrap Keys
+
+```typescript
+// Key encryption key (KEK) wraps another key
+const keyMaterial = Buffer.from("32-byte-key-material-here!!!!!");  // 32 bytes for AES-256
+
+// Wrap (encrypt) the key material
+const wrapResult = await cryptoClient.wrapKey("RSA-OAEP", keyMaterial);
+console.log(`Wrapped key (${wrapResult.result.length} bytes)`);
+
+// Unwrap (decrypt) the key material
+const unwrapResult = await cryptoClient.unwrapKey("RSA-OAEP", wrapResult.result);
+console.log(`Unwrapped: ${unwrapResult.result.length} bytes`);
+```
+
+## Backup and Restore
+
+```typescript
+// Backup key (returns encrypted blob)
+const backup = await keyClient.backupKey("my-key");
+if (backup) {
+  // Store backup securely (e.g., blob storage)
+  console.log(`Backup size: ${backup.length} bytes`);
+}
+
+// Restore key (can restore to different vault in same region/subscription)
+const restoredKey = await keyClient.restoreKeyBackup(backup!);
+console.log(`Restored: ${restoredKey.name}`);
+```
+
+## Error Handling
+
+```typescript
+import { RestError } from "@azure/core-rest-pipeline";
+
+try {
+  const key = await keyClient.getKey("non-existent-key");
+} catch (error) {
+  if (error instanceof RestError) {
+    switch (error.statusCode) {
+      case 404:
+        console.log("Key not found");
+        break;
+      case 403:
+        console.log("Access denied - check RBAC permissions");
+        break;
+      case 409:
+        console.log("Conflict - key already exists or is being deleted");
+        break;
+      default:
+        console.log(`Error ${error.statusCode}: ${error.message}`);
+    }
+  }
+  throw error;
+}
+```
+
+## Best Practices
+
+1. **Use managed identity in production** - DefaultAzureCredential handles this automatically
+2. **Enable soft-delete and purge protection** - Required for production vaults
+3. **Set key expiration** - Use `expiresOn` to enforce key lifecycle
+4. **Use rotation policies** - Automate key rotation for security compliance
+5. **Limit key operations** - Only grant needed operations (`keyOps`)
+6. **Use HSM for sensitive keys** - Hardware protection for critical cryptographic material
+7. **Backup keys before deletion** - Soft-delete has retention limits
+8. **Use specific key versions** - Pin to versions in production for stability
+
+## See Also
+
+- [secrets.md](./secrets.md) - Secret management operations

--- a/skills/typescript/security/keyvault/references/secrets.md
+++ b/skills/typescript/security/keyvault/references/secrets.md
@@ -1,0 +1,473 @@
+# Secrets Reference
+
+Secret management operations using @azure/keyvault-secrets SDK.
+
+## Overview
+
+The SecretClient provides operations for managing secrets in Azure Key Vault:
+- Create, update, and delete secrets
+- List secrets and versions
+- Soft-delete and purge operations
+- Backup and restore capabilities
+
+## Core Types
+
+```typescript
+import {
+  SecretClient,
+  KeyVaultSecret,
+  SecretProperties,
+  DeletedSecret,
+  SetSecretOptions,
+  GetSecretOptions,
+  UpdateSecretPropertiesOptions,
+  BeginDeleteSecretOptions,
+  BeginRecoverDeletedSecretOptions,
+  ListPropertiesOfSecretsOptions,
+  ListPropertiesOfSecretVersionsOptions,
+  ListDeletedSecretsOptions
+} from "@azure/keyvault-secrets";
+```
+
+## SecretClient Initialization
+
+```typescript
+import { SecretClient } from "@azure/keyvault-secrets";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const vaultUrl = `https://${process.env.AZURE_KEYVAULT_NAME}.vault.azure.net`;
+const credential = new DefaultAzureCredential();
+
+const secretClient = new SecretClient(vaultUrl, credential);
+```
+
+## Creating and Updating Secrets
+
+### Set Secret (Create or Update)
+
+```typescript
+// Basic secret
+const secret = await secretClient.setSecret("MySecret", "secret-value");
+console.log(`Secret: ${secret.name}, Version: ${secret.properties.version}`);
+
+// Secret with options
+const secretWithOptions = await secretClient.setSecret("MySecret", "secret-value", {
+  enabled: true,
+  expiresOn: new Date("2025-12-31"),
+  notBefore: new Date("2024-01-01"),
+  contentType: "text/plain",
+  tags: {
+    environment: "production",
+    application: "my-app",
+    owner: "team-a"
+  }
+});
+```
+
+### Content Types
+
+```typescript
+// JSON content
+const jsonSecret = await secretClient.setSecret(
+  "config-secret",
+  JSON.stringify({ apiKey: "xyz", endpoint: "https://api.example.com" }),
+  { contentType: "application/json" }
+);
+
+// Connection string
+const connString = await secretClient.setSecret(
+  "db-connection",
+  "Server=tcp:myserver.database.windows.net;Database=mydb;...",
+  { contentType: "text/plain; charset=utf-8" }
+);
+
+// Base64 encoded binary
+const binarySecret = await secretClient.setSecret(
+  "certificate-data",
+  Buffer.from(certificateBytes).toString("base64"),
+  { contentType: "application/x-pkcs12" }
+);
+```
+
+### Versioning Behavior
+
+```typescript
+// Each setSecret creates a new version
+const v1 = await secretClient.setSecret("MySecret", "value-1");
+console.log(`Version 1: ${v1.properties.version}`);
+
+const v2 = await secretClient.setSecret("MySecret", "value-2");
+console.log(`Version 2: ${v2.properties.version}`);
+
+// v1 still exists and is accessible by version ID
+const v1Retrieved = await secretClient.getSecret("MySecret", {
+  version: v1.properties.version
+});
+```
+
+## Retrieving Secrets
+
+### Get Secret
+
+```typescript
+// Get latest version
+const secret = await secretClient.getSecret("MySecret");
+console.log(`Value: ${secret.value}`);
+console.log(`Version: ${secret.properties.version}`);
+console.log(`Created: ${secret.properties.createdOn}`);
+
+// Get specific version
+const specificVersion = await secretClient.getSecret("MySecret", {
+  version: "abc123def456..."
+});
+```
+
+### KeyVaultSecret Structure
+
+```typescript
+interface KeyVaultSecret {
+  name: string;
+  value?: string;  // Only present when retrieved, not in list operations
+  properties: SecretProperties;
+}
+
+interface SecretProperties {
+  id?: string;                    // Full secret identifier URL
+  name: string;
+  version?: string;
+  vaultUrl: string;
+  enabled?: boolean;
+  notBefore?: Date;
+  expiresOn?: Date;
+  createdOn?: Date;
+  updatedOn?: Date;
+  contentType?: string;
+  tags?: { [key: string]: string };
+  managed?: boolean;              // True if managed by Key Vault (e.g., storage account keys)
+  recoverableDays?: number;
+  recoveryLevel?: string;
+}
+```
+
+## Listing Secrets
+
+### List All Secrets
+
+```typescript
+// List secret properties (not values - use getSecret for values)
+for await (const secretProperties of secretClient.listPropertiesOfSecrets()) {
+  console.log(`Secret: ${secretProperties.name}`);
+  console.log(`  Enabled: ${secretProperties.enabled}`);
+  console.log(`  Content Type: ${secretProperties.contentType}`);
+  console.log(`  Tags: ${JSON.stringify(secretProperties.tags)}`);
+}
+```
+
+### List Secret Versions
+
+```typescript
+// List all versions of a specific secret
+for await (const version of secretClient.listPropertiesOfSecretVersions("MySecret")) {
+  console.log(`Version: ${version.version}`);
+  console.log(`  Created: ${version.createdOn}`);
+  console.log(`  Enabled: ${version.enabled}`);
+  console.log(`  Expires: ${version.expiresOn}`);
+}
+```
+
+### Collect to Array
+
+```typescript
+// Collect all secrets to array
+const allSecrets: SecretProperties[] = [];
+for await (const secret of secretClient.listPropertiesOfSecrets()) {
+  allSecrets.push(secret);
+}
+
+// Or use byPage for pagination control
+const pages = secretClient.listPropertiesOfSecrets().byPage({ maxPageSize: 25 });
+for await (const page of pages) {
+  console.log(`Page with ${page.length} secrets`);
+}
+```
+
+### Filter by Tags
+
+```typescript
+// SDK doesn't support server-side filtering, filter client-side
+const productionSecrets: SecretProperties[] = [];
+for await (const secret of secretClient.listPropertiesOfSecrets()) {
+  if (secret.tags?.environment === "production") {
+    productionSecrets.push(secret);
+  }
+}
+```
+
+## Updating Secret Properties
+
+```typescript
+// Update properties without changing value
+const updated = await secretClient.updateSecretProperties("MySecret", "version-id", {
+  enabled: false,
+  expiresOn: new Date("2026-12-31"),
+  tags: { status: "deprecated", deprecatedOn: new Date().toISOString() }
+});
+
+// Update latest version (get version first)
+const current = await secretClient.getSecret("MySecret");
+await secretClient.updateSecretProperties("MySecret", current.properties.version!, {
+  enabled: true
+});
+```
+
+## Soft Delete Operations
+
+### Delete Secret
+
+```typescript
+// Begin delete (long-running operation)
+const deletePoller = await secretClient.beginDeleteSecret("MySecret");
+
+// Option 1: Wait for completion
+const deletedSecret = await deletePoller.pollUntilDone();
+console.log(`Deleted: ${deletedSecret.name}`);
+console.log(`Scheduled purge: ${deletedSecret.scheduledPurgeDate}`);
+console.log(`Deleted on: ${deletedSecret.deletedOn}`);
+
+// Option 2: Non-blocking with periodic checks
+const poller = await secretClient.beginDeleteSecret("MySecret");
+while (!poller.isDone()) {
+  await poller.poll();
+  const state = poller.getOperationState();
+  console.log(`Delete status: ${state.isStarted ? "in progress" : "pending"}`);
+  await new Promise(resolve => setTimeout(resolve, 2000));
+}
+```
+
+### Get Deleted Secret
+
+```typescript
+// Get info about a deleted secret
+const deleted = await secretClient.getDeletedSecret("MySecret");
+console.log(`Recovery ID: ${deleted.recoveryId}`);
+console.log(`Scheduled purge: ${deleted.scheduledPurgeDate}`);
+```
+
+### List Deleted Secrets
+
+```typescript
+// List all deleted secrets in vault
+for await (const deletedSecret of secretClient.listDeletedSecrets()) {
+  console.log(`Deleted secret: ${deletedSecret.name}`);
+  console.log(`  Deleted on: ${deletedSecret.deletedOn}`);
+  console.log(`  Purge date: ${deletedSecret.scheduledPurgeDate}`);
+}
+```
+
+### Recover Deleted Secret
+
+```typescript
+// Recover a soft-deleted secret
+const recoverPoller = await secretClient.beginRecoverDeletedSecret("MySecret");
+const recoveredSecret = await recoverPoller.pollUntilDone();
+console.log(`Recovered: ${recoveredSecret.name}`);
+```
+
+### Purge Secret (Permanent Delete)
+
+```typescript
+// Permanently delete - IRREVERSIBLE
+// Requires "purge" permission in RBAC
+await secretClient.purgeDeletedSecret("MySecret");
+
+// Common pattern: delete then purge
+const deletePoller = await secretClient.beginDeleteSecret("MySecret");
+await deletePoller.pollUntilDone();
+await secretClient.purgeDeletedSecret("MySecret");
+```
+
+## Backup and Restore
+
+### Backup Secret
+
+```typescript
+// Backup returns encrypted blob containing all versions
+const backup = await secretClient.backupSecret("MySecret");
+
+if (backup) {
+  // Store backup securely (e.g., blob storage, local file)
+  console.log(`Backup size: ${backup.length} bytes`);
+  
+  // Save to file
+  import { writeFileSync } from "node:fs";
+  writeFileSync("secret-backup.bin", backup);
+}
+```
+
+### Restore Secret
+
+```typescript
+import { readFileSync } from "node:fs";
+
+// Read backup from storage
+const backupData = readFileSync("secret-backup.bin");
+
+// Restore to vault (can be different vault in same region/subscription)
+const restoredSecret = await secretClient.restoreSecretBackup(backupData);
+console.log(`Restored: ${restoredSecret.name}`);
+```
+
+### Backup Constraints
+
+| Constraint | Description |
+|------------|-------------|
+| Same subscription | Backup can only be restored to vault in same Azure subscription |
+| Same geography | Target vault must be in same Azure geography |
+| All versions | Backup includes all versions of the secret |
+| Encrypted | Backup blob is encrypted with Microsoft-managed keys |
+
+## Error Handling
+
+```typescript
+import { RestError } from "@azure/core-rest-pipeline";
+
+async function getSecretSafely(name: string): Promise<KeyVaultSecret | null> {
+  try {
+    return await secretClient.getSecret(name);
+  } catch (error) {
+    if (error instanceof RestError) {
+      switch (error.statusCode) {
+        case 404:
+          console.log(`Secret '${name}' not found`);
+          return null;
+        case 403:
+          console.log("Access denied - check RBAC permissions");
+          throw error;
+        case 409:
+          console.log("Conflict - secret is being deleted or already exists");
+          throw error;
+        default:
+          console.log(`Error ${error.statusCode}: ${error.message}`);
+          throw error;
+      }
+    }
+    throw error;
+  }
+}
+```
+
+### Common Error Codes
+
+| Code | Meaning |
+|------|---------|
+| 404 | Secret not found (or deleted) |
+| 403 | Access denied (RBAC permission missing) |
+| 409 | Conflict (secret exists in deleted state) |
+| 429 | Rate limited (too many requests) |
+
+## Common Patterns
+
+### Secret Rotation
+
+```typescript
+async function rotateSecret(name: string, newValue: string): Promise<KeyVaultSecret> {
+  // Get current secret to preserve metadata
+  const current = await secretClient.getSecret(name);
+  
+  // Disable old version
+  await secretClient.updateSecretProperties(name, current.properties.version!, {
+    enabled: false,
+    tags: {
+      ...current.properties.tags,
+      rotatedOn: new Date().toISOString(),
+      status: "rotated"
+    }
+  });
+  
+  // Create new version with same settings
+  const newSecret = await secretClient.setSecret(name, newValue, {
+    enabled: true,
+    contentType: current.properties.contentType,
+    expiresOn: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000), // 90 days
+    tags: {
+      ...current.properties.tags,
+      status: "active",
+      createdOn: new Date().toISOString()
+    }
+  });
+  
+  return newSecret;
+}
+```
+
+### Bulk Secret Operations
+
+```typescript
+async function exportAllSecrets(): Promise<Map<string, string>> {
+  const secrets = new Map<string, string>();
+  
+  for await (const properties of secretClient.listPropertiesOfSecrets()) {
+    if (properties.enabled) {
+      const secret = await secretClient.getSecret(properties.name);
+      if (secret.value) {
+        secrets.set(properties.name, secret.value);
+      }
+    }
+  }
+  
+  return secrets;
+}
+
+async function importSecrets(secrets: Map<string, string>, tags?: Record<string, string>): Promise<void> {
+  for (const [name, value] of secrets) {
+    await secretClient.setSecret(name, value, { tags });
+    console.log(`Imported: ${name}`);
+  }
+}
+```
+
+### Check Secret Expiration
+
+```typescript
+async function getExpiringSecrets(daysThreshold: number = 30): Promise<SecretProperties[]> {
+  const expiringSecrets: SecretProperties[] = [];
+  const thresholdDate = new Date(Date.now() + daysThreshold * 24 * 60 * 60 * 1000);
+  
+  for await (const secret of secretClient.listPropertiesOfSecrets()) {
+    if (secret.enabled && secret.expiresOn && secret.expiresOn <= thresholdDate) {
+      expiringSecrets.push(secret);
+    }
+  }
+  
+  return expiringSecrets;
+}
+```
+
+## Best Practices
+
+1. **Use managed identity** - DefaultAzureCredential handles MI in Azure, dev credentials locally
+2. **Set expiration dates** - Enforce secret rotation with `expiresOn`
+3. **Use content types** - Helps consumers understand secret format
+4. **Tag secrets** - Environment, application, owner for organization
+5. **Enable soft-delete** - Required for production vaults (default for new vaults)
+6. **Enable purge protection** - Prevents accidental permanent deletion
+7. **Backup before rotation** - Backup secrets before making changes
+8. **Least privilege** - Grant only needed permissions (Get vs List vs Set)
+9. **Monitor expiration** - Alert on secrets expiring within threshold
+10. **Avoid storing in code** - Use Key Vault references in App Service/Functions
+
+## RBAC Permissions
+
+| Operation | Required Permission |
+|-----------|---------------------|
+| Get secret | `Microsoft.KeyVault/vaults/secrets/getSecret/action` |
+| List secrets | `Microsoft.KeyVault/vaults/secrets/readMetadata/action` |
+| Set secret | `Microsoft.KeyVault/vaults/secrets/setSecret/action` |
+| Delete secret | `Microsoft.KeyVault/vaults/secrets/delete` |
+| Purge secret | `Microsoft.KeyVault/vaults/secrets/purge/action` |
+| Backup | `Microsoft.KeyVault/vaults/secrets/backup/action` |
+| Restore | `Microsoft.KeyVault/vaults/secrets/restore/action` |
+
+## See Also
+
+- [keys.md](./keys.md) - Cryptographic key management


### PR DESCRIPTION
## Summary

Adds comprehensive SDK skill coverage across 4 languages (Python, .NET, TypeScript, Java) with a unified catalog structure.

- **Python:** 33 skills (extended from core)
- **.NET:** 29 skills
- **TypeScript:** 23 skills (new)
- **Java:** 28 skills (new)
- **Total:** 113 extended skills + 16 core skills

## Changes

### New Skills
- Add 23 TypeScript skills covering Foundry, AI, Data, Messaging, Frontend, Identity, and Security
- Add 28 Java skills covering Foundry, AI, Data, Communication, Messaging, and Monitoring
- Add shared reference docs (`references/`) for cross-language patterns (vector-search, streaming, semantic-ranking, etc.)

### Documentation
- Create `CATALOG.md` with full skill inventory organized by language and category
- Simplify `README.md` with direct links to catalog (reduced from 460 to 90 lines)
- Update `Agents.md` with extended catalog summary

### Structure
```
skills/
├── python/     # 33 skills
├── dotnet/     # 29 skills  
├── typescript/ # 23 skills (new)
└── java/       # 28 skills (new)

references/     # Shared reference docs (new)
CATALOG.md      # Full skill inventory (new)
```

## Testing

- Skills follow established SKILL.md format with YAML frontmatter
- Reference docs included for common patterns
- All skills organized by product area (Foundry, AI, Data, etc.)