### PR TITLE
Add m365 agents .NET skill

### DIFF
--- a/.github/skills/m365-agents-dotnet/SKILL.md
+++ b/.github/skills/m365-agents-dotnet/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: m365-agents-dotnet
+description: |
+  Microsoft 365 Agents SDK for .NET. Build multichannel agents for Teams/M365/Copilot Studio with ASP.NET Core hosting, AgentApplication routing, and MSAL-based auth. Triggers: "Microsoft 365 Agents SDK", "Microsoft.Agents", "AddAgentApplicationOptions", "AgentApplication", "AddAgentAspNetAuthentication", "Copilot Studio client", "IAgentHttpAdapter".
+package: Microsoft.Agents.Hosting.AspNetCore, Microsoft.Agents.Authentication.Msal, Microsoft.Agents.CopilotStudio.Client
+---
+
+# Microsoft 365 Agents SDK (.NET)
+
+## Overview
+Build enterprise agents for Microsoft 365, Teams, and Copilot Studio using the Microsoft.Agents SDK with ASP.NET Core hosting, agent routing, and MSAL-based authentication.
+
+## Before implementation
+- Use the microsoft-docs MCP to verify the latest APIs for AddAgent, AgentApplication, and authentication options.
+- Confirm package versions in NuGet for the Microsoft.Agents.* packages you plan to use.
+
+## Installation
+
+```bash
+dotnet add package Microsoft.Agents.Hosting.AspNetCore
+dotnet add package Microsoft.Agents.Authentication.Msal
+dotnet add package Microsoft.Agents.Storage
+dotnet add package Microsoft.Agents.CopilotStudio.Client
+dotnet add package Microsoft.Identity.Client.Extensions.Msal
+```
+
+## Configuration (appsettings.json)
+
+```json
+{
+  "TokenValidation": {
+    "Enabled": true,
+    "Audiences": [
+      "{{ClientId}}"
+    ],
+    "TenantId": "{{TenantId}}"
+  },
+  "AgentApplication": {
+    "StartTypingTimer": false,
+    "RemoveRecipientMention": false,
+    "NormalizeMentions": false
+  },
+  "Connections": {
+    "ServiceConnection": {
+      "Settings": {
+        "AuthType": "ClientSecret",
+        "ClientId": "{{ClientId}}",
+        "ClientSecret": "{{ClientSecret}}",
+        "AuthorityEndpoint": "https://login.microsoftonline.com/{{TenantId}}",
+        "Scopes": [
+          "https://api.botframework.com/.default"
+        ]
+      }
+    }
+  },
+  "ConnectionsMap": [
+    {
+      "ServiceUrl": "*",
+      "Connection": "ServiceConnection"
+    }
+  ],
+  "CopilotStudioClientSettings": {
+    "DirectConnectUrl": "",
+    "EnvironmentId": "",
+    "SchemaName": "",
+    "TenantId": "",
+    "AppClientId": "",
+    "AppClientSecret": ""
+  }
+}
+```
+
+## Core Workflow: ASP.NET Core agent host
+
+```csharp
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Hosting.AspNetCore;
+using Microsoft.Agents.Storage;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHttpClient();
+builder.AddAgentApplicationOptions();
+builder.AddAgent<MyAgent>();
+builder.Services.AddSingleton<IStorage, MemoryStorage>();
+
+builder.Services.AddControllers();
+builder.Services.AddAgentAspNetAuthentication(builder.Configuration);
+
+WebApplication app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/", () => "Microsoft Agents SDK Sample");
+
+var incomingRoute = app.MapPost("/api/messages",
+    async (HttpRequest request, HttpResponse response, IAgentHttpAdapter adapter, IAgent agent, CancellationToken ct) =>
+    {
+        await adapter.ProcessAsync(request, response, agent, ct);
+    });
+
+if (!app.Environment.IsDevelopment())
+{
+    incomingRoute.RequireAuthorization();
+}
+else
+{
+    app.Urls.Add("http://localhost:3978");
+}
+
+app.Run();
+```
+
+## AgentApplication routing
+
+```csharp
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public sealed class MyAgent : AgentApplication
+{
+    public MyAgent(AgentApplicationOptions options) : base(options)
+    {
+        OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeAsync);
+        OnActivity(ActivityTypes.Message, OnMessageAsync, rank: RouteRank.Last);
+        OnTurnError(OnTurnErrorAsync);
+    }
+
+    private static async Task WelcomeAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken ct)
+    {
+        foreach (ChannelAccount member in turnContext.Activity.MembersAdded)
+        {
+            if (member.Id != turnContext.Activity.Recipient.Id)
+            {
+                await turnContext.SendActivityAsync(
+                    MessageFactory.Text("Welcome to the agent."),
+                    ct);
+            }
+        }
+    }
+
+    private static async Task OnMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken ct)
+    {
+        await turnContext.SendActivityAsync(
+            MessageFactory.Text($"You said: {turnContext.Activity.Text}"),
+            ct);
+    }
+
+    private static async Task OnTurnErrorAsync(
+        ITurnContext turnContext,
+        ITurnState turnState,
+        Exception exception,
+        CancellationToken ct)
+    {
+        await turnState.Conversation.DeleteStateAsync(turnContext, ct);
+
+        var endOfConversation = Activity.CreateEndOfConversationActivity();
+        endOfConversation.Code = EndOfConversationCodes.Error;
+        endOfConversation.Text = exception.Message;
+        await turnContext.SendActivityAsync(endOfConversation, ct);
+    }
+}
+```
+
+## Copilot Studio direct-to-engine client
+
+### DelegatingHandler for token acquisition (interactive flow)
+
+```csharp
+using System.Net.Http.Headers;
+using Microsoft.Agents.CopilotStudio.Client;
+using Microsoft.Identity.Client;
+
+internal sealed class AddTokenHandler : DelegatingHandler
+{
+    private readonly SampleConnectionSettings _settings;
+
+    public AddTokenHandler(SampleConnectionSettings settings) : base(new HttpClientHandler())
+    {
+        _settings = settings;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Headers.Authorization is null)
+        {
+            string[] scopes = [CopilotClient.ScopeFromSettings(_settings)];
+
+            IPublicClientApplication app = PublicClientApplicationBuilder
+                .Create(_settings.AppClientId)
+                .WithAuthority(AadAuthorityAudience.AzureAdMyOrg)
+                .WithTenantId(_settings.TenantId)
+                .WithRedirectUri("http://localhost")
+                .Build();
+
+            AuthenticationResult authResponse;
+            try
+            {
+                var account = (await app.GetAccountsAsync()).FirstOrDefault();
+                authResponse = await app.AcquireTokenSilent(scopes, account).ExecuteAsync(cancellationToken);
+            }
+            catch (MsalUiRequiredException)
+            {
+                authResponse = await app.AcquireTokenInteractive(scopes).ExecuteAsync(cancellationToken);
+            }
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authResponse.AccessToken);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}
+```
+
+### Console host with CopilotClient
+
+```csharp
+using Microsoft.Agents.CopilotStudio.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+var settings = new SampleConnectionSettings(
+    builder.Configuration.GetSection("CopilotStudioClientSettings"));
+
+builder.Services.AddHttpClient("mcs").ConfigurePrimaryHttpMessageHandler(() =>
+{
+    return new AddTokenHandler(settings);
+});
+
+builder.Services
+    .AddSingleton(settings)
+    .AddTransient<CopilotClient>(sp =>
+    {
+        var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<CopilotClient>();
+        return new CopilotClient(settings, sp.GetRequiredService<IHttpClientFactory>(), logger, "mcs");
+    });
+
+IHost host = builder.Build();
+var client = host.Services.GetRequiredService<CopilotClient>();
+
+await foreach (var activity in client.StartConversationAsync(emitStartConversationEvent: true))
+{
+    Console.WriteLine(activity.Type);
+}
+
+await foreach (var activity in client.AskQuestionAsync("Hello!", null))
+{
+    Console.WriteLine(activity.Type);
+}
+```
+
+## Best Practices
+
+1. Use AgentApplication subclasses to centralize routing and error handling.
+2. Use MemoryStorage only for development; use persisted storage in production.
+3. Enable TokenValidation in production and require authorization on /api/messages.
+4. Keep auth secrets in configuration providers (Key Vault, managed identity, env vars).
+5. Reuse HttpClient from IHttpClientFactory and cache MSAL tokens.
+6. Prefer async handlers and pass CancellationToken to SDK calls.
+
+## Reference Files
+
+| File | Contents |
+| --- | --- |
+| [references/acceptance-criteria.md](references/acceptance-criteria.md) | Import paths, hosting pipeline, Copilot Studio client patterns, anti-patterns |
+
+## Reference Links
+
+| Resource | URL |
+| --- | --- |
+| Microsoft 365 Agents SDK | https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/ |
+| AddAgent API | https://learn.microsoft.com/en-us/dotnet/api/microsoft.agents.hosting.aspnetcore.servicecollectionextensions.addagent?view=m365-agents-sdk |
+| AgentApplication API | https://learn.microsoft.com/en-us/dotnet/api/microsoft.agents.builder.app.agentapplication?view=m365-agents-sdk |
+| Auth configuration options | https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/microsoft-authentication-library-configuration-options |
+| Copilot Studio integration | https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/integrate-with-mcs |
+| GitHub samples | https://github.com/microsoft/agents |

