### PR TITLE
ci: add test harness workflow for PR and push events

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -1,0 +1,44 @@
+name: Test Harness
+
+on:
+  pull_request:
+    paths:
+      - 'tests/**'
+      - '.github/skills/**'
+  push:
+    branches: [main]
+    paths:
+      - 'tests/**'
+      - '.github/skills/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: tests/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: tests
+        run: pnpm install
+
+      - name: TypeScript check
+        working-directory: tests
+        run: pnpm typecheck
+
+      - name: Run tests
+        working-directory: tests
+        run: pnpm test:run
+
+      - name: Run harness (mock mode)
+        working-directory: tests
+        run: pnpm harness azure-ai-agents-py --mock


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to run the test harness on PRs and pushes to main.

## Changes

- New `.github/workflows/test-harness.yml` workflow that:
  - Triggers on PRs and pushes to `main` that touch `tests/**` or `.github/skills/**`
  - Sets up Node.js 20 with pnpm 9
  - Runs TypeScript type checking (`pnpm typecheck`)
  - Runs all tests (`pnpm test:run`)
  - Runs harness in mock mode to verify CLI works

## Testing

- All 45 harness tests pass locally (15 ralph-loop + 30 feedback-builder)
- TypeScript compiles without errors

## Related

Follow-up to PR #54 which implemented the Ralph Loop and migrated to TypeScript-only.