### PR TITLE
docs: add links to MCP configs and agent personas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo provides that context:
 - **[127 skills](#skill-catalog)** for Azure SDK and Microsoft Foundry development
 - **[Live Foundry docs](https://context7.com/microsoft/agent-skills)** — Context7-indexed documentation, updated via GitHub Actions workflow
 - **[MCP server configs](.vscode/mcp.json)** — Pre-configured servers for docs, GitHub, browser automation ([full implementations](https://github.com/microsoft/mcp))
-- **Agent personas** — Role-specific agents (backend, frontend, infrastructure, planner) with domain expertise
+- **[Agent personas](.github/agents/)** — Role-specific agents (backend, frontend, infrastructure, planner) with domain expertise
 - **[AGENTS.md](AGENTS.md)** — Template for configuring agent behavior in your projects
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

Follow-up to #28 - adds direct links in the README value proposition section:

- **MCP server configs**: Links to `.vscode/mcp.json` (with secondary link to `microsoft/mcp` for full implementations)
- **Agent personas**: Links to `.github/agents/` folder

## Changes

Before:
```markdown
- **[MCP servers](https://github.com/microsoft/mcp)** — Model Context Protocol implementations for Azure services
- **Agent personas** — Role-specific agents (backend, frontend, infrastructure, planner) with domain expertise
```

After:
```markdown
- **[MCP server configs](.vscode/mcp.json)** — Pre-configured servers for docs, GitHub, browser automation ([full implementations](https://github.com/microsoft/mcp))
- **[Agent personas](.github/agents/)** — Role-specific agents (backend, frontend, infrastructure, planner) with domain expertise
```