--- a/.github/skills/m365-agents-dotnet/references/acceptance-criteria.md
+++ b/.github/skills/m365-agents-dotnet/references/acceptance-criteria.md
@@ -1,0 +1,163 @@
+# Microsoft 365 Agents SDK Acceptance Criteria (.NET)
+
+**SDK**: `Microsoft.Agents.*` (Hosting.AspNetCore, Builder, Authentication.Msal, CopilotStudio.Client)
+**Repository**: https://github.com/microsoft/agents
+**NuGet Packages**: https://www.nuget.org/packages?q=Microsoft.Agents
+**Purpose**: Skill testing acceptance criteria for validating generated C# code correctness
+
+---
+
+## 1. Correct Using Statements
+
+### 1.1 Core Imports (Hosting)
+
+#### CORRECT
+```csharp
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Hosting.AspNetCore;
+using Microsoft.Agents.Storage;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+```
+
+### 1.2 Core Imports (AgentApplication)
+
+#### CORRECT
+```csharp
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+```
+
+### 1.3 Core Imports (Copilot Studio Client)
+
+#### CORRECT
+```csharp
+using Microsoft.Agents.CopilotStudio.Client;
+using Microsoft.Identity.Client;
+```
+
+### 1.4 Anti-Patterns (ERRORS)
+
+#### INCORRECT: Bot Framework namespaces
+```csharp
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+var adapter = new BotFrameworkHttpAdapter();
+```
+
+---
+
+## 2. Hosting Pipeline
+
+### 2.1 CORRECT: ASP.NET Core registration
+```csharp
+builder.Services.AddHttpClient();
+builder.AddAgentApplicationOptions();
+builder.AddAgent<MyAgent>();
+builder.Services.AddSingleton<IStorage, MemoryStorage>();
+
+builder.Services.AddControllers();
+builder.Services.AddAgentAspNetAuthentication(builder.Configuration);
+```
+
+### 2.2 CORRECT: /api/messages endpoint
+```csharp
+var incomingRoute = app.MapPost("/api/messages",
+    async (HttpRequest request, HttpResponse response, IAgentHttpAdapter adapter, IAgent agent, CancellationToken ct) =>
+    {
+        await adapter.ProcessAsync(request, response, agent, ct);
+    });
+```
+
+### 2.3 INCORRECT: Bot Framework adapter usage
+```csharp
+// WRONG - uses Bot Framework adapter instead of IAgentHttpAdapter
+var adapter = new BotFrameworkHttpAdapter();
+```
+
+---
+
+## 3. AgentApplication Routing
+
+### 3.1 CORRECT: Activity handlers
+```csharp
+public sealed class MyAgent : AgentApplication
+{
+    public MyAgent(AgentApplicationOptions options) : base(options)
+    {
+        OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeAsync);
+        OnActivity(ActivityTypes.Message, OnMessageAsync, rank: RouteRank.Last);
+        OnTurnError(OnTurnErrorAsync);
+    }
+}
+```
+
+### 3.2 CORRECT: Turn error handling
+```csharp
+await turnState.Conversation.DeleteStateAsync(turnContext, ct);
+
+var endOfConversation = Activity.CreateEndOfConversationActivity();
+endOfConversation.Code = EndOfConversationCodes.Error;
+endOfConversation.Text = exception.Message;
+await turnContext.SendActivityAsync(endOfConversation, ct);
+```
+
+### 3.3 INCORRECT: Bot Framework activity handler
+```csharp
+// WRONG - Bot Framework ActivityHandler is not used with Microsoft.Agents SDK
+public class MyBot : ActivityHandler { }
+```
+
+---
+
+## 4. Token Validation Configuration
+
+### 4.1 CORRECT: appsettings.json section
+```json
+{
+  "TokenValidation": {
+    "Enabled": true,
+    "Audiences": ["{{ClientId}}"],
+    "TenantId": "{{TenantId}}"
+  }
+}
+```
+
+---
+
+## 5. Copilot Studio Client Patterns
+
+### 5.1 CORRECT: CopilotClient with IHttpClientFactory
+```csharp
+builder.Services.AddHttpClient("mcs").ConfigurePrimaryHttpMessageHandler(() =>
+{
+    return new AddTokenHandler(settings);
+});
+
+builder.Services.AddTransient<CopilotClient>(sp =>
+{
+    var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<CopilotClient>();
+    return new CopilotClient(settings, sp.GetRequiredService<IHttpClientFactory>(), logger, "mcs");
+});
+```
+
+### 5.2 CORRECT: Start conversation and ask question
+```csharp
+await foreach (var activity in client.StartConversationAsync(emitStartConversationEvent: true))
+{
+    Console.WriteLine(activity.Type);
+}
+
+await foreach (var activity in client.AskQuestionAsync("Hello!", null))
+{
+    Console.WriteLine(activity.Type);
+}
+```
+
+### 5.3 INCORRECT: DirectLine usage
+```csharp
+// WRONG - DirectLine client is not part of Microsoft.Agents SDK
+var directLine = new DirectLineClient();
+```

