### PR TITLE
Improve workflow naming, badges, and evaluation speed

### DIFF
--- a/.github/workflows/skill-evaluation.yml
+++ b/.github/workflows/skill-evaluation.yml
@@ -1,4 +1,4 @@
-name: Skill Evaluation (Real SDK)
+name: Copilot SDK Tests
 
 on:
   schedule:
@@ -24,7 +24,7 @@ on:
         description: 'Max Ralph Loop iterations'
         required: false
         type: number
-        default: 5
+        default: 2
 
 jobs:
   evaluate:
@@ -72,7 +72,7 @@ jobs:
           SKILL_ARG="${{ inputs.skill }}"
           RALPH_FLAG=""
           THRESHOLD="${{ inputs.threshold || 80 }}"
-          MAX_ITER="${{ inputs.max_iterations || 5 }}"
+          MAX_ITER="${{ inputs.max_iterations || 2 }}"
           
           if [ "${{ inputs.ralph }}" = "true" ]; then
             RALPH_FLAG="--ralph --threshold $THRESHOLD --max-iterations $MAX_ITER"
@@ -85,9 +85,9 @@ jobs:
             pnpm harness "$SKILL_ARG" $RALPH_FLAG --output json --output-file results.json
           else
             # All skills evaluation
-            pnpm harness --all $RALPH_FLAG --output markdown --output-file results.md
+            pnpm harness --all $RALPH_FLAG --verbose --output markdown --output-file results.md
             HARNESS_EXIT=$?
-            pnpm harness --all $RALPH_FLAG --output json --output-file results.json
+            pnpm harness --all $RALPH_FLAG --verbose --output json --output-file results.json
           fi
           
           set -e
@@ -98,11 +98,11 @@ jobs:
         if: always()
         working-directory: tests
         run: |
-          echo "## Skill Evaluation Results (Real SDK)" >> $GITHUB_STEP_SUMMARY
+          echo "## Copilot SDK Tests Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Mode:** Real Copilot SDK evaluation" >> $GITHUB_STEP_SUMMARY
+          echo "**Mode:** Real Copilot SDK evaluation (nightly)" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.ralph }}" = "true" ]; then
-            echo "**Ralph Loop:** Enabled (threshold: ${{ inputs.threshold || 80 }}, max iterations: ${{ inputs.max_iterations || 5 }})" >> $GITHUB_STEP_SUMMARY
+            echo "**Ralph Loop:** Enabled (threshold: ${{ inputs.threshold || 80 }}, max iterations: ${{ inputs.max_iterations || 2 }})" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -1,7 +1,7 @@
-name: Test Harness (Mock Mode)
+name: Smoke Test
 
 # Fast, deterministic testing for PRs and pushes
-# For real SDK evaluation, see skill-evaluation.yml (scheduled/manual trigger)
+# Full evaluation with real SDK runs nightly via skill-evaluation.yml
 
 on:
   pull_request:
@@ -63,10 +63,15 @@ jobs:
             echo "⚠️ No results file found" >> $GITHUB_STEP_SUMMARY
           fi
           
-          # Show overall status
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "ℹ️ This is a **smoke test** using mock responses for fast CI feedback." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Full evaluation with real Copilot SDK runs **nightly at 2 AM UTC** via [Skill Evaluation](../actions/workflows/skill-evaluation.yml)." >> $GITHUB_STEP_SUMMARY
+          
           if [ "${{ steps.harness.outputs.exit_code }}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "---" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ **Some skills have failing scenarios.** See details above." >> $GITHUB_STEP_SUMMARY
           fi
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Agent Skills
 
-[![Evals & Tests](https://github.com/microsoft/agent-skills/actions/workflows/test-harness.yml/badge.svg?branch=main)](https://github.com/microsoft/agent-skills/actions/workflows/test-harness.yml)
+[![Evals & Tests](https://img.shields.io/github/actions/workflow/status/microsoft/agent-skills/test-harness.yml?branch=main&label=Evals%20%26%20Tests)](https://github.com/microsoft/agent-skills/actions/workflows/test-harness.yml)
+[![Copilot SDK Tests](https://img.shields.io/github/actions/workflow/status/microsoft/agent-skills/skill-evaluation.yml?branch=main&label=Copilot%20SDK%20Tests)](https://github.com/microsoft/agent-skills/actions/workflows/skill-evaluation.yml)
 [![Install via skills.sh](https://img.shields.io/badge/skills.sh-install-blue)](https://skills.sh/microsoft/agent-skills)
 [![Browse on Context7](https://img.shields.io/badge/Context7-browse%20skills-purple)](https://context7.com/microsoft/agent-skills?tab=skills)
 


### PR DESCRIPTION
## Summary

- Rename `skill-evaluation.yml` workflow to **Copilot SDK Tests** for clarity
- Rename `test-harness.yml` workflow to **Smoke Test** with explanatory job summary
- Add shields.io badges to README for both workflows (Evals & Tests + Copilot SDK Tests)
- Add `--verbose` flag to all harness runs for better debugging when failures occur
- Reduce default `max_iterations` from 5 to 2 for faster CI runs
- Update job summaries to explain the difference between smoke tests and nightly evaluation

## Changes

| File | Change |
|------|--------|
| `README.md` | Add second badge for Copilot SDK Tests, use shields.io format |
| `.github/workflows/skill-evaluation.yml` | Rename to "Copilot SDK Tests", add verbose logging, reduce max iterations |
| `.github/workflows/test-harness.yml` | Rename to "Smoke Test", add explanatory summary |