### PR TITLE
Update deploy-pages to trigger after llms.txt update workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
     paths: [docs/**]
+  workflow_run:
+    workflows: ["Update Foundry llms.txt Documentation"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +21,8 @@ concurrency:
 
 jobs:
   deploy:
+    # Only run if workflow_dispatch, push, or workflow_run succeeded
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This pull request updates the deployment workflow for GitHub Pages to better coordinate with documentation updates. The main improvement is that the deployment workflow will now automatically trigger after the "Update Foundry llms.txt Documentation" workflow completes successfully, in addition to the existing triggers.