### PR TITLE
Add azure-speech-to-text-rest-py skill for short audio transcription

### DIFF
--- a/.github/skills/azure-speech-to-text-rest-py/SKILL.md
+++ b/.github/skills/azure-speech-to-text-rest-py/SKILL.md
@@ -1,0 +1,372 @@
+---
+name: azure-speech-to-text-rest-py
+description: |
+  Azure Speech to Text REST API for short audio (Python). Use for simple speech recognition of audio files up to 60 seconds without the Speech SDK.
+  Triggers: "speech to text REST", "short audio transcription", "speech recognition REST API", "STT REST", "recognize speech REST".
+  DO NOT USE FOR: Long audio (>60 seconds), real-time streaming, batch transcription, custom speech models, speech translation. Use Speech SDK or Batch Transcription API instead.
+---
+
+# Azure Speech to Text REST API for Short Audio
+
+Simple REST API for speech-to-text transcription of short audio files (up to 60 seconds). No SDK required - just HTTP requests.
+
+## Prerequisites
+
+1. **Azure subscription** - [Create one free](https://azure.microsoft.com/free/)
+2. **Speech resource** - Create in [Azure Portal](https://portal.azure.com/#create/Microsoft.CognitiveServicesSpeechServices)
+3. **Get credentials** - After deployment, go to resource > Keys and Endpoint
+
+## Environment Variables
+
+```bash
+# Required
+AZURE_SPEECH_KEY=<your-speech-resource-key>
+AZURE_SPEECH_REGION=<region>  # e.g., eastus, westus2, westeurope
+
+# Alternative: Use endpoint directly
+AZURE_SPEECH_ENDPOINT=https://<region>.stt.speech.microsoft.com
+```
+
+## Installation
+
+```bash
+pip install requests
+```
+
+## Quick Start
+
+```python
+import os
+import requests
+
+def transcribe_audio(audio_file_path: str, language: str = "en-US") -> dict:
+    """Transcribe short audio file (max 60 seconds) using REST API."""
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    headers = {
+        "Ocp-Apim-Subscription-Key": api_key,
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Accept": "application/json"
+    }
+    
+    params = {
+        "language": language,
+        "format": "detailed"  # or "simple"
+    }
+    
+    with open(audio_file_path, "rb") as audio_file:
+        response = requests.post(url, headers=headers, params=params, data=audio_file)
+    
+    response.raise_for_status()
+    return response.json()
+
+# Usage
+result = transcribe_audio("audio.wav", "en-US")
+print(result["DisplayText"])
+```
+
+## Audio Requirements
+
+| Format | Codec | Sample Rate | Notes |
+|--------|-------|-------------|-------|
+| WAV | PCM | 16 kHz, mono | **Recommended** |
+| OGG | OPUS | 16 kHz, mono | Smaller file size |
+
+**Limitations:**
+- Maximum 60 seconds of audio
+- For pronunciation assessment: maximum 30 seconds
+- No partial/interim results (final only)
+
+## Content-Type Headers
+
+```python
+# WAV PCM 16kHz
+"Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000"
+
+# OGG OPUS
+"Content-Type": "audio/ogg; codecs=opus"
+```
+
+## Response Formats
+
+### Simple Format (default)
+
+```python
+params = {"language": "en-US", "format": "simple"}
+```
+
+```json
+{
+  "RecognitionStatus": "Success",
+  "DisplayText": "Remind me to buy 5 pencils.",
+  "Offset": "1236645672289",
+  "Duration": "1236645672289"
+}
+```
+
+### Detailed Format
+
+```python
+params = {"language": "en-US", "format": "detailed"}
+```
+
+```json
+{
+  "RecognitionStatus": "Success",
+  "Offset": "1236645672289",
+  "Duration": "1236645672289",
+  "NBest": [
+    {
+      "Confidence": 0.9052885,
+      "Display": "What's the weather like?",
+      "ITN": "what's the weather like",
+      "Lexical": "what's the weather like",
+      "MaskedITN": "what's the weather like"
+    }
+  ]
+}
+```
+
+## Chunked Transfer (Recommended)
+
+For lower latency, stream audio in chunks:
+
+```python
+import os
+import requests
+
+def transcribe_chunked(audio_file_path: str, language: str = "en-US") -> dict:
+    """Stream audio in chunks for lower latency."""
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    headers = {
+        "Ocp-Apim-Subscription-Key": api_key,
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Accept": "application/json",
+        "Transfer-Encoding": "chunked",
+        "Expect": "100-continue"
+    }
+    
+    params = {"language": language, "format": "detailed"}
+    
+    def generate_chunks(file_path: str, chunk_size: int = 1024):
+        with open(file_path, "rb") as f:
+            while chunk := f.read(chunk_size):
+                yield chunk
+    
+    response = requests.post(
+        url, 
+        headers=headers, 
+        params=params, 
+        data=generate_chunks(audio_file_path)
+    )
+    
+    response.raise_for_status()
+    return response.json()
+```
+
+## Authentication Options
+
+### Option 1: Subscription Key (Simple)
+
+```python
+headers = {
+    "Ocp-Apim-Subscription-Key": os.environ["AZURE_SPEECH_KEY"]
+}
+```
+
+### Option 2: Bearer Token
+
+```python
+import requests
+import os
+
+def get_access_token() -> str:
+    """Get access token from the token endpoint."""
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    token_url = f"https://{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken"
+    
+    response = requests.post(
+        token_url,
+        headers={
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Length": "0"
+        }
+    )
+    response.raise_for_status()
+    return response.text
+
+# Use token in requests (valid for 10 minutes)
+token = get_access_token()
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+    "Accept": "application/json"
+}
+```
+
+## Query Parameters
+
+| Parameter | Required | Values | Description |
+|-----------|----------|--------|-------------|
+| `language` | **Yes** | `en-US`, `de-DE`, etc. | Language of speech |
+| `format` | No | `simple`, `detailed` | Result format (default: simple) |
+| `profanity` | No | `masked`, `removed`, `raw` | Profanity handling (default: masked) |
+
+## Recognition Status Values
+
+| Status | Description |
+|--------|-------------|
+| `Success` | Recognition succeeded |
+| `NoMatch` | Speech detected but no words matched |
+| `InitialSilenceTimeout` | Only silence detected |
+| `BabbleTimeout` | Only noise detected |
+| `Error` | Internal service error |
+
+## Profanity Handling
+
+```python
+# Mask profanity with asterisks (default)
+params = {"language": "en-US", "profanity": "masked"}
+
+# Remove profanity entirely
+params = {"language": "en-US", "profanity": "removed"}
+
+# Include profanity as-is
+params = {"language": "en-US", "profanity": "raw"}
+```
+
+## Error Handling
+
+```python
+import requests
+
+def transcribe_with_error_handling(audio_path: str, language: str = "en-US") -> dict | None:
+    """Transcribe with proper error handling."""
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    try:
+        with open(audio_path, "rb") as audio_file:
+            response = requests.post(
+                url,
+                headers={
+                    "Ocp-Apim-Subscription-Key": api_key,
+                    "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+                    "Accept": "application/json"
+                },
+                params={"language": language, "format": "detailed"},
+                data=audio_file
+            )
+        
+        if response.status_code == 200:
+            result = response.json()
+            if result.get("RecognitionStatus") == "Success":
+                return result
+            else:
+                print(f"Recognition failed: {result.get('RecognitionStatus')}")
+                return None
+        elif response.status_code == 400:
+            print(f"Bad request: Check language code or audio format")
+        elif response.status_code == 401:
+            print(f"Unauthorized: Check API key or token")
+        elif response.status_code == 403:
+            print(f"Forbidden: Missing authorization header")
+        else:
+            print(f"Error {response.status_code}: {response.text}")
+        
+        return None
+        
+    except requests.exceptions.RequestException as e:
+        print(f"Request failed: {e}")
+        return None
+```
+
+## Async Version
+
+```python
+import os
+import aiohttp
+import asyncio
+
+async def transcribe_async(audio_file_path: str, language: str = "en-US") -> dict:
+    """Async version using aiohttp."""
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    headers = {
+        "Ocp-Apim-Subscription-Key": api_key,
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Accept": "application/json"
+    }
+    
+    params = {"language": language, "format": "detailed"}
+    
+    async with aiohttp.ClientSession() as session:
+        with open(audio_file_path, "rb") as f:
+            audio_data = f.read()
+        
+        async with session.post(url, headers=headers, params=params, data=audio_data) as response:
+            response.raise_for_status()
+            return await response.json()
+
+# Usage
+result = asyncio.run(transcribe_async("audio.wav", "en-US"))
+print(result["DisplayText"])
+```
+
+## Supported Languages
+
+Common language codes (see [full list](https://learn.microsoft.com/azure/ai-services/speech-service/language-support)):
+
+| Code | Language |
+|------|----------|
+| `en-US` | English (US) |
+| `en-GB` | English (UK) |
+| `de-DE` | German |
+| `fr-FR` | French |
+| `es-ES` | Spanish (Spain) |
+| `es-MX` | Spanish (Mexico) |
+| `zh-CN` | Chinese (Mandarin) |
+| `ja-JP` | Japanese |
+| `ko-KR` | Korean |
+| `pt-BR` | Portuguese (Brazil) |
+
+## Best Practices
+
+1. **Use WAV PCM 16kHz mono** for best compatibility
+2. **Enable chunked transfer** for lower latency
+3. **Cache access tokens** for 9 minutes (valid for 10)
+4. **Specify the correct language** for accurate recognition
+5. **Use detailed format** when you need confidence scores
+6. **Handle all RecognitionStatus values** in production code
+
+## When NOT to Use This API
+
+Use the Speech SDK or Batch Transcription API instead when you need:
+
+- Audio longer than 60 seconds
+- Real-time streaming transcription
+- Partial/interim results
+- Speech translation
+- Custom speech models
+- Batch transcription of many files
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| [references/pronunciation-assessment.md](references/pronunciation-assessment.md) | Pronunciation assessment parameters and scoring |

--- a/.github/skills/azure-speech-to-text-rest-py/references/acceptance-criteria.md
+++ b/.github/skills/azure-speech-to-text-rest-py/references/acceptance-criteria.md
@@ -1,0 +1,369 @@
+# Azure Speech to Text REST API Acceptance Criteria
+
+**API**: Azure Speech to Text REST API for Short Audio
+**Documentation**: https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-speech-to-text-short
+**Purpose**: Skill testing acceptance criteria for validating generated code correctness
+
+---
+
+## 1. HTTP Request Construction
+
+### 1.1 ✅ CORRECT: REST API URL Format
+```python
+import os
+
+region = os.environ["AZURE_SPEECH_REGION"]
+url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+```
+
+### 1.2 ✅ CORRECT: Alternative Recognition Mode
+```python
+# For dictation (longer pauses allowed)
+url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/dictation/cognitiveservices/v1"
+```
+
+### 1.3 ❌ INCORRECT: Wrong URL format
+```python
+# WRONG - Missing stt subdomain
+url = f"https://{region}.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+
+# WRONG - Using API instead of stt
+url = f"https://{region}.api.cognitive.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+
+# WRONG - Using SDK-style endpoint
+url = f"https://{region}.cognitiveservices.azure.com/speech"
+```
+
+---
+
+## 2. Authentication
+
+### 2.1 ✅ CORRECT: Subscription Key Header
+```python
+headers = {
+    "Ocp-Apim-Subscription-Key": os.environ["AZURE_SPEECH_KEY"]
+}
+```
+
+### 2.2 ✅ CORRECT: Bearer Token Authentication
+```python
+def get_access_token() -> str:
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    token_url = f"https://{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken"
+    
+    response = requests.post(
+        token_url,
+        headers={
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Length": "0"
+        }
+    )
+    response.raise_for_status()
+    return response.text
+
+token = get_access_token()
+headers = {"Authorization": f"Bearer {token}"}
+```
+
+### 2.3 ❌ INCORRECT: Wrong authentication
+```python
+# WRONG - Hardcoded credentials
+headers = {"Ocp-Apim-Subscription-Key": "abc123"}
+
+# WRONG - Wrong header name
+headers = {"X-Api-Key": os.environ["AZURE_SPEECH_KEY"]}
+
+# WRONG - Using AzureKeyCredential (this is REST API, not SDK)
+from azure.core.credentials import AzureKeyCredential
+credential = AzureKeyCredential(os.environ["AZURE_SPEECH_KEY"])
+```
+
+---
+
+## 3. Content-Type Headers
+
+### 3.1 ✅ CORRECT: WAV PCM 16kHz
+```python
+headers = {
+    "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000"
+}
+```
+
+### 3.2 ✅ CORRECT: OGG OPUS
+```python
+headers = {
+    "Content-Type": "audio/ogg; codecs=opus"
+}
+```
+
+### 3.3 ❌ INCORRECT: Wrong content type
+```python
+# WRONG - Missing codec and sample rate
+headers = {"Content-Type": "audio/wav"}
+
+# WRONG - Wrong MIME type
+headers = {"Content-Type": "audio/mpeg"}
+
+# WRONG - Missing codecs parameter
+headers = {"Content-Type": "audio/ogg"}
+```
+
+---
+
+## 4. Request Parameters
+
+### 4.1 ✅ CORRECT: Required Language Parameter
+```python
+params = {
+    "language": "en-US"
+}
+```
+
+### 4.2 ✅ CORRECT: Full Parameters
+```python
+params = {
+    "language": "en-US",
+    "format": "detailed",  # or "simple"
+    "profanity": "masked"  # or "removed", "raw"
+}
+```
+
+### 4.3 ❌ INCORRECT: Missing language
+```python
+# WRONG - Language is required
+params = {"format": "detailed"}
+
+# WRONG - Using locale instead of language
+params = {"locale": "en-US"}
+```
+
+---
+
+## 5. Making the Request
+
+### 5.1 ✅ CORRECT: Basic Request
+```python
+import requests
+
+def transcribe_audio(audio_file_path: str, language: str = "en-US") -> dict:
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    headers = {
+        "Ocp-Apim-Subscription-Key": api_key,
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Accept": "application/json"
+    }
+    
+    params = {"language": language, "format": "detailed"}
+    
+    with open(audio_file_path, "rb") as audio_file:
+        response = requests.post(url, headers=headers, params=params, data=audio_file)
+    
+    response.raise_for_status()
+    return response.json()
+```
+
+### 5.2 ✅ CORRECT: Chunked Transfer for Lower Latency
+```python
+def transcribe_chunked(audio_file_path: str) -> dict:
+    headers = {
+        "Ocp-Apim-Subscription-Key": os.environ["AZURE_SPEECH_KEY"],
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Transfer-Encoding": "chunked",
+        "Expect": "100-continue"
+    }
+    
+    def generate_chunks(file_path: str, chunk_size: int = 1024):
+        with open(file_path, "rb") as f:
+            while chunk := f.read(chunk_size):
+                yield chunk
+    
+    response = requests.post(url, headers=headers, params=params, data=generate_chunks(audio_file_path))
+    return response.json()
+```
+
+### 5.3 ❌ INCORRECT: Wrong request method or format
+```python
+# WRONG - GET instead of POST
+response = requests.get(url, headers=headers, params=params)
+
+# WRONG - Using JSON body instead of binary audio
+response = requests.post(url, headers=headers, json={"audio": audio_data})
+
+# WRONG - Using Speech SDK client
+from azure.cognitiveservices.speech import SpeechRecognizer
+```
+
+---
+
+## 6. Response Handling
+
+### 6.1 ✅ CORRECT: Simple Response
+```python
+result = response.json()
+if result.get("RecognitionStatus") == "Success":
+    print(result["DisplayText"])
+```
+
+### 6.2 ✅ CORRECT: Detailed Response with NBest
+```python
+result = response.json()
+if result.get("RecognitionStatus") == "Success":
+    for item in result.get("NBest", []):
+        print(f"Text: {item['Display']}")
+        print(f"Confidence: {item['Confidence']}")
+```
+
+### 6.3 ✅ CORRECT: Status Handling
+```python
+status = result.get("RecognitionStatus")
+if status == "Success":
+    print(result["DisplayText"])
+elif status == "NoMatch":
+    print("No speech detected")
+elif status == "InitialSilenceTimeout":
+    print("Only silence detected")
+elif status == "BabbleTimeout":
+    print("Only noise detected")
+else:
+    print(f"Error: {status}")
+```
+
+### 6.4 ❌ INCORRECT: Wrong response access
+```python
+# WRONG - Using lowercase keys
+print(result["displayText"])
+
+# WRONG - Assuming always has text
+print(result["DisplayText"])  # May be None if NoMatch
+
+# WRONG - SDK-style response
+print(result.text)
+```
+
+---
+
+## 7. Async Version
+
+### 7.1 ✅ CORRECT: Using aiohttp
+```python
+import aiohttp
+import asyncio
+
+async def transcribe_async(audio_file_path: str, language: str = "en-US") -> dict:
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    headers = {
+        "Ocp-Apim-Subscription-Key": api_key,
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Accept": "application/json"
+    }
+    
+    params = {"language": language, "format": "detailed"}
+    
+    async with aiohttp.ClientSession() as session:
+        with open(audio_file_path, "rb") as f:
+            audio_data = f.read()
+        
+        async with session.post(url, headers=headers, params=params, data=audio_data) as response:
+            response.raise_for_status()
+            return await response.json()
+```
+
+### 7.2 ❌ INCORRECT: Blocking in async
+```python
+# WRONG - Using blocking requests in async
+async def transcribe_wrong():
+    response = requests.post(url, data=audio)  # Blocks event loop
+```
+
+---
+
+## 8. Error Handling
+
+### 8.1 ✅ CORRECT: HTTP and Recognition Errors
+```python
+try:
+    response = requests.post(url, headers=headers, params=params, data=audio_file)
+    
+    if response.status_code == 200:
+        result = response.json()
+        if result.get("RecognitionStatus") == "Success":
+            return result
+        else:
+            print(f"Recognition failed: {result.get('RecognitionStatus')}")
+    elif response.status_code == 400:
+        print("Bad request: Check language code or audio format")
+    elif response.status_code == 401:
+        print("Unauthorized: Check API key")
+    elif response.status_code == 403:
+        print("Forbidden: Missing authorization header")
+        
+except requests.exceptions.RequestException as e:
+    print(f"Request failed: {e}")
+```
+
+### 8.2 ❌ INCORRECT: No error handling
+```python
+# WRONG - No error handling
+response = requests.post(url, data=audio)
+return response.json()["DisplayText"]
+```
+
+---
+
+## 9. Do NOT Use
+
+### 9.1 ❌ INCORRECT: Using Speech SDK
+```python
+# WRONG - This skill is for REST API, not SDK
+from azure.cognitiveservices.speech import SpeechRecognizer
+from azure.cognitiveservices.speech import SpeechConfig
+
+# WRONG - SDK-style configuration
+speech_config = SpeechConfig(subscription=key, region=region)
+```
+
+### 9.2 ❌ INCORRECT: Using Azure SDK Credentials
+```python
+# WRONG - REST API doesn't use Azure SDK credentials
+from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AzureKeyCredential
+```
+
+---
+
+## 10. Audio Limitations
+
+### 10.1 ✅ CORRECT: Documented Limits
+- Maximum audio duration: 60 seconds
+- For pronunciation assessment: 30 seconds maximum
+- Supported formats: WAV PCM 16kHz mono, OGG OPUS
+
+### 10.2 ❌ INCORRECT: Exceeding Limits
+```python
+# WRONG - No validation of audio length
+# Audio > 60 seconds will fail
+```
+
+---
+
+## Summary: Key Patterns
+
+| Pattern | Correct | Incorrect |
+|---------|---------|-----------|
+| URL format | `{region}.stt.speech.microsoft.com` | `{region}.speech.microsoft.com` |
+| Auth header | `Ocp-Apim-Subscription-Key` | `X-Api-Key`, hardcoded |
+| Content-Type | `audio/wav; codecs=audio/pcm; samplerate=16000` | `audio/wav` (missing params) |
+| Required param | `language=en-US` | Missing or `locale=en-US` |
+| Response key | `RecognitionStatus`, `DisplayText` | `recognitionStatus`, `displayText` |
+| Library | `requests`, `aiohttp` | `azure.cognitiveservices.speech` |

--- a/.github/skills/azure-speech-to-text-rest-py/references/pronunciation-assessment.md
+++ b/.github/skills/azure-speech-to-text-rest-py/references/pronunciation-assessment.md
@@ -1,0 +1,276 @@
+# Pronunciation Assessment
+
+Evaluate pronunciation quality of speech input using the REST API for short audio.
+
+## Limitations
+
+- Maximum 30 seconds of audio (vs 60 seconds for regular transcription)
+- Requires reference text to compare against
+
+## Headers
+
+Add the `Pronunciation-Assessment` header with Base64-encoded JSON parameters:
+
+```python
+import base64
+import json
+import os
+import requests
+
+def transcribe_with_pronunciation_assessment(
+    audio_file_path: str,
+    reference_text: str,
+    language: str = "en-US"
+) -> dict:
+    """Transcribe with pronunciation assessment."""
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    # Build pronunciation assessment parameters
+    pron_params = {
+        "ReferenceText": reference_text,
+        "GradingSystem": "HundredMark",
+        "Granularity": "Word",
+        "Dimension": "Comprehensive",
+        "EnableProsodyAssessment": True
+    }
+    
+    # Base64 encode the JSON
+    pron_header = base64.b64encode(
+        json.dumps(pron_params).encode("utf-8")
+    ).decode("utf-8")
+    
+    headers = {
+        "Ocp-Apim-Subscription-Key": api_key,
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Accept": "application/json",
+        "Pronunciation-Assessment": pron_header
+    }
+    
+    params = {"language": language, "format": "detailed"}
+    
+    with open(audio_file_path, "rb") as audio_file:
+        response = requests.post(url, headers=headers, params=params, data=audio_file)
+    
+    response.raise_for_status()
+    return response.json()
+
+# Usage
+result = transcribe_with_pronunciation_assessment(
+    "greeting.wav",
+    "Good morning.",
+    "en-US"
+)
+
+# Access pronunciation scores
+if result["RecognitionStatus"] == "Success":
+    nbest = result["NBest"][0]
+    print(f"Accuracy: {nbest['AccuracyScore']}")
+    print(f"Fluency: {nbest['FluencyScore']}")
+    print(f"Prosody: {nbest.get('ProsodyScore', 'N/A')}")
+    print(f"Completeness: {nbest['CompletenessScore']}")
+    print(f"Overall: {nbest['PronScore']}")
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `ReferenceText` | **Yes** | Text the pronunciation is evaluated against |
+| `GradingSystem` | No | `FivePoint` (0-5) or `HundredMark` (0-100). Default: `FivePoint` |
+| `Granularity` | No | `Phoneme`, `Word`, or `FullText`. Default: `Phoneme` |
+| `Dimension` | No | `Basic` (accuracy only) or `Comprehensive`. Default: `Basic` |
+| `EnableMiscue` | No | Enable omission/insertion detection. Default: `False` |
+| `EnableProsodyAssessment` | No | Enable prosody scoring. Default: `False` |
+| `ScenarioId` | No | GUID for custom point system |
+
+## Grading Systems
+
+### FivePoint (Default)
+- Returns floating-point scores from 0.0 to 5.0
+
+### HundredMark
+- Returns floating-point scores from 0.0 to 100.0
+- More intuitive for most applications
+
+## Granularity Levels
+
+### Phoneme (Default)
+Shows scores at full-text, word, and phoneme levels:
+```json
+{
+  "AccuracyScore": 95.0,
+  "Words": [
+    {
+      "Word": "good",
+      "AccuracyScore": 100.0,
+      "Phonemes": [
+        {"Phoneme": "g", "AccuracyScore": 100.0},
+        {"Phoneme": "uh", "AccuracyScore": 95.0},
+        {"Phoneme": "d", "AccuracyScore": 100.0}
+      ]
+    }
+  ]
+}
+```
+
+### Word
+Shows scores at full-text and word levels only.
+
+### FullText
+Shows score at full-text level only.
+
+## Response with Pronunciation Assessment
+
+```json
+{
+  "RecognitionStatus": "Success",
+  "Offset": 700000,
+  "Duration": 8400000,
+  "DisplayText": "Good morning.",
+  "SNR": 38.76819,
+  "NBest": [
+    {
+      "Confidence": 0.98503506,
+      "Lexical": "good morning",
+      "Display": "Good morning.",
+      "AccuracyScore": 100.0,
+      "FluencyScore": 100.0,
+      "ProsodyScore": 87.8,
+      "CompletenessScore": 100.0,
+      "PronScore": 95.1,
+      "Words": [
+        {
+          "Word": "good",
+          "Offset": 700000,
+          "Duration": 2600000,
+          "AccuracyScore": 100.0,
+          "ErrorType": "None",
+          "Feedback": {
+            "Prosody": {
+              "Break": {
+                "ErrorTypes": ["None"],
+                "BreakLength": 0
+              },
+              "Intonation": {
+                "ErrorTypes": [],
+                "Monotone": {
+                  "Confidence": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "Word": "morning",
+          "Offset": 3400000,
+          "Duration": 5700000,
+          "AccuracyScore": 100.0,
+          "ErrorType": "None"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Score Definitions
+
+| Score | Description |
+|-------|-------------|
+| `AccuracyScore` | How closely phonemes match native speaker pronunciation |
+| `FluencyScore` | How well speech matches native speaker's use of silent breaks |
+| `ProsodyScore` | Naturalness including stress, intonation, speaking speed, rhythm |
+| `CompletenessScore` | Ratio of pronounced words to reference text |
+| `PronScore` | Overall pronunciation quality (weighted aggregate) |
+
+## Error Types
+
+When `EnableMiscue` is true, words include `ErrorType`:
+
+| ErrorType | Description |
+|-----------|-------------|
+| `None` | Word pronounced correctly |
+| `Omission` | Word in reference was skipped |
+| `Insertion` | Extra word not in reference |
+| `Mispronunciation` | Word pronounced incorrectly |
+
+## Complete Example with All Features
+
+```python
+import base64
+import json
+import os
+import requests
+
+def full_pronunciation_assessment(
+    audio_path: str,
+    reference_text: str,
+    language: str = "en-US"
+) -> None:
+    """Full pronunciation assessment with detailed output."""
+    region = os.environ["AZURE_SPEECH_REGION"]
+    api_key = os.environ["AZURE_SPEECH_KEY"]
+    
+    url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+    
+    pron_params = {
+        "ReferenceText": reference_text,
+        "GradingSystem": "HundredMark",
+        "Granularity": "Word",
+        "Dimension": "Comprehensive",
+        "EnableMiscue": True,
+        "EnableProsodyAssessment": True
+    }
+    
+    pron_header = base64.b64encode(
+        json.dumps(pron_params).encode()
+    ).decode()
+    
+    headers = {
+        "Ocp-Apim-Subscription-Key": api_key,
+        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+        "Accept": "application/json",
+        "Pronunciation-Assessment": pron_header
+    }
+    
+    with open(audio_path, "rb") as f:
+        response = requests.post(
+            url,
+            headers=headers,
+            params={"language": language, "format": "detailed"},
+            data=f
+        )
+    
+    response.raise_for_status()
+    result = response.json()
+    
+    if result["RecognitionStatus"] != "Success":
+        print(f"Recognition failed: {result['RecognitionStatus']}")
+        return
+    
+    nbest = result["NBest"][0]
+    
+    print(f"\n=== Overall Scores ===")
+    print(f"Accuracy:     {nbest['AccuracyScore']:.1f}")
+    print(f"Fluency:      {nbest['FluencyScore']:.1f}")
+    print(f"Prosody:      {nbest.get('ProsodyScore', 'N/A')}")
+    print(f"Completeness: {nbest['CompletenessScore']:.1f}")
+    print(f"Overall:      {nbest['PronScore']:.1f}")
+    
+    print(f"\n=== Word-Level Analysis ===")
+    for word in nbest["Words"]:
+        error = word.get("ErrorType", "None")
+        accuracy = word.get("AccuracyScore", 0)
+        marker = "" if error == "None" else f" [{error}]"
+        print(f"  {word['Word']}: {accuracy:.1f}{marker}")
+
+# Usage
+full_pronunciation_assessment(
+    "user_speech.wav",
+    "The quick brown fox jumps over the lazy dog.",
+    "en-US"
+)
+```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx ctx7 skills install /microsoft/agent-skills azure-ai-projects-py
 
 | Resource | Description |
 |----------|-------------|
-| **[128 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
+| **[129 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
 | **[Custom Agents](#agents)** | Role-specific agents (backend, frontend, infrastructure, planner) |
 | **[AGENTS.md](AGENTS.md)** | Template for configuring agent behavior in your projects |
 | **[MCP Configs](#mcp-servers)** | Pre-configured servers for docs, GitHub, browser automation |
@@ -71,12 +71,12 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 ## Skill Catalog
 
-> 128 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
+> 129 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
 
 | Language | Count | Suffix | 
 |----------|-------|--------|
 | [Core](#core) | 5 | — |
-| [Python](#python) | 41 | `-py` |
+| [Python](#python) | 42 | `-py` |
 | [.NET](#net) | 29 | `-dotnet` |
 | [TypeScript](#typescript) | 25 | `-ts` |
 | [Java](#java) | 28 | `-java` |
@@ -99,7 +99,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 ### Python
 
-> 41 skills • suffix: `-py`
+> 42 skills • suffix: `-py`
 
 <details>
 <summary><strong>Foundry & AI</strong> (7 skills)</summary>
@@ -117,7 +117,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 </details>
 
 <details>
-<summary><strong>AI Services</strong> (8 skills)</summary>
+<summary><strong>AI Services</strong> (9 skills)</summary>
 
 | Skill | Description |
 |-------|-------------|
@@ -129,6 +129,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 | [azure-ai-translation-text-py](.github/skills/azure-ai-translation-text-py/) | Text Translation — real-time translation, transliteration, language detection. |
 | [azure-ai-vision-imageanalysis-py](.github/skills/azure-ai-vision-imageanalysis-py/) | Vision SDK — captions, tags, objects, OCR, people detection, smart cropping. |
 | [azure-ai-voicelive-py](.github/skills/azure-ai-voicelive-py/) | Voice Live SDK — real-time bidirectional voice AI with WebSocket, VAD, avatars. |
+| [azure-speech-to-text-rest-py](.github/skills/azure-speech-to-text-rest-py/) | Speech to Text REST API — transcribe short audio (≤60 seconds) via HTTP without Speech SDK. |
 
 </details>
 

--- a/skills/python/foundry/speech-to-text-rest
+++ b/skills/python/foundry/speech-to-text-rest
@@ -1,0 +1,1 @@
+../../../.github/skills/azure-speech-to-text-rest-py

--- a/tests/scenarios/azure-speech-to-text-rest-py/scenarios.yaml
+++ b/tests/scenarios/azure-speech-to-text-rest-py/scenarios.yaml
@@ -1,0 +1,423 @@
+config:
+  max_tokens: 2000
+  model: gpt-4
+  temperature: 0.3
+scenarios:
+- expected_patterns:
+  - requests\.post
+  - stt\.speech\.microsoft\.com
+  - Ocp-Apim-Subscription-Key
+  - Content-Type
+  - audio/wav; codecs=audio/pcm; samplerate=16000
+  - language
+  forbidden_patterns:
+  - SpeechRecognizer
+  - SpeechConfig
+  - azure\.cognitiveservices\.speech
+  - DefaultAzureCredential
+  - AzureKeyCredential
+  mock_response: |
+    import os
+    import requests
+
+    def transcribe_audio(audio_file_path: str, language: str = "en-US") -> dict:
+        """Transcribe short audio file (max 60 seconds) using REST API."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        headers = {
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+            "Accept": "application/json"
+        }
+        
+        params = {"language": language}
+        
+        with open(audio_file_path, "rb") as audio_file:
+            response = requests.post(url, headers=headers, params=params, data=audio_file)
+        
+        response.raise_for_status()
+        return response.json()
+
+    # Usage
+    result = transcribe_audio("audio.wav", "en-US")
+    print(result["DisplayText"])
+  name: basic_transcription
+  prompt: |
+    Create a basic speech-to-text transcription function using Azure Speech REST API.
+    Use the requests library to make an HTTP POST request to transcribe a WAV audio file.
+    Include proper authentication with subscription key from environment variables.
+  tags:
+  - basic
+  - authentication
+- expected_patterns:
+  - format.*detailed
+  - NBest
+  - Confidence
+  - Display
+  - RecognitionStatus
+  forbidden_patterns:
+  - format.*simple
+  mock_response: |
+    import os
+    import requests
+
+    def transcribe_detailed(audio_file_path: str, language: str = "en-US") -> dict:
+        """Transcribe audio with detailed response including NBest alternatives."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        headers = {
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+            "Accept": "application/json"
+        }
+        
+        params = {
+            "language": language,
+            "format": "detailed"
+        }
+        
+        with open(audio_file_path, "rb") as audio_file:
+            response = requests.post(url, headers=headers, params=params, data=audio_file)
+        
+        response.raise_for_status()
+        result = response.json()
+        
+        if result.get("RecognitionStatus") == "Success":
+            for item in result.get("NBest", []):
+                print(f"Text: {item['Display']}")
+                print(f"Confidence: {item['Confidence']}")
+        
+        return result
+  name: detailed_format_response
+  prompt: |
+    Create a speech-to-text function that uses the detailed response format.
+    Parse the NBest array to extract multiple recognition alternatives with confidence scores.
+    Print each alternative's Display text and Confidence score.
+  tags:
+  - detailed
+  - nbest
+- expected_patterns:
+  - Transfer-Encoding.*chunked
+  - Expect.*100-continue
+  - yield
+  - chunk
+  - generate_chunks|def.*chunk
+  forbidden_patterns:
+  - data=audio_file\.read\(\)
+  mock_response: |
+    import os
+    import requests
+
+    def transcribe_chunked(audio_file_path: str, language: str = "en-US") -> dict:
+        """Stream audio in chunks for lower latency."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        headers = {
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+            "Accept": "application/json",
+            "Transfer-Encoding": "chunked",
+            "Expect": "100-continue"
+        }
+        
+        params = {"language": language, "format": "detailed"}
+        
+        def generate_chunks(file_path: str, chunk_size: int = 1024):
+            with open(file_path, "rb") as f:
+                while chunk := f.read(chunk_size):
+                    yield chunk
+        
+        response = requests.post(
+            url, 
+            headers=headers, 
+            params=params, 
+            data=generate_chunks(audio_file_path)
+        )
+        
+        response.raise_for_status()
+        return response.json()
+  name: chunked_transfer
+  prompt: |
+    Create a speech-to-text function that uses chunked transfer encoding for lower latency.
+    Stream the audio file in chunks using a generator function.
+    Include the Transfer-Encoding and Expect headers required for chunked transfer.
+  tags:
+  - chunked
+  - streaming
+  - latency
+- expected_patterns:
+  - sts/v1\.0/issueToken
+  - Bearer
+  - Authorization
+  - get_access_token|get_token|fetch_token
+  forbidden_patterns:
+  - Ocp-Apim-Subscription-Key.*stt\.speech
+  mock_response: |
+    import os
+    import requests
+
+    def get_access_token() -> str:
+        """Get access token from the token endpoint."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        token_url = f"https://{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken"
+        
+        response = requests.post(
+            token_url,
+            headers={
+                "Ocp-Apim-Subscription-Key": api_key,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Content-Length": "0"
+            }
+        )
+        response.raise_for_status()
+        return response.text
+
+    def transcribe_with_token(audio_file_path: str, language: str = "en-US") -> dict:
+        """Transcribe audio using bearer token authentication."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        token = get_access_token()
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+            "Accept": "application/json"
+        }
+        
+        params = {"language": language}
+        
+        with open(audio_file_path, "rb") as audio_file:
+            response = requests.post(url, headers=headers, params=params, data=audio_file)
+        
+        response.raise_for_status()
+        return response.json()
+  name: bearer_token_auth
+  prompt: |
+    Create a speech-to-text function that uses bearer token authentication instead of subscription key.
+    First obtain an access token from the token endpoint, then use it in the Authorization header.
+    The token endpoint is at {region}.api.cognitive.microsoft.com/sts/v1.0/issueToken.
+  tags:
+  - authentication
+  - bearer-token
+- expected_patterns:
+  - aiohttp
+  - async def
+  - await
+  - ClientSession
+  - async with
+  forbidden_patterns:
+  - requests\.post
+  - requests\.get
+  mock_response: |
+    import os
+    import aiohttp
+    import asyncio
+
+    async def transcribe_async(audio_file_path: str, language: str = "en-US") -> dict:
+        """Async version using aiohttp."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        headers = {
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+            "Accept": "application/json"
+        }
+        
+        params = {"language": language, "format": "detailed"}
+        
+        async with aiohttp.ClientSession() as session:
+            with open(audio_file_path, "rb") as f:
+                audio_data = f.read()
+            
+            async with session.post(url, headers=headers, params=params, data=audio_data) as response:
+                response.raise_for_status()
+                return await response.json()
+
+    # Usage
+    result = asyncio.run(transcribe_async("audio.wav", "en-US"))
+    print(result["DisplayText"])
+  name: async_transcription
+  prompt: |
+    Create an async speech-to-text function using aiohttp instead of requests.
+    Use async/await patterns with ClientSession for non-blocking HTTP requests.
+    Do not use the blocking requests library.
+  tags:
+  - async
+  - aiohttp
+- expected_patterns:
+  - 'try:'
+  - except
+  - status_code.*200
+  - status_code.*400|status_code.*401|status_code.*403
+  - RecognitionStatus
+  - RequestException|requests\.exceptions
+  forbidden_patterns:
+  - return response\.json\(\)\["DisplayText"\]
+  mock_response: |
+    import os
+    import requests
+
+    def transcribe_with_error_handling(audio_path: str, language: str = "en-US") -> dict | None:
+        """Transcribe with proper error handling."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        try:
+            with open(audio_path, "rb") as audio_file:
+                response = requests.post(
+                    url,
+                    headers={
+                        "Ocp-Apim-Subscription-Key": api_key,
+                        "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+                        "Accept": "application/json"
+                    },
+                    params={"language": language, "format": "detailed"},
+                    data=audio_file
+                )
+            
+            if response.status_code == 200:
+                result = response.json()
+                if result.get("RecognitionStatus") == "Success":
+                    return result
+                else:
+                    print(f"Recognition failed: {result.get('RecognitionStatus')}")
+                    return None
+            elif response.status_code == 400:
+                print("Bad request: Check language code or audio format")
+            elif response.status_code == 401:
+                print("Unauthorized: Check API key or token")
+            elif response.status_code == 403:
+                print("Forbidden: Missing authorization header")
+            else:
+                print(f"Error {response.status_code}: {response.text}")
+            
+            return None
+            
+        except requests.exceptions.RequestException as e:
+            print(f"Request failed: {e}")
+            return None
+  name: error_handling
+  prompt: |
+    Create a speech-to-text function with comprehensive error handling.
+    Handle HTTP status codes (200, 400, 401, 403) and RecognitionStatus values.
+    Also handle requests.exceptions.RequestException for network errors.
+  tags:
+  - error-handling
+  - production
+- expected_patterns:
+  - profanity
+  - masked|removed|raw
+  - params.*profanity|profanity.*params
+  forbidden_patterns: []
+  mock_response: |
+    import os
+    import requests
+
+    def transcribe_with_profanity_filter(
+        audio_file_path: str, 
+        language: str = "en-US",
+        profanity_mode: str = "masked"
+    ) -> dict:
+        """Transcribe audio with configurable profanity handling.
+        
+        Args:
+            profanity_mode: "masked" (asterisks), "removed" (omit), or "raw" (include)
+        """
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        headers = {
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
+            "Accept": "application/json"
+        }
+        
+        params = {
+            "language": language,
+            "format": "detailed",
+            "profanity": profanity_mode
+        }
+        
+        with open(audio_file_path, "rb") as audio_file:
+            response = requests.post(url, headers=headers, params=params, data=audio_file)
+        
+        response.raise_for_status()
+        return response.json()
+
+    # Usage examples
+    result_masked = transcribe_with_profanity_filter("audio.wav", profanity_mode="masked")
+    result_raw = transcribe_with_profanity_filter("audio.wav", profanity_mode="raw")
+  name: profanity_handling
+  prompt: |
+    Create a speech-to-text function with configurable profanity handling.
+    Support the three profanity modes: "masked" (asterisks), "removed" (omit), and "raw" (include).
+    Pass the profanity parameter in the query string.
+  tags:
+  - profanity
+  - content-filtering
+- expected_patterns:
+  - audio/ogg; codecs=opus
+  - Content-Type.*ogg
+  forbidden_patterns:
+  - audio/wav; codecs=audio/pcm
+  - samplerate=16000
+  mock_response: |
+    import os
+    import requests
+
+    def transcribe_ogg_opus(audio_file_path: str, language: str = "en-US") -> dict:
+        """Transcribe OGG OPUS audio file (smaller file size than WAV)."""
+        region = os.environ["AZURE_SPEECH_REGION"]
+        api_key = os.environ["AZURE_SPEECH_KEY"]
+        
+        url = f"https://{region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
+        
+        headers = {
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "audio/ogg; codecs=opus",
+            "Accept": "application/json"
+        }
+        
+        params = {
+            "language": language,
+            "format": "detailed"
+        }
+        
+        with open(audio_file_path, "rb") as audio_file:
+            response = requests.post(url, headers=headers, params=params, data=audio_file)
+        
+        response.raise_for_status()
+        return response.json()
+
+    # Usage
+    result = transcribe_ogg_opus("audio.ogg", "en-US")
+    if result.get("RecognitionStatus") == "Success":
+        print(result.get("DisplayText"))
+  name: ogg_opus_format
+  prompt: |
+    Create a speech-to-text function for OGG OPUS audio format instead of WAV.
+    Use the correct Content-Type header for OGG OPUS files.
+    This format has smaller file sizes compared to WAV PCM.
+  tags:
+  - audio-format
+  - ogg
+  - opus


### PR DESCRIPTION
## Summary
- Add new Python skill for Azure Speech-to-Text using REST API (no SDK dependency)
- Simple HTTP-based approach using only the `requests` library
- Designed for short audio files (≤60 seconds)

## Why REST API instead of Speech SDK?
- **Simpler**: Just HTTP requests, no complex SDK setup
- **Lighter**: No SDK installation required, just `requests`
- **Portable**: Works in any Python environment without native dependencies

## Files Added
| File | Description |
|------|-------------|
| `.github/skills/azure-speech-to-text-rest-py/SKILL.md` | Main skill documentation with REST API patterns |
| `.github/skills/azure-speech-to-text-rest-py/references/acceptance-criteria.md` | Correct/incorrect code patterns |
| `.github/skills/azure-speech-to-text-rest-py/references/pronunciation-assessment.md` | Pronunciation assessment feature |
| `tests/scenarios/azure-speech-to-text-rest-py/scenarios.yaml` | 8 test scenarios |
| `skills/python/foundry/speech-to-text-rest` | Symlink for discovery |

## Test Results
```
Pass Rate: 100.0%
Average Score: 91.3
Scenarios: 8
```

| Scenario | Description |
|----------|-------------|
| `basic_transcription` | Simple audio transcription with subscription key |
| `detailed_format_response` | NBest results with confidence scores |
| `chunked_transfer` | Streaming audio in chunks for lower latency |
| `bearer_token_auth` | Token endpoint authentication |
| `async_transcription` | aiohttp async version |
| `error_handling` | HTTP and RecognitionStatus error handling |
| `profanity_handling` | masked/removed/raw profanity modes |
| `ogg_opus_format` | OGG OPUS audio format |

## Key Features
- Subscription key and Bearer token authentication
- Multiple audio formats (WAV, OGG OPUS)
- Simple and detailed response formats
- Chunked transfer encoding for streaming
- Pronunciation assessment
- Profanity handling options
- Async support with aiohttp