### PR TITLE
fix: context7.json validation - remove $schema, shorten description

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,7 +1,6 @@
 {
-  "$schema": "https://context7.com/schema/context7.json",
   "projectTitle": "Agent Skills",
-  "description": "Skills, prompts, and MCP configurations for AI coding agents working with Azure SDKs and Microsoft AI Foundry. Includes 127 skills for Python, .NET, TypeScript, and Java with patterns for authentication, data storage, messaging, and AI services.",
+  "description": "127 skills for AI coding agents working with Azure SDKs and Microsoft AI Foundry. Python, .NET, TypeScript, Java patterns.",
   "folders": [".github/skills", ".github/prompts", ".github/agents", ".github/docs", "output"],
   "excludeFolders": ["skills", ".claude", ".opencode", "node_modules"],
   "excludeFiles": ["SECURITY.md", "blog.wordpress.xml"],


### PR DESCRIPTION
## Problem

Context7 validation failing with:
```
description: String exceeds maximum length of 200
Unrecognized key(s) in object: '$schema'
```

## Fix

- Remove `$schema` key (validator rejects it despite schema allowing it)
- Shorten description from 245 → 122 chars

## Before/After

**Before (invalid):**
```json
{
  "$schema": "https://context7.com/schema/context7.json",
  "description": "Skills, prompts, and MCP configurations for AI coding agents working with Azure SDKs and Microsoft AI Foundry. Includes 127 skills for Python, .NET, TypeScript, and Java with patterns for authentication, data storage, messaging, and AI services."
}
```

**After (valid):**
```json
{
  "description": "127 skills for AI coding agents working with Azure SDKs and Microsoft AI Foundry. Python, .NET, TypeScript, Java patterns."
}
```

This should allow Context7 to index the repository and improve benchmark scores.