--- a/Agents.md
+++ b/Agents.md
@@ -159,15 +159,15 @@ npx skills add microsoft/agent-skills
 
 ### Skill Catalog
 
-> Location: `.github/skills/` • 130 skills • See [README.md#skill-catalog](README.md#skill-catalog)
+> Location: `.github/skills/` • 124 skills • See [README.md#skill-catalog](README.md#skill-catalog)
 
 | Language | Skills | Suffix | Examples |
 |----------|--------|--------|----------|
 | **Core** | 5 | — | `mcp-builder`, `skill-creator`, `azd-deployment` |
-| **Python** | 43 | `-py` | `azure-ai-inference-py`, `azure-cosmos-py`, `azure-ai-projects-py` |
-| **.NET** | 29 | `-dotnet` | `azure-ai-inference-dotnet`, `azure-resource-manager-cosmosdb-dotnet`, `azure-security-keyvault-keys-dotnet` |
-| **TypeScript** | 25 | `-ts` | `azure-ai-inference-ts`, `azure-ai-agents-ts`, `azure-storage-blob-ts` |
-| **Java** | 28 | `-java` | `azure-ai-inference-java`, `azure-cosmos-java`, `azure-eventhub-java` |
+| **Python** | 41 | `-py` | `azure-ai-projects-py`, `azure-cosmos-py`, `azure-ai-ml-py` |
+| **.NET** | 29 | `-dotnet` | `azure-ai-projects-dotnet`, `azure-resource-manager-cosmosdb-dotnet`, `azure-security-keyvault-keys-dotnet` |
+| **TypeScript** | 23 | `-ts` | `azure-ai-projects-ts`, `azure-storage-blob-ts`, `azure-servicebus-ts` |
+| **Java** | 26 | `-java` | `azure-ai-projects-java`, `azure-cosmos-java`, `azure-eventhub-java` |
 
 ### Skill Selection
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 | Resource | Description |
 |----------|-------------|
-| **[123 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
+| **[124 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
 | **[Custom Agents](#agents)** | Role-specific agents (backend, frontend, infrastructure, planner) |
 | **[AGENTS.md](AGENTS.md)** | Template for configuring agent behavior in your projects |
 | **[MCP Configs](#mcp-servers)** | Pre-configured servers for docs, GitHub, browser automation |
@@ -72,13 +72,13 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 ## Skill Catalog
 
-> 123 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
+> 124 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
 
 | Language | Count | Suffix | 
 |----------|-------|--------|
 | [Core](#core) | 5 | — |
 | [Python](#python) | 41 | `-py` |
-| [.NET](#net) | 28 | `-dotnet` |
+| [.NET](#net) | 29 | `-dotnet` |
 | [TypeScript](#typescript) | 23 | `-ts` |
 | [Java](#java) | 26 | `-java` |
 
@@ -211,10 +211,10 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 ### .NET
 
-> 28 skills • suffix: `-dotnet`
+> 29 skills • suffix: `-dotnet`
 
 <details>
-<summary><strong>Foundry & AI</strong> (7 skills)</summary>
+<summary><strong>Foundry & AI</strong> (8 skills)</summary>
 
 | Skill | Description |
 |-------|-------------|
@@ -225,6 +225,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 | [azure-ai-voicelive-dotnet](.github/skills/azure-ai-voicelive-dotnet/) | Voice Live — real-time voice AI with bidirectional WebSocket. |
 | [azure-mgmt-weightsandbiases-dotnet](.github/skills/azure-mgmt-weightsandbiases-dotnet/) | Weights & Biases — ML experiment tracking via Azure Marketplace. |
 | [azure-search-documents-dotnet](.github/skills/azure-search-documents-dotnet/) | AI Search — full-text, vector, semantic, hybrid search. |
+| [m365-agents-dotnet](.github/skills/m365-agents-dotnet/) | Microsoft 365 Agents SDK — ASP.NET Core hosting, AgentApplication routing, Copilot Studio client. |
 
 </details>
 
@@ -446,7 +447,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 AGENTS.md                # Agent configuration template
 
 .github/
-├── skills/              # All 123 skills (flat structure)
+├── skills/              # All 124 skills (flat structure)
 ├── prompts/             # Reusable prompt templates
 ├── agents/              # Agent persona definitions
 ├── scripts/             # Automation scripts (doc scraping)
@@ -580,13 +581,13 @@ pnpm test
 
 ### Test Coverage Summary
 
-**123 skills with 1114 test scenarios** — all skills have acceptance criteria and test scenarios.
+**124 skills with 1144 test scenarios** — all skills have acceptance criteria and test scenarios.
 
 | Language | Skills | Scenarios | Top Skills by Scenarios |
 |----------|--------|-----------|-------------------------|
 | Core | 5 | 51 | `azd-deployment` (8), `github-issue-creator` (8), `mcp-builder` (8) |
-| Python | 41 | 333 | `azure-ai-projects-py` (12), `pydantic-models-py` (12), `azure-ai-translation-text-py` (11) |
-| .NET | 28 | 286 | `azure-resource-manager-redis-dotnet` (14), `azure-resource-manager-sql-dotnet` (14), `azure-ai-projects-dotnet` (13) |
+| Python | 41 | 359 | `azure-ai-projects-py` (12), `pydantic-models-py` (12), `azure-ai-translation-text-py` (11) |
+| .NET | 29 | 290 | `azure-resource-manager-redis-dotnet` (14), `azure-resource-manager-sql-dotnet` (14), `azure-ai-projects-dotnet` (13) |
 | TypeScript | 23 | 249 | `azure-storage-blob-ts` (17), `azure-servicebus-ts` (14), `azure-ai-contentsafety-ts` (12) |
 | Java | 26 | 195 | `azure-identity-java` (12), `azure-storage-blob-java` (12), `azure-ai-agents-persistent-java` (11) |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -714,7 +714,7 @@
 
             <div class="badges">
                 <span class="badge">
-                    <span class="badge-count">130</span> Skills
+                    <span class="badge-count">124</span> Skills
                 </span>
                 <span class="badge">
                     <span class="badge-count">6</span> Custom Agents
@@ -763,7 +763,7 @@
             <!-- Stats -->
             <div class="stats-grid">
                 <div class="stat-card">
-                    <div class="stat-number">42</div>
+                    <div class="stat-number">41</div>
                     <div class="stat-label">Python Skills</div>
                 </div>
                 <div class="stat-card">
@@ -771,11 +771,11 @@
                     <div class="stat-label">.NET Skills</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number">25</div>
+                    <div class="stat-number">23</div>
                     <div class="stat-label">TypeScript Skills</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number">28</div>
+                    <div class="stat-number">26</div>
                     <div class="stat-label">Java Skills</div>
                 </div>
             </div>
@@ -803,22 +803,22 @@
 
                 <div class="language-tabs">
                     <button class="tab-btn active" onclick="showTab('all')">
-                        All <span class="tab-count">130</span>
+                        All <span class="tab-count">124</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('core')">
                         Core <span class="tab-count">5</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('py')">
-                        Python <span class="tab-count">42</span>
+                        Python <span class="tab-count">41</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('dotnet')">
                         .NET <span class="tab-count">29</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('ts')">
-                        TypeScript <span class="tab-count">25</span>
+                        TypeScript <span class="tab-count">23</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('java')">
-                        Java <span class="tab-count">28</span>
+                        Java <span class="tab-count">26</span>
                     </button>
                 </div>
 
@@ -1309,6 +1309,11 @@
                     name: "azure-ai-voicelive-dotnet",
                     lang: "dotnet",
                     desc: "Voice Live — real-time voice AI with WebSocket",
+                },
+                {
+                    name: "m365-agents-dotnet",
+                    lang: "dotnet",
+                    desc: "Microsoft 365 Agents SDK — ASP.NET Core hosting, AgentApplication routing, Copilot Studio client",
                 },
                 {
                     name: "azure-search-documents-dotnet",

--- a/skills/dotnet/foundry/m365-agents
+++ b/skills/dotnet/foundry/m365-agents
@@ -1,0 +1,1 @@
+../../../.github/skills/m365-agents-dotnet

--- a/tests/scenarios/m365-agents-dotnet/scenarios.yaml
+++ b/tests/scenarios/m365-agents-dotnet/scenarios.yaml
@@ -1,0 +1,227 @@
+# Test scenarios for m365-agents-dotnet skill evaluation
+# Each scenario tests a specific usage pattern against acceptance criteria
+
+config:
+  model: gpt-4
+  max_tokens: 2000
+  temperature: 0.3
+
+scenarios:
+  - name: aspnet_agent_hosting
+    prompt: |
+      Create a minimal ASP.NET Core host for a Microsoft 365 Agent using
+      AddAgentApplicationOptions, AddAgent<T>, and the /api/messages endpoint.
+    expected_patterns:
+      - "AddAgentApplicationOptions"
+      - "AddAgent<"
+      - "IAgentHttpAdapter"
+      - "ProcessAsync"
+      - 'MapPost("/api/messages")'
+      - "AddAgentAspNetAuthentication"
+    forbidden_patterns:
+      - "BotFrameworkHttpAdapter"
+      - "Microsoft.Bot.Builder"
+    tags:
+      - hosting
+      - authentication
+    mock_response: |
+      using Microsoft.Agents.Builder;
+      using Microsoft.Agents.Hosting.AspNetCore;
+      using Microsoft.Agents.Storage;
+      using Microsoft.AspNetCore.Builder;
+      using Microsoft.AspNetCore.Http;
+      using Microsoft.Extensions.DependencyInjection;
+      using Microsoft.Extensions.Hosting;
+
+      var builder = WebApplication.CreateBuilder(args);
+      builder.Services.AddHttpClient();
+      builder.AddAgentApplicationOptions();
+      builder.AddAgent<MyAgent>();
+      builder.Services.AddSingleton<IStorage, MemoryStorage>();
+
+      builder.Services.AddControllers();
+      builder.Services.AddAgentAspNetAuthentication(builder.Configuration);
+
+      WebApplication app = builder.Build();
+      app.UseAuthentication();
+      app.UseAuthorization();
+
+      var incomingRoute = app.MapPost("/api/messages",
+          async (HttpRequest request, HttpResponse response, IAgentHttpAdapter adapter, IAgent agent, CancellationToken ct) =>
+          {
+              await adapter.ProcessAsync(request, response, agent, ct);
+          });
+
+      if (!app.Environment.IsDevelopment())
+      {
+          incomingRoute.RequireAuthorization();
+      }
+
+      app.Run();
+
+  - name: agent_application_routing
+    prompt: |
+      Create an AgentApplication subclass that handles welcome messages,
+      message activities, and turn errors using Microsoft.Agents SDK.
+    expected_patterns:
+      - "AgentApplication"
+      - "OnConversationUpdate"
+      - "OnActivity"
+      - "OnTurnError"
+      - "EndOfConversationCodes.Error"
+    forbidden_patterns:
+      - "ActivityHandler"
+    tags:
+      - routing
+      - errors
+    mock_response: |
+      using Microsoft.Agents.Builder;
+      using Microsoft.Agents.Builder.App;
+      using Microsoft.Agents.Builder.State;
+      using Microsoft.Agents.Core.Models;
+      using System;
+      using System.Threading;
+      using System.Threading.Tasks;
+
+      public sealed class MyAgent : AgentApplication
+      {
+          public MyAgent(AgentApplicationOptions options) : base(options)
+          {
+              OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeAsync);
+              OnActivity(ActivityTypes.Message, OnMessageAsync, rank: RouteRank.Last);
+              OnTurnError(OnTurnErrorAsync);
+          }
+
+          private static async Task WelcomeAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken ct)
+          {
+              foreach (ChannelAccount member in turnContext.Activity.MembersAdded)
+              {
+                  if (member.Id != turnContext.Activity.Recipient.Id)
+                  {
+                      await turnContext.SendActivityAsync(MessageFactory.Text("Welcome!"), ct);
+                  }
+              }
+          }
+
+          private static async Task OnMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken ct)
+          {
+              await turnContext.SendActivityAsync(MessageFactory.Text(turnContext.Activity.Text), ct);
+          }
+
+          private static async Task OnTurnErrorAsync(ITurnContext turnContext, ITurnState turnState, Exception ex, CancellationToken ct)
+          {
+              await turnState.Conversation.DeleteStateAsync(turnContext, ct);
+
+              var eoc = Activity.CreateEndOfConversationActivity();
+              eoc.Code = EndOfConversationCodes.Error;
+              eoc.Text = ex.Message;
+              await turnContext.SendActivityAsync(eoc, ct);
+          }
+      }
+
+  - name: copilot_studio_client
+    prompt: |
+      Show how to configure CopilotClient with IHttpClientFactory and
+      start a conversation using StartConversationAsync and AskQuestionAsync.
+    expected_patterns:
+      - "CopilotClient"
+      - 'AddHttpClient("mcs")'
+      - "StartConversationAsync"
+      - "AskQuestionAsync"
+    forbidden_patterns:
+      - "DirectLineClient"
+    tags:
+      - copilot-studio
+      - client
+    mock_response: |
+      using Microsoft.Agents.CopilotStudio.Client;
+      using Microsoft.Extensions.DependencyInjection;
+      using Microsoft.Extensions.Hosting;
+
+      HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+      var settings = new SampleConnectionSettings(builder.Configuration.GetSection("CopilotStudioClientSettings"));
+
+      builder.Services.AddHttpClient("mcs").ConfigurePrimaryHttpMessageHandler(() =>
+      {
+          return new AddTokenHandler(settings);
+      });
+
+      builder.Services.AddTransient<CopilotClient>(sp =>
+      {
+          var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<CopilotClient>();
+          return new CopilotClient(settings, sp.GetRequiredService<IHttpClientFactory>(), logger, "mcs");
+      });
+
+      IHost host = builder.Build();
+      var client = host.Services.GetRequiredService<CopilotClient>();
+
+      await foreach (var activity in client.StartConversationAsync(emitStartConversationEvent: true))
+      {
+          Console.WriteLine(activity.Type);
+      }
+
+      await foreach (var activity in client.AskQuestionAsync("Hello!", null))
+      {
+          Console.WriteLine(activity.Type);
+      }
+
+  - name: token_handler_msal
+    prompt: |
+      Create a DelegatingHandler that uses MSAL to acquire a token for
+      Copilot Studio requests and attaches it to Authorization headers.
+    expected_patterns:
+      - "DelegatingHandler"
+      - "PublicClientApplicationBuilder"
+      - "AcquireTokenSilent"
+      - "AcquireTokenInteractive"
+      - "CopilotClient.ScopeFromSettings"
+      - "AuthenticationHeaderValue"
+    tags:
+      - authentication
+      - msal
+    mock_response: |
+      using System.Net.Http.Headers;
+      using Microsoft.Agents.CopilotStudio.Client;
+      using Microsoft.Identity.Client;
+
+      internal sealed class AddTokenHandler : DelegatingHandler
+      {
+          private readonly SampleConnectionSettings _settings;
+
+          public AddTokenHandler(SampleConnectionSettings settings) : base(new HttpClientHandler())
+          {
+              _settings = settings;
+          }
+
+          protected override async Task<HttpResponseMessage> SendAsync(
+              HttpRequestMessage request,
+              CancellationToken cancellationToken)
+          {
+              if (request.Headers.Authorization is null)
+              {
+                  string[] scopes = [CopilotClient.ScopeFromSettings(_settings)];
+
+                  IPublicClientApplication app = PublicClientApplicationBuilder
+                      .Create(_settings.AppClientId)
+                      .WithAuthority(AadAuthorityAudience.AzureAdMyOrg)
+                      .WithTenantId(_settings.TenantId)
+                      .WithRedirectUri("http://localhost")
+                      .Build();
+
+                  AuthenticationResult authResponse;
+                  try
+                  {
+                      var account = (await app.GetAccountsAsync()).FirstOrDefault();
+                      authResponse = await app.AcquireTokenSilent(scopes, account).ExecuteAsync(cancellationToken);
+                  }
+                  catch (MsalUiRequiredException)
+                  {
+                      authResponse = await app.AcquireTokenInteractive(scopes).ExecuteAsync(cancellationToken);
+                  }
+
+                  request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authResponse.AccessToken);
+              }
+
+              return await base.SendAsync(request, cancellationToken);
+          }
+      }


### PR DESCRIPTION
## Summary
- add m365-agents-dotnet skill with guidance, acceptance criteria, and scenarios
- add dotnet/foundry symlink and update README/docs counts and catalog entries

## Testing
- pnpm harness m365-agents-dotnet --mock --verbose