### PR TITLE
feat(frontend-ui-dark-ts): add mobile web compatibility

### DIFF
--- a/.github/skills/frontend-ui-dark-ts/SKILL.md
+++ b/.github/skills/frontend-ui-dark-ts/SKILL.md
@@ -33,6 +33,12 @@ npx tailwindcss init -p
 ## Project Structure
 
 ```
+public/
+├── favicon.ico                    # Classic favicon (32x32)
+├── favicon.svg                    # Modern SVG favicon
+├── apple-touch-icon.png           # iOS home screen (180x180)
+├── og-image.png                   # Social sharing image (1200x630)
+└── site.webmanifest               # PWA manifest
 src/
 ├── assets/
 │   └── fonts/
@@ -60,6 +66,66 @@ src/
 ```
 
 ## Configuration
+
+### index.html
+
+The HTML entry point with mobile viewport, favicons, and social meta tags:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    
+    <!-- Favicons -->
+    <link rel="icon" href="/favicon.ico" sizes="32x32" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    
+    <!-- Theme color for mobile browser chrome -->
+    <meta name="theme-color" content="#18181B" />
+    
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="App Name" />
+    <meta property="og:description" content="App description" />
+    <meta property="og:image" content="https://example.com/og-image.png" />
+    <meta property="og:url" content="https://example.com" />
+    
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="App Name" />
+    <meta name="twitter:description" content="App description" />
+    <meta name="twitter:image" content="https://example.com/og-image.png" />
+    
+    <title>App Name</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+### public/site.webmanifest
+
+PWA manifest for installable web apps:
+
+```json
+{
+  "name": "App Name",
+  "short_name": "App",
+  "icons": [
+    { "src": "/favicon.ico", "sizes": "32x32", "type": "image/x-icon" },
+    { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png" }
+  ],
+  "theme_color": "#18181B",
+  "background_color": "#18181B",
+  "display": "standalone"
+}
+```
 
 ### tailwind.config.js
 
@@ -143,6 +209,20 @@ export default {
           '0%': { opacity: '0', transform: 'translateY(-10px)' },
           '100%': { opacity: '1', transform: 'translateY(0)' },
         },
+      },
+      // Mobile: safe area insets for notched devices
+      spacing: {
+        'safe-top': 'env(safe-area-inset-top)',
+        'safe-bottom': 'env(safe-area-inset-bottom)',
+        'safe-left': 'env(safe-area-inset-left)',
+        'safe-right': 'env(safe-area-inset-right)',
+      },
+      // Mobile: minimum touch target sizes (44px per Apple/Google guidelines)
+      minHeight: {
+        'touch': '44px',
+      },
+      minWidth: {
+        'touch': '44px',
       },
     },
   },

--- a/.github/skills/frontend-ui-dark-ts/references/components.md
+++ b/.github/skills/frontend-ui-dark-ts/references/components.md
@@ -28,10 +28,11 @@ const variants: Record<ButtonVariant, string> = {
   danger: 'bg-status-error text-white hover:bg-red-600 active:bg-red-700',
 };
 
+// Size variants - all sizes meet 44px minimum height on mobile for touch targets
 const sizes: Record<ButtonSize, string> = {
-  sm: 'h-8 px-3 text-xs gap-1.5 rounded',
-  md: 'h-10 px-4 text-sm gap-2 rounded-lg',
-  lg: 'h-12 px-6 text-base gap-2.5 rounded-lg',
+  sm: 'h-8 min-h-touch px-3 text-xs gap-1.5 rounded',      // 32px desktop, 44px mobile minimum
+  md: 'h-10 min-h-touch px-4 text-sm gap-2 rounded-lg',    // 40px desktop, 44px mobile minimum
+  lg: 'h-12 px-6 text-base gap-2.5 rounded-lg',            // 48px already exceeds 44px
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -138,7 +139,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             ref={ref}
             id={inputId}
             className={clsx(
-              'w-full h-10 px-3 rounded-lg text-sm text-text-primary',
+              'w-full h-10 min-h-touch px-3 rounded-lg text-sm text-text-primary', // min-h-touch for 44px mobile touch target
               'bg-neutral-bg2 border border-border',
               'placeholder:text-text-muted',
               'focus:outline-none focus:border-brand focus:bg-neutral-bg3',


### PR DESCRIPTION
## Summary

Adds mobile web compatibility patterns to the `frontend-ui-dark-ts` skill:

- **index.html template** with viewport meta, favicon links, Open Graph/Twitter meta tags for social sharing
- **site.webmanifest** for PWA support
- **Tailwind config extensions**: `safe-area-inset-*` spacing utilities for notched devices, `min-h-touch`/`min-w-touch` (44px) for touch targets
- **ResponsiveAppShell** pattern - desktop fixed sidebar, mobile hamburger with drawer
- **MobileHeader** component - fixed top header with 44px hamburger toggle
- **MobileDrawer** component - animated slide-in navigation with backdrop
- **Button/Input updates** - `min-h-touch` for 44px minimum touch targets on mobile

## Design Decisions

- **Breakpoint:** `lg` (1024px) - sidebar visible on desktop, hidden on mobile
- **Touch targets:** 44px minimum per Apple/Google guidelines
- **Safe areas:** Support notched devices (iPhone X+) with `viewport-fit=cover`
- **Theme color:** `#18181B` (neutral-bg1) for browser chrome
- **OG Image:** 1200x630px recommended for social sharing