### PR TITLE
feat: Add m365-agents-py skill for Microsoft 365 Agents SDK (Python)

### DIFF
--- a/.github/skills/m365-agents-py/SKILL.md
+++ b/.github/skills/m365-agents-py/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: m365-agents-py
+description: |
+  Microsoft 365 Agents SDK for Python. Build multichannel agents for Teams/M365/Copilot Studio with aiohttp hosting, AgentApplication routing, streaming responses, and MSAL-based auth. Triggers: "Microsoft 365 Agents SDK", "microsoft_agents", "AgentApplication", "start_agent_process", "TurnContext", "Copilot Studio client", "CloudAdapter".
+package: microsoft-agents-hosting-core, microsoft-agents-hosting-aiohttp, microsoft-agents-activity, microsoft-agents-authentication-msal, microsoft-agents-copilotstudio-client
+---
+
+# Microsoft 365 Agents SDK (Python)
+
+Build enterprise agents for Microsoft 365, Teams, and Copilot Studio using the Microsoft Agents SDK with aiohttp hosting, AgentApplication routing, streaming responses, and MSAL-based authentication.
+
+## Before implementation
+- Use the microsoft-docs MCP to verify the latest API signatures for AgentApplication, start_agent_process, and authentication options.
+- Confirm package versions on PyPI for the microsoft-agents-* packages you plan to use.
+
+## Important Notice - Import Changes
+
+> **⚠️ Breaking Change**: Recent updates have changed the Python import structure from `microsoft.agents` to `microsoft_agents` (using underscores instead of dots).
+
+## Installation
+
+```bash
+pip install microsoft-agents-hosting-core
+pip install microsoft-agents-hosting-aiohttp
+pip install microsoft-agents-activity
+pip install microsoft-agents-authentication-msal
+pip install microsoft-agents-copilotstudio-client
+pip install python-dotenv aiohttp
+```
+
+## Environment Variables (.env)
+
+```bash
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID=<client-id>
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTSECRET=<client-secret>
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__TENANTID=<tenant-id>
+
+# Optional: OAuth handlers for auto sign-in
+AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__GRAPH__SETTINGS__AZUREBOTOAUTHCONNECTIONNAME=<connection-name>
+
+# Optional: Azure OpenAI for streaming
+AZURE_OPENAI_ENDPOINT=<endpoint>
+AZURE_OPENAI_API_VERSION=<version>
+AZURE_OPENAI_API_KEY=<key>
+
+# Optional: Copilot Studio client
+COPILOTSTUDIOAGENT__ENVIRONMENTID=<environment-id>
+COPILOTSTUDIOAGENT__SCHEMANAME=<schema-name>
+COPILOTSTUDIOAGENT__TENANTID=<tenant-id>
+COPILOTSTUDIOAGENT__AGENTAPPID=<app-id>
+```
+
+## Core Workflow: aiohttp-hosted AgentApplication
+
+```python
+import logging
+from os import environ
+
+from dotenv import load_dotenv
+from aiohttp.web import Request, Response, Application, run_app
+
+from microsoft_agents.activity import load_configuration_from_env
+from microsoft_agents.hosting.core import (
+    Authorization,
+    AgentApplication,
+    TurnState,
+    TurnContext,
+    MemoryStorage,
+)
+from microsoft_agents.hosting.aiohttp import (
+    CloudAdapter,
+    start_agent_process,
+    jwt_authorization_middleware,
+)
+from microsoft_agents.authentication.msal import MsalConnectionManager
+
+# Enable logging
+ms_agents_logger = logging.getLogger("microsoft_agents")
+ms_agents_logger.addHandler(logging.StreamHandler())
+ms_agents_logger.setLevel(logging.INFO)
+
+# Load configuration
+load_dotenv()
+agents_sdk_config = load_configuration_from_env(environ)
+
+# Create storage and connection manager
+STORAGE = MemoryStorage()
+CONNECTION_MANAGER = MsalConnectionManager(**agents_sdk_config)
+ADAPTER = CloudAdapter(connection_manager=CONNECTION_MANAGER)
+AUTHORIZATION = Authorization(STORAGE, CONNECTION_MANAGER, **agents_sdk_config)
+
+# Create AgentApplication
+AGENT_APP = AgentApplication[TurnState](
+    storage=STORAGE, adapter=ADAPTER, authorization=AUTHORIZATION, **agents_sdk_config
+)
+
+
+@AGENT_APP.conversation_update("membersAdded")
+async def on_members_added(context: TurnContext, _state: TurnState):
+    await context.send_activity("Welcome to the agent!")
+
+
+@AGENT_APP.activity("message")
+async def on_message(context: TurnContext, _state: TurnState):
+    await context.send_activity(f"You said: {context.activity.text}")
+
+
+@AGENT_APP.error
+async def on_error(context: TurnContext, error: Exception):
+    await context.send_activity("The agent encountered an error.")
+
+
+# Server setup
+async def entry_point(req: Request) -> Response:
+    agent: AgentApplication = req.app["agent_app"]
+    adapter: CloudAdapter = req.app["adapter"]
+    return await start_agent_process(req, agent, adapter)
+
+
+APP = Application(middlewares=[jwt_authorization_middleware])
+APP.router.add_post("/api/messages", entry_point)
+APP["agent_configuration"] = CONNECTION_MANAGER.get_default_connection_configuration()
+APP["agent_app"] = AGENT_APP
+APP["adapter"] = AGENT_APP.adapter
+
+if __name__ == "__main__":
+    run_app(APP, host="localhost", port=environ.get("PORT", 3978))
+```
+
+## AgentApplication Routing
+
+```python
+import re
+from microsoft_agents.hosting.core import (
+    AgentApplication, TurnState, TurnContext, MessageFactory
+)
+from microsoft_agents.activity import ActivityTypes
+
+AGENT_APP = AgentApplication[TurnState](
+    storage=STORAGE, adapter=ADAPTER, authorization=AUTHORIZATION, **agents_sdk_config
+)
+
+# Welcome handler
+@AGENT_APP.conversation_update("membersAdded")
+async def on_members_added(context: TurnContext, _state: TurnState):
+    await context.send_activity("Welcome!")
+
+# Regex-based message handler
+@AGENT_APP.message(re.compile(r"^hello$", re.IGNORECASE))
+async def on_hello(context: TurnContext, _state: TurnState):
+    await context.send_activity("Hello!")
+
+# Simple string message handler
+@AGENT_APP.message("/status")
+async def on_status(context: TurnContext, _state: TurnState):
+    await context.send_activity("Status: OK")
+
+# Auth-protected message handler
+@AGENT_APP.message("/me", auth_handlers=["GRAPH"])
+async def on_profile(context: TurnContext, state: TurnState):
+    token_response = await AGENT_APP.auth.get_token(context, "GRAPH")
+    if token_response and token_response.token:
+        # Use token to call Graph API
+        await context.send_activity("Profile retrieved")
+
+# Invoke activity handler
+@AGENT_APP.activity(ActivityTypes.invoke)
+async def on_invoke(context: TurnContext, _state: TurnState):
+    invoke_response = Activity(
+        type=ActivityTypes.invoke_response, value={"status": 200}
+    )
+    await context.send_activity(invoke_response)
+
+# Fallback message handler
+@AGENT_APP.activity("message")
+async def on_message(context: TurnContext, _state: TurnState):
+    await context.send_activity(f"Echo: {context.activity.text}")
+
+# Error handler
+@AGENT_APP.error
+async def on_error(context: TurnContext, error: Exception):
+    await context.send_activity("An error occurred.")
+```
+
+## Streaming Responses with Azure OpenAI
+
+```python
+from openai import AsyncAzureOpenAI
+from microsoft_agents.activity import SensitivityUsageInfo
+
+CLIENT = AsyncAzureOpenAI(
+    api_version=environ["AZURE_OPENAI_API_VERSION"],
+    azure_endpoint=environ["AZURE_OPENAI_ENDPOINT"],
+    api_key=environ["AZURE_OPENAI_API_KEY"]
+)
+
+@AGENT_APP.message("poem")
+async def on_poem_message(context: TurnContext, _state: TurnState):
+    # Configure streaming response
+    context.streaming_response.set_feedback_loop(True)
+    context.streaming_response.set_generated_by_ai_label(True)
+    context.streaming_response.set_sensitivity_label(
+        SensitivityUsageInfo(
+            type="https://schema.org/Message",
+            schema_type="CreativeWork",
+            name="Internal",
+        )
+    )
+    context.streaming_response.queue_informative_update("Starting a poem...\n")
+
+    # Stream from Azure OpenAI
+    streamed_response = await CLIENT.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": "You are a creative assistant."},
+            {"role": "user", "content": "Write a poem about Python."}
+        ],
+        stream=True,
+    )
+    
+    try:
+        async for chunk in streamed_response:
+            if chunk.choices and chunk.choices[0].delta.content:
+                context.streaming_response.queue_text_chunk(
+                    chunk.choices[0].delta.content
+                )
+    finally:
+        await context.streaming_response.end_stream()
+```
+
+## OAuth / Auto Sign-In
+
+```python
+@AGENT_APP.message("/logout")
+async def logout(context: TurnContext, state: TurnState):
+    await AGENT_APP.auth.sign_out(context, "GRAPH")
+    await context.send_activity(MessageFactory.text("You have been logged out."))
+
+
+@AGENT_APP.message("/me", auth_handlers=["GRAPH"])
+async def profile_request(context: TurnContext, state: TurnState):
+    user_token_response = await AGENT_APP.auth.get_token(context, "GRAPH")
+    if user_token_response and user_token_response.token:
+        # Use token to call Microsoft Graph
+        async with aiohttp.ClientSession() as session:
+            headers = {
+                "Authorization": f"Bearer {user_token_response.token}",
+                "Content-Type": "application/json",
+            }
+            async with session.get(
+                "https://graph.microsoft.com/v1.0/me", headers=headers
+            ) as response:
+                if response.status == 200:
+                    user_info = await response.json()
+                    await context.send_activity(f"Hello, {user_info['displayName']}!")
+```
+
+## Copilot Studio Client (Direct to Engine)
+
+```python
+import asyncio
+from msal import PublicClientApplication
+from microsoft_agents.activity import ActivityTypes, load_configuration_from_env
+from microsoft_agents.copilotstudio.client import (
+    ConnectionSettings,
+    CopilotClient,
+)
+
+# Token cache (local file for interactive flows)
+class LocalTokenCache:
+    # See samples for full implementation
+    pass
+
+def acquire_token(settings, app_client_id, tenant_id):
+    pca = PublicClientApplication(
+        client_id=app_client_id,
+        authority=f"https://login.microsoftonline.com/{tenant_id}",
+    )
+    
+    token_request = {"scopes": ["https://api.powerplatform.com/.default"]}
+    accounts = pca.get_accounts()
+    
+    if accounts:
+        response = pca.acquire_token_silent(token_request["scopes"], account=accounts[0])
+        return response.get("access_token")
+    else:
+        response = pca.acquire_token_interactive(**token_request)
+        return response.get("access_token")
+
+
+async def main():
+    settings = ConnectionSettings(
+        environment_id=environ.get("COPILOTSTUDIOAGENT__ENVIRONMENTID"),
+        agent_identifier=environ.get("COPILOTSTUDIOAGENT__SCHEMANAME"),
+    )
+    
+    token = acquire_token(
+        settings,
+        app_client_id=environ.get("COPILOTSTUDIOAGENT__AGENTAPPID"),
+        tenant_id=environ.get("COPILOTSTUDIOAGENT__TENANTID"),
+    )
+    
+    copilot_client = CopilotClient(settings, token)
+    
+    # Start conversation
+    act = copilot_client.start_conversation(True)
+    async for action in act:
+        if action.text:
+            print(action.text)
+    
+    # Ask question
+    replies = copilot_client.ask_question("Hello!", action.conversation.id)
+    async for reply in replies:
+        if reply.type == ActivityTypes.message:
+            print(reply.text)
+
+
+asyncio.run(main())
+```
+
+## Best Practices
+
+1. Use `microsoft_agents` import prefix (underscores, not dots).
+2. Use `MemoryStorage` only for development; use BlobStorage or CosmosDB in production.
+3. Always use `load_configuration_from_env(environ)` to load SDK configuration.
+4. Include `jwt_authorization_middleware` in aiohttp Application middlewares.
+5. Use `MsalConnectionManager` for MSAL-based authentication.
+6. Call `end_stream()` in finally blocks when using streaming responses.
+7. Use `auth_handlers` parameter on message decorators for OAuth-protected routes.
+8. Keep secrets in environment variables, not in source code.
+
+## Reference Files
+
+| File | Contents |
+| --- | --- |
+| [references/acceptance-criteria.md](references/acceptance-criteria.md) | Import paths, hosting pipeline, streaming, OAuth, and Copilot Studio patterns |
+
+## Reference Links
+
+| Resource | URL |
+| --- | --- |
+| Microsoft 365 Agents SDK | https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/ |
+| GitHub samples (Python) | https://github.com/microsoft/Agents-for-python |
+| PyPI packages | https://pypi.org/search/?q=microsoft-agents |
+| Integrate with Copilot Studio | https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/integrate-with-mcs |

--- a/.github/skills/m365-agents-py/references/acceptance-criteria.md
+++ b/.github/skills/m365-agents-py/references/acceptance-criteria.md
@@ -1,0 +1,334 @@
+# Microsoft 365 Agents SDK Acceptance Criteria (Python)
+
+**SDK**: `microsoft-agents-hosting-core`, `microsoft-agents-hosting-aiohttp`, `microsoft-agents-activity`, `microsoft-agents-authentication-msal`, `microsoft-agents-copilotstudio-client`
+**Repository**: https://github.com/microsoft/Agents-for-python
+**PyPI Packages**: https://pypi.org/search/?q=microsoft-agents
+**Purpose**: Skill testing acceptance criteria for validating generated Python code correctness
+
+---
+
+## 1. Correct Import Patterns
+
+### 1.1 Core Imports (Hosting)
+
+#### CORRECT
+```python
+from microsoft_agents.hosting.core import (
+    Authorization,
+    AgentApplication,
+    TurnState,
+    TurnContext,
+    MemoryStorage,
+    MessageFactory,
+)
+from microsoft_agents.hosting.aiohttp import (
+    CloudAdapter,
+    start_agent_process,
+    jwt_authorization_middleware,
+)
+```
+
+### 1.2 Core Imports (Activity)
+
+#### CORRECT
+```python
+from microsoft_agents.activity import (
+    Activity,
+    ActivityTypes,
+    load_configuration_from_env,
+    SensitivityUsageInfo,
+)
+```
+
+### 1.3 Core Imports (Authentication)
+
+#### CORRECT
+```python
+from microsoft_agents.authentication.msal import MsalConnectionManager
+```
+
+### 1.4 Core Imports (Copilot Studio Client)
+
+#### CORRECT
+```python
+from microsoft_agents.copilotstudio.client import (
+    ConnectionSettings,
+    CopilotClient,
+)
+```
+
+### 1.5 Anti-Patterns (ERRORS)
+
+#### INCORRECT: Old dot-notation imports
+```python
+# WRONG - old import structure with dots
+from microsoft.agents.hosting.core import AgentApplication
+from microsoft.agents.activity import Activity
+```
+
+#### INCORRECT: Bot Framework imports
+```python
+# WRONG - Bot Framework SDK is not used with Microsoft 365 Agents SDK
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.integration.aiohttp import CloudAdapter
+```
+
+---
+
+## 2. Hosting Pipeline
+
+### 2.1 CORRECT: aiohttp registration with middleware
+```python
+from aiohttp.web import Request, Response, Application, run_app
+from microsoft_agents.hosting.aiohttp import (
+    start_agent_process,
+    jwt_authorization_middleware,
+    CloudAdapter,
+)
+
+async def entry_point(req: Request) -> Response:
+    agent: AgentApplication = req.app["agent_app"]
+    adapter: CloudAdapter = req.app["adapter"]
+    return await start_agent_process(req, agent, adapter)
+
+APP = Application(middlewares=[jwt_authorization_middleware])
+APP.router.add_post("/api/messages", entry_point)
+APP["agent_configuration"] = CONNECTION_MANAGER.get_default_connection_configuration()
+APP["agent_app"] = AGENT_APP
+APP["adapter"] = AGENT_APP.adapter
+```
+
+### 2.2 CORRECT: Configuration loading
+```python
+from os import environ
+from dotenv import load_dotenv
+from microsoft_agents.activity import load_configuration_from_env
+
+load_dotenv()
+agents_sdk_config = load_configuration_from_env(environ)
+```
+
+### 2.3 CORRECT: Storage and connection manager setup
+```python
+STORAGE = MemoryStorage()
+CONNECTION_MANAGER = MsalConnectionManager(**agents_sdk_config)
+ADAPTER = CloudAdapter(connection_manager=CONNECTION_MANAGER)
+AUTHORIZATION = Authorization(STORAGE, CONNECTION_MANAGER, **agents_sdk_config)
+
+AGENT_APP = AgentApplication[TurnState](
+    storage=STORAGE, adapter=ADAPTER, authorization=AUTHORIZATION, **agents_sdk_config
+)
+```
+
+### 2.4 INCORRECT: Missing middleware
+```python
+# WRONG - jwt_authorization_middleware should be included
+APP = Application()  # Missing middlewares parameter
+```
+
+### 2.5 INCORRECT: Bot Framework adapter
+```python
+# WRONG - uses Bot Framework adapter
+from botbuilder.integration.aiohttp import CloudAdapter
+adapter = CloudAdapter()
+```
+
+---
+
+## 3. AgentApplication Routing
+
+### 3.1 CORRECT: Conversation update handler
+```python
+@AGENT_APP.conversation_update("membersAdded")
+async def on_members_added(context: TurnContext, _state: TurnState):
+    await context.send_activity("Welcome!")
+```
+
+### 3.2 CORRECT: Message handlers (string and regex)
+```python
+import re
+
+@AGENT_APP.message("/status")
+async def on_status(context: TurnContext, _state: TurnState):
+    await context.send_activity("Status: OK")
+
+@AGENT_APP.message(re.compile(r"^hello$", re.IGNORECASE))
+async def on_hello(context: TurnContext, _state: TurnState):
+    await context.send_activity("Hello!")
+```
+
+### 3.3 CORRECT: Activity type handler
+```python
+@AGENT_APP.activity("message")
+async def on_message(context: TurnContext, _state: TurnState):
+    await context.send_activity(f"Echo: {context.activity.text}")
+
+@AGENT_APP.activity(ActivityTypes.invoke)
+async def on_invoke(context: TurnContext, _state: TurnState):
+    invoke_response = Activity(
+        type=ActivityTypes.invoke_response, value={"status": 200}
+    )
+    await context.send_activity(invoke_response)
+```
+
+### 3.4 CORRECT: Error handler
+```python
+@AGENT_APP.error
+async def on_error(context: TurnContext, error: Exception):
+    await context.send_activity("The agent encountered an error.")
+```
+
+### 3.5 INCORRECT: Bot Framework ActivityHandler
+```python
+# WRONG - Bot Framework ActivityHandler is not used
+class MyBot(ActivityHandler):
+    async def on_message_activity(self, turn_context: TurnContext):
+        pass
+```
+
+---
+
+## 4. OAuth / Auto Sign-In
+
+### 4.1 CORRECT: Auth-protected message handler
+```python
+@AGENT_APP.message("/me", auth_handlers=["GRAPH"])
+async def profile_request(context: TurnContext, state: TurnState):
+    user_token_response = await AGENT_APP.auth.get_token(context, "GRAPH")
+    if user_token_response and user_token_response.token:
+        # Use token
+        pass
+```
+
+### 4.2 CORRECT: Sign out
+```python
+@AGENT_APP.message("/logout")
+async def logout(context: TurnContext, state: TurnState):
+    await AGENT_APP.auth.sign_out(context, "GRAPH")
+    await context.send_activity(MessageFactory.text("You have been logged out."))
+```
+
+### 4.3 CORRECT: Begin or continue OAuth flow
+```python
+token_response = await AGENT_APP.auth.begin_or_continue_flow(context, state, "GITHUB")
+if token_response and token_response.token:
+    # Token acquired
+    pass
+```
+
+---
+
+## 5. Streaming Responses
+
+### 5.1 CORRECT: Streaming with Azure OpenAI
+```python
+from openai import AsyncAzureOpenAI
+from microsoft_agents.activity import SensitivityUsageInfo
+
+@AGENT_APP.message("poem")
+async def on_poem_message(context: TurnContext, _state: TurnState):
+    context.streaming_response.set_feedback_loop(True)
+    context.streaming_response.set_generated_by_ai_label(True)
+    context.streaming_response.set_sensitivity_label(
+        SensitivityUsageInfo(
+            type="https://schema.org/Message",
+            schema_type="CreativeWork",
+            name="Internal",
+        )
+    )
+    context.streaming_response.queue_informative_update("Starting...")
+
+    streamed_response = await CLIENT.chat.completions.create(
+        model="gpt-4o",
+        messages=[...],
+        stream=True,
+    )
+    
+    try:
+        async for chunk in streamed_response:
+            if chunk.choices and chunk.choices[0].delta.content:
+                context.streaming_response.queue_text_chunk(
+                    chunk.choices[0].delta.content
+                )
+    finally:
+        await context.streaming_response.end_stream()
+```
+
+### 5.2 INCORRECT: Missing end_stream
+```python
+# WRONG - end_stream should always be called in finally block
+async for chunk in streamed_response:
+    context.streaming_response.queue_text_chunk(chunk)
+# Missing: await context.streaming_response.end_stream()
+```
+
+---
+
+## 6. Copilot Studio Client
+
+### 6.1 CORRECT: ConnectionSettings and CopilotClient
+```python
+from microsoft_agents.copilotstudio.client import (
+    ConnectionSettings,
+    CopilotClient,
+)
+
+settings = ConnectionSettings(
+    environment_id=environ.get("COPILOTSTUDIOAGENT__ENVIRONMENTID"),
+    agent_identifier=environ.get("COPILOTSTUDIOAGENT__SCHEMANAME"),
+)
+
+token = acquire_token(...)  # MSAL token acquisition
+copilot_client = CopilotClient(settings, token)
+```
+
+### 6.2 CORRECT: Start conversation and ask question
+```python
+# Start conversation
+act = copilot_client.start_conversation(True)
+async for action in act:
+    if action.text:
+        print(action.text)
+
+# Ask question
+replies = copilot_client.ask_question("Hello!", action.conversation.id)
+async for reply in replies:
+    if reply.type == ActivityTypes.message:
+        print(reply.text)
+```
+
+### 6.3 INCORRECT: DirectLine usage
+```python
+# WRONG - DirectLine client is not part of Microsoft 365 Agents SDK
+from botframework.directlineclient import DirectLineClient
+```
+
+---
+
+## 7. Environment Variables
+
+### 7.1 CORRECT: Configuration pattern
+```bash
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID=<client-id>
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTSECRET=<client-secret>
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__TENANTID=<tenant-id>
+```
+
+### 7.2 INCORRECT: Hardcoded secrets
+```python
+# WRONG - do not hardcode secrets
+CLIENT_SECRET = "super-secret-value"
+```
+
+---
+
+## 8. Logging Configuration
+
+### 8.1 CORRECT: Enable SDK logging
+```python
+import logging
+
+ms_agents_logger = logging.getLogger("microsoft_agents")
+ms_agents_logger.addHandler(logging.StreamHandler())
+ms_agents_logger.setLevel(logging.INFO)
+```

--- a/.github/skills/m365-agents-ts/SKILL.md
+++ b/.github/skills/m365-agents-ts/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: m365-agents-ts
+description: |
+  Microsoft 365 Agents SDK for TypeScript/Node.js. Build multichannel agents for Teams/M365/Copilot Studio with AgentApplication routing, Express hosting, streaming responses, and Copilot Studio client integration. Triggers: "Microsoft 365 Agents SDK", "@microsoft/agents-hosting", "AgentApplication", "startServer", "streamingResponse", "Copilot Studio client", "@microsoft/agents-copilotstudio-client".
+package: @microsoft/agents-hosting, @microsoft/agents-hosting-express, @microsoft/agents-activity, @microsoft/agents-copilotstudio-client
+---
+
+# Microsoft 365 Agents SDK (TypeScript)
+
+Build enterprise agents for Microsoft 365, Teams, and Copilot Studio using the Microsoft 365 Agents SDK with Express hosting, AgentApplication routing, streaming responses, and Copilot Studio client integrations.
+
+## Before implementation
+- Use the microsoft-docs MCP to verify the latest API signatures for AgentApplication, startServer, and CopilotStudioClient.
+- Confirm package versions on npm before wiring up samples or templates.
+
+## Installation
+
+```bash
+npm install @microsoft/agents-hosting @microsoft/agents-hosting-express @microsoft/agents-activity
+npm install @microsoft/agents-copilotstudio-client
+```
+
+## Environment Variables
+
+```bash
+PORT=3978
+AZURE_RESOURCE_NAME=<azure-openai-resource>
+AZURE_API_KEY=<azure-openai-key>
+AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o-mini
+
+TENANT_ID=<tenant-id>
+CLIENT_ID=<client-id>
+CLIENT_SECRET=<client-secret>
+
+COPILOT_ENVIRONMENT_ID=<environment-id>
+COPILOT_SCHEMA_NAME=<schema-name>
+COPILOT_CLIENT_ID=<copilot-app-client-id>
+COPILOT_BEARER_TOKEN=<copilot-jwt>
+```
+
+## Core Workflow: Express-hosted AgentApplication
+
+```typescript
+import { AgentApplication, TurnContext, TurnState } from "@microsoft/agents-hosting";
+import { startServer } from "@microsoft/agents-hosting-express";
+
+const agent = new AgentApplication<TurnState>();
+
+agent.onConversationUpdate("membersAdded", async (context: TurnContext) => {
+  await context.sendActivity("Welcome to the agent.");
+});
+
+agent.onMessage("hello", async (context: TurnContext) => {
+  await context.sendActivity(`Echo: ${context.activity.text}`);
+});
+
+startServer(agent);
+```
+
+## Streaming responses with Azure OpenAI
+
+```typescript
+import { azure } from "@ai-sdk/azure";
+import { AgentApplication, TurnContext, TurnState } from "@microsoft/agents-hosting";
+import { startServer } from "@microsoft/agents-hosting-express";
+import { streamText } from "ai";
+
+const agent = new AgentApplication<TurnState>();
+
+agent.onMessage("poem", async (context: TurnContext) => {
+  context.streamingResponse.setFeedbackLoop(true);
+  context.streamingResponse.setGeneratedByAILabel(true);
+  context.streamingResponse.setSensitivityLabel({
+    type: "https://schema.org/Message",
+    "@type": "CreativeWork",
+    name: "Internal",
+  });
+
+  await context.streamingResponse.queueInformativeUpdate("starting a poem...");
+
+  const { fullStream } = streamText({
+    model: azure(process.env.AZURE_OPENAI_DEPLOYMENT_NAME || "gpt-4o-mini"),
+    system: "You are a creative assistant.",
+    prompt: "Write a poem about Apollo.",
+  });
+
+  try {
+    for await (const part of fullStream) {
+      if (part.type === "text-delta" && part.text.length > 0) {
+        await context.streamingResponse.queueTextChunk(part.text);
+      }
+      if (part.type === "error") {
+        throw new Error(`Streaming error: ${part.error}`);
+      }
+    }
+  } finally {
+    await context.streamingResponse.endStream();
+  }
+});
+
+startServer(agent);
+```
+
+## Invoke activity handling
+
+```typescript
+import { Activity, ActivityTypes } from "@microsoft/agents-activity";
+import { AgentApplication, TurnContext, TurnState } from "@microsoft/agents-hosting";
+
+const agent = new AgentApplication<TurnState>();
+
+agent.onActivity("invoke", async (context: TurnContext) => {
+  const invokeResponse = Activity.fromObject({
+    type: ActivityTypes.InvokeResponse,
+    value: { status: 200 },
+  });
+
+  await context.sendActivity(invokeResponse);
+  await context.sendActivity("Thanks for submitting your feedback.");
+});
+```
+
+## Copilot Studio client (Direct to Engine)
+
+```typescript
+import { CopilotStudioClient } from "@microsoft/agents-copilotstudio-client";
+
+const settings = {
+  environmentId: process.env.COPILOT_ENVIRONMENT_ID!,
+  schemaName: process.env.COPILOT_SCHEMA_NAME!,
+  clientId: process.env.COPILOT_CLIENT_ID!,
+};
+
+const tokenProvider = async (): Promise<string> => {
+  return process.env.COPILOT_BEARER_TOKEN!;
+};
+
+const client = new CopilotStudioClient(settings, tokenProvider);
+
+const conversation = await client.startConversationAsync();
+const reply = await client.askQuestionAsync("Hello!", conversation.id);
+console.log(reply);
+```
+
+## Copilot Studio WebChat integration
+
+```typescript
+import { CopilotStudioWebChat } from "@microsoft/agents-copilotstudio-client";
+
+const directLine = CopilotStudioWebChat.createConnection(client, {
+  showTyping: true,
+});
+
+window.WebChat.renderWebChat({
+  directLine,
+}, document.getElementById("webchat")!);
+```
+
+## Best Practices
+
+1. Use AgentApplication for routing and keep handlers focused on one responsibility.
+2. Prefer streamingResponse for long-running completions and call endStream in finally blocks.
+3. Keep secrets out of source code; load tokens from environment variables or secure stores.
+4. Reuse CopilotStudioClient instances and cache tokens in your token provider.
+5. Validate invoke payloads before logging or persisting feedback.
+
+## Reference Files
+
+| File | Contents |
+| --- | --- |
+| [references/acceptance-criteria.md](references/acceptance-criteria.md) | Import paths, hosting pipeline, streaming, and Copilot Studio patterns |
+
+## Reference Links
+
+| Resource | URL |
+| --- | --- |
+| Microsoft 365 Agents SDK | https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/ |
+| JavaScript SDK overview | https://learn.microsoft.com/en-us/javascript/api/overview/agents-overview?view=agents-sdk-js-latest |
+| @microsoft/agents-hosting-express | https://learn.microsoft.com/en-us/javascript/api/%40microsoft/agents-hosting-express?view=agents-sdk-js-latest |
+| @microsoft/agents-copilotstudio-client | https://learn.microsoft.com/en-us/javascript/api/%40microsoft/agents-copilotstudio-client?view=agents-sdk-js-latest |
+| Integrate with Copilot Studio | https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/integrate-with-mcs |
+| GitHub samples | https://github.com/microsoft/Agents/tree/main/samples/nodejs |

--- a/.github/skills/m365-agents-ts/references/acceptance-criteria.md
+++ b/.github/skills/m365-agents-ts/references/acceptance-criteria.md
@@ -1,0 +1,152 @@
+# Microsoft 365 Agents SDK Acceptance Criteria (TypeScript)
+
+**SDK**: `@microsoft/agents-hosting`, `@microsoft/agents-hosting-express`, `@microsoft/agents-activity`, `@microsoft/agents-copilotstudio-client`
+**Repository**: https://github.com/microsoft/Agents-for-js
+**Purpose**: Skill testing acceptance criteria for validating generated TypeScript code correctness
+
+---
+
+## 1. Correct Import Patterns
+
+### 1.1 CORRECT: AgentApplication hosting
+```typescript
+import { AgentApplication, TurnContext, TurnState } from "@microsoft/agents-hosting";
+import { startServer } from "@microsoft/agents-hosting-express";
+```
+
+### 1.2 CORRECT: Activity types
+```typescript
+import { Activity, ActivityTypes } from "@microsoft/agents-activity";
+```
+
+### 1.3 CORRECT: Copilot Studio client
+```typescript
+import { CopilotStudioClient, CopilotStudioWebChat } from "@microsoft/agents-copilotstudio-client";
+```
+
+### 1.4 INCORRECT: Bot Framework imports
+```typescript
+// WRONG - Bot Framework SDK is not used with Microsoft 365 Agents SDK
+import { ActivityHandler } from "botbuilder";
+import { BotFrameworkAdapter } from "botbuilder";
+```
+
+---
+
+## 2. Express Hosting
+
+### 2.1 CORRECT: AgentApplication with startServer
+```typescript
+const agent = new AgentApplication<TurnState>();
+
+agent.onMessage("hello", async (context: TurnContext) => {
+  await context.sendActivity("Hello!");
+});
+
+startServer(agent);
+```
+
+### 2.2 INCORRECT: Manual Express routing
+```typescript
+// WRONG - prefer startServer from @microsoft/agents-hosting-express
+const app = express();
+app.post("/api/messages", handler);
+```
+
+---
+
+## 3. Streaming Responses
+
+### 3.1 CORRECT: streamingResponse usage
+```typescript
+agent.onMessage("poem", async (context: TurnContext) => {
+  context.streamingResponse.setFeedbackLoop(true);
+  context.streamingResponse.setGeneratedByAILabel(true);
+  await context.streamingResponse.queueInformativeUpdate("starting...");
+
+  const { fullStream } = streamText({
+    model: azure(process.env.AZURE_OPENAI_DEPLOYMENT_NAME || "gpt-4o-mini"),
+    prompt: "Write a poem.",
+  });
+
+  try {
+    for await (const part of fullStream) {
+      if (part.type === "text-delta" && part.text.length > 0) {
+        await context.streamingResponse.queueTextChunk(part.text);
+      }
+      if (part.type === "error") {
+        throw new Error(`Streaming error: ${part.error}`);
+      }
+    }
+  } finally {
+    await context.streamingResponse.endStream();
+  }
+});
+```
+
+### 3.2 INCORRECT: Missing endStream
+```typescript
+// WRONG - endStream should always be called
+await context.streamingResponse.queueTextChunk("partial");
+```
+
+---
+
+## 4. Invoke Activities
+
+### 4.1 CORRECT: Invoke response pattern
+```typescript
+agent.onActivity("invoke", async (context: TurnContext) => {
+  const invokeResponse = Activity.fromObject({
+    type: ActivityTypes.InvokeResponse,
+    value: { status: 200 },
+  });
+
+  await context.sendActivity(invokeResponse);
+});
+```
+
+---
+
+## 5. Copilot Studio Client
+
+### 5.1 CORRECT: CopilotStudioClient with token provider
+```typescript
+const client = new CopilotStudioClient(settings, async () => {
+  return process.env.COPILOT_BEARER_TOKEN!;
+});
+
+const conversation = await client.startConversationAsync();
+const reply = await client.askQuestionAsync("Hello!", conversation.id);
+```
+
+### 5.2 CORRECT: WebChat integration
+```typescript
+const directLine = CopilotStudioWebChat.createConnection(client, {
+  showTyping: true,
+});
+
+window.WebChat.renderWebChat({ directLine }, document.getElementById("webchat")!);
+```
+
+### 5.3 INCORRECT: DirectLine client usage
+```typescript
+// WRONG - DirectLineClient is not part of Microsoft 365 Agents SDK
+const directLine = new DirectLineClient();
+```
+
+---
+
+## 6. Environment Variables
+
+### 6.1 CORRECT: Using process.env
+```typescript
+const deployment = process.env.AZURE_OPENAI_DEPLOYMENT_NAME || "gpt-4o-mini";
+const envId = process.env.COPILOT_ENVIRONMENT_ID!;
+```
+
+### 6.2 INCORRECT: Hardcoded secrets
+```typescript
+// WRONG - do not hardcode secrets
+const clientSecret = "super-secret";
+```

--- a/Agents.md
+++ b/Agents.md
@@ -159,14 +159,14 @@ npx skills add microsoft/agent-skills
 
 ### Skill Catalog
 
-> Location: `.github/skills/` • 124 skills • See [README.md#skill-catalog](README.md#skill-catalog)
+> Location: `.github/skills/` • 126 skills • See [README.md#skill-catalog](README.md#skill-catalog)
 
 | Language | Skills | Suffix | Examples |
 |----------|--------|--------|----------|
 | **Core** | 5 | — | `mcp-builder`, `skill-creator`, `azd-deployment` |
-| **Python** | 41 | `-py` | `azure-ai-projects-py`, `azure-cosmos-py`, `azure-ai-ml-py` |
+| **Python** | 42 | `-py` | `azure-ai-projects-py`, `azure-cosmos-py`, `azure-ai-ml-py` |
 | **.NET** | 29 | `-dotnet` | `azure-ai-projects-dotnet`, `azure-resource-manager-cosmosdb-dotnet`, `azure-security-keyvault-keys-dotnet` |
-| **TypeScript** | 23 | `-ts` | `azure-ai-projects-ts`, `azure-storage-blob-ts`, `azure-servicebus-ts` |
+| **TypeScript** | 24 | `-ts` | `azure-ai-projects-ts`, `azure-storage-blob-ts`, `azure-servicebus-ts` |
 | **Java** | 26 | `-java` | `azure-ai-projects-java`, `azure-cosmos-java`, `azure-eventhub-java` |
 
 ### Skill Selection

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 | Resource | Description |
 |----------|-------------|
-| **[124 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
+| **[126 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
 | **[Custom Agents](#agents)** | Role-specific agents (backend, frontend, infrastructure, planner) |
 | **[AGENTS.md](AGENTS.md)** | Template for configuring agent behavior in your projects |
 | **[MCP Configs](#mcp-servers)** | Pre-configured servers for docs, GitHub, browser automation |
@@ -72,14 +72,14 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 ## Skill Catalog
 
-> 124 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
+> 126 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
 
 | Language | Count | Suffix | 
 |----------|-------|--------|
 | [Core](#core) | 5 | — |
-| [Python](#python) | 41 | `-py` |
+| [Python](#python) | 42 | `-py` |
 | [.NET](#net) | 29 | `-dotnet` |
-| [TypeScript](#typescript) | 23 | `-ts` |
+| [TypeScript](#typescript) | 24 | `-ts` |
 | [Java](#java) | 26 | `-java` |
 
 ---
@@ -100,10 +100,10 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 ### Python
 
-> 41 skills • suffix: `-py`
+> 42 skills • suffix: `-py`
 
 <details>
-<summary><strong>Foundry & AI</strong> (7 skills)</summary>
+<summary><strong>Foundry & AI</strong> (8 skills)</summary>
 
 | Skill | Description |
 |-------|-------------|
@@ -114,6 +114,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 | [hosted-agents-v2-py](.github/skills/hosted-agents-v2-py/) | Hosted Agents SDK — container-based agents with ImageBasedHostedAgentDefinition, custom images, tools. |
 | [azure-ai-projects-py](.github/skills/azure-ai-projects-py/) | High-level Foundry SDK — project client, versioned agents, evals, connections, OpenAI-compatible clients. |
 | [azure-search-documents-py](.github/skills/azure-search-documents-py/) | AI Search SDK — vector search, hybrid search, semantic ranking, indexing, skillsets. |
+| [m365-agents-py](.github/skills/m365-agents-py/) | Microsoft 365 Agents SDK — aiohttp hosting, AgentApplication routing, streaming, Copilot Studio client. |
 
 </details>
 
@@ -294,16 +295,17 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 
 ### TypeScript
 
-> 23 skills • suffix: `-ts`
+> 24 skills • suffix: `-ts`
 
 <details>
-<summary><strong>Foundry & AI</strong> (7 skills)</summary>
+<summary><strong>Foundry & AI</strong> (8 skills)</summary>
 
 | Skill | Description |
 |-------|-------------|
 | [azure-ai-contentsafety-ts](.github/skills/azure-ai-contentsafety-ts/) | Content Safety — moderate text/images, detect harmful content. |
 | [azure-ai-document-intelligence-ts](.github/skills/azure-ai-document-intelligence-ts/) | Document Intelligence — extract from invoices, receipts, IDs, forms. |
 | [azure-ai-projects-ts](.github/skills/azure-ai-projects-ts/) | AI Projects SDK — Foundry client, agents, connections, evals. |
+| [m365-agents-ts](.github/skills/m365-agents-ts/) | Microsoft 365 Agents SDK — AgentApplication routing, Express hosting, streaming, Copilot Studio client. |
 | [azure-ai-translation-ts](.github/skills/azure-ai-translation-ts/) | Translation — text translation, transliteration, document batch. |
 | [azure-ai-voicelive-ts](.github/skills/azure-ai-voicelive-ts/) | Voice Live — real-time voice AI with WebSocket, Node.js or browser. |
 | [azure-search-documents-ts](.github/skills/azure-search-documents-ts/) | AI Search — vector/hybrid search, semantic ranking, knowledge bases. |
@@ -366,7 +368,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 > 26 skills • suffix: `-java`
 
 <details>
-<summary><strong>Foundry & AI</strong> (7 skills)</summary>
+<summary><strong>Foundry & AI</strong> (8 skills)</summary>
 
 | Skill | Description |
 |-------|-------------|
@@ -447,7 +449,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 AGENTS.md                # Agent configuration template
 
 .github/
-├── skills/              # All 124 skills (flat structure)
+├── skills/              # All 126 skills (flat structure)
 ├── prompts/             # Reusable prompt templates
 ├── agents/              # Agent persona definitions
 ├── scripts/             # Automation scripts (doc scraping)
@@ -581,15 +583,15 @@ pnpm test
 
 ### Test Coverage Summary
 
-**124 skills with 1144 test scenarios** — all skills have acceptance criteria and test scenarios.
+**126 skills with 1134 test scenarios** — all skills have acceptance criteria and test scenarios.
 
 | Language | Skills | Scenarios | Top Skills by Scenarios |
 |----------|--------|-----------|-------------------------|
-| Core | 5 | 51 | `azd-deployment` (8), `github-issue-creator` (8), `mcp-builder` (8) |
-| Python | 41 | 359 | `azure-ai-projects-py` (12), `pydantic-models-py` (12), `azure-ai-translation-text-py` (11) |
-| .NET | 29 | 290 | `azure-resource-manager-redis-dotnet` (14), `azure-resource-manager-sql-dotnet` (14), `azure-ai-projects-dotnet` (13) |
-| TypeScript | 23 | 249 | `azure-storage-blob-ts` (17), `azure-servicebus-ts` (14), `azure-ai-contentsafety-ts` (12) |
-| Java | 26 | 195 | `azure-identity-java` (12), `azure-storage-blob-java` (12), `azure-ai-agents-persistent-java` (11) |
+| Core | 5 | 51 | `scaffold-foundry-app` (11), `podcast-generation` (8), `skill-creator` (8) |
+| Python | 42 | 341 | `azure-ai-projects-py` (12), `pydantic-models-py` (12), `azure-ai-translation-text-py` (11) |
+| .NET | 29 | 290 | `azure-resource-manager-sql-dotnet` (14), `azure-resource-manager-redis-dotnet` (14), `azure-servicebus-dotnet` (13) |
+| TypeScript | 24 | 257 | `azure-storage-blob-ts` (17), `azure-servicebus-ts` (14), `azure-microsoft-playwright-testing-ts` (13) |
+| Java | 26 | 195 | `azure-storage-blob-java` (12), `azure-identity-java` (12), `azure-data-tables-java` (11) |
 
 ### Adding Test Coverage
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -714,7 +714,7 @@
 
             <div class="badges">
                 <span class="badge">
-                    <span class="badge-count">124</span> Skills
+                    <span class="badge-count">126</span> Skills
                 </span>
                 <span class="badge">
                     <span class="badge-count">6</span> Custom Agents
@@ -763,7 +763,7 @@
             <!-- Stats -->
             <div class="stats-grid">
                 <div class="stat-card">
-                    <div class="stat-number">41</div>
+                    <div class="stat-number">42</div>
                     <div class="stat-label">Python Skills</div>
                 </div>
                 <div class="stat-card">
@@ -771,7 +771,7 @@
                     <div class="stat-label">.NET Skills</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number">23</div>
+                    <div class="stat-number">24</div>
                     <div class="stat-label">TypeScript Skills</div>
                 </div>
                 <div class="stat-card">
@@ -803,19 +803,19 @@
 
                 <div class="language-tabs">
                     <button class="tab-btn active" onclick="showTab('all')">
-                        All <span class="tab-count">124</span>
+                        All <span class="tab-count">126</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('core')">
                         Core <span class="tab-count">5</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('py')">
-                        Python <span class="tab-count">41</span>
+                        Python <span class="tab-count">42</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('dotnet')">
                         .NET <span class="tab-count">29</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('ts')">
-                        TypeScript <span class="tab-count">23</span>
+                        TypeScript <span class="tab-count">24</span>
                     </button>
                     <button class="tab-btn" onclick="showTab('java')">
                         Java <span class="tab-count">26</span>
@@ -1278,6 +1278,11 @@
                     lang: "py",
                     desc: "Pydantic patterns — Base, Create, Update, Response variants",
                 },
+                {
+                    name: "m365-agents-py",
+                    lang: "py",
+                    desc: "Microsoft 365 Agents SDK — aiohttp hosting, AgentApplication routing, streaming, Copilot Studio client",
+                },
 
                 // .NET
                 {
@@ -1456,6 +1461,11 @@
                     name: "azure-ai-projects-ts",
                     lang: "ts",
                     desc: "AI Projects SDK — Foundry client, agents",
+                },
+                {
+                    name: "m365-agents-ts",
+                    lang: "ts",
+                    desc: "Microsoft 365 Agents SDK — AgentApplication routing, Express hosting, streaming, Copilot Studio client",
                 },
                 {
                     name: "azure-ai-translation-ts",

--- a/skills/typescript/foundry/m365-agents
+++ b/skills/typescript/foundry/m365-agents
@@ -1,0 +1,1 @@
+../../../.github/skills/m365-agents-ts

--- a/tests/scenarios/m365-agents-py/scenarios.yaml
+++ b/tests/scenarios/m365-agents-py/scenarios.yaml
@@ -1,0 +1,296 @@
+# yaml-language-server: $schema=../skill-scenarios.schema.json
+# Test scenarios for m365-agents-py skill evaluation
+# Each scenario tests a specific usage pattern against acceptance criteria
+
+config:
+  model: gpt-4
+  max_tokens: 2000
+  temperature: 0.3
+
+scenarios:
+  - name: aiohttp_agent_hosting
+    prompt: |
+      Create a minimal aiohttp-hosted Microsoft 365 agent in Python using
+      AgentApplication, start_agent_process, and jwt_authorization_middleware.
+    expected_patterns:
+      - "AgentApplication"
+      - "start_agent_process"
+      - "jwt_authorization_middleware"
+      - "microsoft_agents.hosting.core"
+      - "microsoft_agents.hosting.aiohttp"
+      - "CloudAdapter"
+      - "MsalConnectionManager"
+    forbidden_patterns:
+      - "botbuilder"
+      - "microsoft.agents"
+      - "ActivityHandler"
+    tags:
+      - hosting
+    mock_response: |
+      import logging
+      from os import environ
+      from dotenv import load_dotenv
+      from aiohttp.web import Request, Response, Application, run_app
+
+      from microsoft_agents.activity import load_configuration_from_env
+      from microsoft_agents.hosting.core import (
+          Authorization,
+          AgentApplication,
+          TurnState,
+          TurnContext,
+          MemoryStorage,
+      )
+      from microsoft_agents.hosting.aiohttp import (
+          CloudAdapter,
+          start_agent_process,
+          jwt_authorization_middleware,
+      )
+      from microsoft_agents.authentication.msal import MsalConnectionManager
+
+      load_dotenv()
+      agents_sdk_config = load_configuration_from_env(environ)
+
+      STORAGE = MemoryStorage()
+      CONNECTION_MANAGER = MsalConnectionManager(**agents_sdk_config)
+      ADAPTER = CloudAdapter(connection_manager=CONNECTION_MANAGER)
+      AUTHORIZATION = Authorization(STORAGE, CONNECTION_MANAGER, **agents_sdk_config)
+
+      AGENT_APP = AgentApplication[TurnState](
+          storage=STORAGE, adapter=ADAPTER, authorization=AUTHORIZATION, **agents_sdk_config
+      )
+
+      @AGENT_APP.activity("message")
+      async def on_message(context: TurnContext, _state: TurnState):
+          await context.send_activity(f"You said: {context.activity.text}")
+
+      async def entry_point(req: Request) -> Response:
+          agent: AgentApplication = req.app["agent_app"]
+          adapter: CloudAdapter = req.app["adapter"]
+          return await start_agent_process(req, agent, adapter)
+
+      APP = Application(middlewares=[jwt_authorization_middleware])
+      APP.router.add_post("/api/messages", entry_point)
+      APP["agent_app"] = AGENT_APP
+      APP["adapter"] = AGENT_APP.adapter
+
+      if __name__ == "__main__":
+          run_app(APP, host="localhost", port=3978)
+
+  - name: agent_application_routing
+    prompt: |
+      Create an AgentApplication that handles welcome messages with
+      conversation_update, message handlers with regex, and an error handler.
+    expected_patterns:
+      - "AgentApplication"
+      - "@AGENT_APP.conversation_update"
+      - "@AGENT_APP.message"
+      - "@AGENT_APP.error"
+      - "re.compile"
+    forbidden_patterns:
+      - "ActivityHandler"
+      - "on_message_activity"
+    tags:
+      - routing
+    mock_response: |
+      import re
+      from microsoft_agents.hosting.core import (
+          AgentApplication, TurnState, TurnContext, MemoryStorage
+      )
+
+      AGENT_APP = AgentApplication[TurnState](storage=MemoryStorage())
+
+      @AGENT_APP.conversation_update("membersAdded")
+      async def on_members_added(context: TurnContext, _state: TurnState):
+          await context.send_activity("Welcome to the agent!")
+
+      @AGENT_APP.message(re.compile(r"^hello$", re.IGNORECASE))
+      async def on_hello(context: TurnContext, _state: TurnState):
+          await context.send_activity("Hello!")
+
+      @AGENT_APP.message("/status")
+      async def on_status(context: TurnContext, _state: TurnState):
+          await context.send_activity("Status: OK")
+
+      @AGENT_APP.activity("message")
+      async def on_message(context: TurnContext, _state: TurnState):
+          await context.send_activity(f"Echo: {context.activity.text}")
+
+      @AGENT_APP.error
+      async def on_error(context: TurnContext, error: Exception):
+          await context.send_activity("An error occurred.")
+
+  - name: streaming_response
+    prompt: |
+      Show how to stream a response using streaming_response with Azure OpenAI
+      and end the stream in a finally block.
+    expected_patterns:
+      - "streaming_response"
+      - "queue_text_chunk"
+      - "end_stream"
+      - "AsyncAzureOpenAI"
+      - "finally"
+    forbidden_patterns:
+      - "endstream"
+    tags:
+      - streaming
+    mock_response: |
+      from os import environ
+      from openai import AsyncAzureOpenAI
+      from microsoft_agents.hosting.core import AgentApplication, TurnState, TurnContext
+      from microsoft_agents.activity import SensitivityUsageInfo
+
+      CLIENT = AsyncAzureOpenAI(
+          api_version=environ["AZURE_OPENAI_API_VERSION"],
+          azure_endpoint=environ["AZURE_OPENAI_ENDPOINT"],
+          api_key=environ["AZURE_OPENAI_API_KEY"]
+      )
+
+      @AGENT_APP.message("poem")
+      async def on_poem_message(context: TurnContext, _state: TurnState):
+          context.streaming_response.set_feedback_loop(True)
+          context.streaming_response.set_generated_by_ai_label(True)
+          context.streaming_response.set_sensitivity_label(
+              SensitivityUsageInfo(
+                  type="https://schema.org/Message",
+                  schema_type="CreativeWork",
+                  name="Internal",
+              )
+          )
+          context.streaming_response.queue_informative_update("Starting a poem...")
+
+          streamed_response = await CLIENT.chat.completions.create(
+              model="gpt-4o",
+              messages=[
+                  {"role": "system", "content": "You are a creative assistant."},
+                  {"role": "user", "content": "Write a poem."}
+              ],
+              stream=True,
+          )
+          
+          try:
+              async for chunk in streamed_response:
+                  if chunk.choices and chunk.choices[0].delta.content:
+                      context.streaming_response.queue_text_chunk(
+                          chunk.choices[0].delta.content
+                      )
+          finally:
+              await context.streaming_response.end_stream()
+
+  - name: oauth_auto_signin
+    prompt: |
+      Show how to use auth_handlers for OAuth-protected routes and
+      sign out the user from an OAuth connection.
+    expected_patterns:
+      - "auth_handlers"
+      - "get_token"
+      - "sign_out"
+      - "AGENT_APP.auth"
+    tags:
+      - oauth
+      - authentication
+    mock_response: |
+      from microsoft_agents.hosting.core import (
+          AgentApplication, TurnState, TurnContext, MessageFactory
+      )
+
+      @AGENT_APP.message("/logout")
+      async def logout(context: TurnContext, state: TurnState):
+          await AGENT_APP.auth.sign_out(context, "GRAPH")
+          await context.send_activity(MessageFactory.text("You have been logged out."))
+
+      @AGENT_APP.message("/me", auth_handlers=["GRAPH"])
+      async def profile_request(context: TurnContext, state: TurnState):
+          user_token_response = await AGENT_APP.auth.get_token(context, "GRAPH")
+          if user_token_response and user_token_response.token:
+              # Use token to call Microsoft Graph
+              await context.send_activity("Profile retrieved successfully!")
+          else:
+              await context.send_activity("Token not available.")
+
+  - name: copilot_studio_client
+    prompt: |
+      Show how to configure CopilotClient with ConnectionSettings, start
+      a conversation, and ask a question using the Copilot Studio client.
+    expected_patterns:
+      - "CopilotClient"
+      - "ConnectionSettings"
+      - "start_conversation"
+      - "ask_question"
+      - "microsoft_agents.copilotstudio.client"
+    forbidden_patterns:
+      - "DirectLineClient"
+    tags:
+      - copilot-studio
+    mock_response: |
+      import asyncio
+      from os import environ
+      from msal import PublicClientApplication
+      from microsoft_agents.activity import ActivityTypes
+      from microsoft_agents.copilotstudio.client import (
+          ConnectionSettings,
+          CopilotClient,
+      )
+
+      def acquire_token(app_client_id, tenant_id):
+          pca = PublicClientApplication(
+              client_id=app_client_id,
+              authority=f"https://login.microsoftonline.com/{tenant_id}",
+          )
+          
+          token_request = {"scopes": ["https://api.powerplatform.com/.default"]}
+          accounts = pca.get_accounts()
+          
+          if accounts:
+              response = pca.acquire_token_silent(token_request["scopes"], account=accounts[0])
+              return response.get("access_token")
+          else:
+              response = pca.acquire_token_interactive(**token_request)
+              return response.get("access_token")
+
+      async def main():
+          settings = ConnectionSettings(
+              environment_id=environ.get("COPILOTSTUDIOAGENT__ENVIRONMENTID"),
+              agent_identifier=environ.get("COPILOTSTUDIOAGENT__SCHEMANAME"),
+          )
+          
+          token = acquire_token(
+              app_client_id=environ.get("COPILOTSTUDIOAGENT__AGENTAPPID"),
+              tenant_id=environ.get("COPILOTSTUDIOAGENT__TENANTID"),
+          )
+          
+          copilot_client = CopilotClient(settings, token)
+          
+          # Start conversation
+          act = copilot_client.start_conversation(True)
+          async for action in act:
+              if action.text:
+                  print(action.text)
+          
+          # Ask question
+          replies = copilot_client.ask_question("Hello!", action.conversation.id)
+          async for reply in replies:
+              if reply.type == ActivityTypes.message:
+                  print(reply.text)
+
+      asyncio.run(main())
+
+  - name: invoke_activity_response
+    prompt: |
+      Create an invoke handler that returns an invoke_response activity.
+    expected_patterns:
+      - "ActivityTypes.invoke"
+      - "invoke_response"
+      - "@AGENT_APP.activity"
+    tags:
+      - invoke
+    mock_response: |
+      from microsoft_agents.hosting.core import AgentApplication, TurnState, TurnContext
+      from microsoft_agents.activity import Activity, ActivityTypes
+
+      @AGENT_APP.activity(ActivityTypes.invoke)
+      async def on_invoke(context: TurnContext, _state: TurnState):
+          invoke_response = Activity(
+              type=ActivityTypes.invoke_response, value={"status": 200}
+          )
+          await context.send_activity(invoke_response)
+          await context.send_activity("Invoke processed.")

--- a/tests/scenarios/m365-agents-ts/scenarios.yaml
+++ b/tests/scenarios/m365-agents-ts/scenarios.yaml
@@ -1,0 +1,129 @@
+# yaml-language-server: $schema=../skill-scenarios.schema.json
+# Test scenarios for m365-agents-ts skill evaluation
+# Each scenario tests a specific usage pattern against acceptance criteria
+
+config:
+  model: gpt-4
+  max_tokens: 2000
+  temperature: 0.3
+
+scenarios:
+  - name: express_agent_hosting
+    prompt: |
+      Create a minimal Express-hosted Microsoft 365 agent in TypeScript using
+      AgentApplication and startServer.
+    expected_patterns:
+      - "AgentApplication"
+      - "startServer"
+      - "@microsoft/agents-hosting"
+      - "@microsoft/agents-hosting-express"
+    forbidden_patterns:
+      - "botbuilder"
+      - "BotFrameworkAdapter"
+    tags:
+      - hosting
+    mock_response: |
+      import { AgentApplication, TurnContext, TurnState } from "@microsoft/agents-hosting";
+      import { startServer } from "@microsoft/agents-hosting-express";
+
+      const agent = new AgentApplication<TurnState>();
+
+      agent.onMessage("hello", async (context: TurnContext) => {
+        await context.sendActivity("Hello from the agent!");
+      });
+
+      startServer(agent);
+
+  - name: streaming_response
+    prompt: |
+      Show how to stream a response using streamingResponse with Azure OpenAI
+      and end the stream in a finally block.
+    expected_patterns:
+      - "streamingResponse"
+      - "queueTextChunk"
+      - "endStream"
+      - "streamText"
+    forbidden_patterns:
+      - "endstream"
+    tags:
+      - streaming
+    mock_response: |
+      import { azure } from "@ai-sdk/azure";
+      import { AgentApplication, TurnContext, TurnState } from "@microsoft/agents-hosting";
+      import { streamText } from "ai";
+
+      const agent = new AgentApplication<TurnState>();
+
+      agent.onMessage("poem", async (context: TurnContext) => {
+        const { fullStream } = streamText({
+          model: azure(process.env.AZURE_OPENAI_DEPLOYMENT_NAME || "gpt-4o-mini"),
+          prompt: "Write a poem.",
+        });
+
+        try {
+          for await (const part of fullStream) {
+            if (part.type === "text-delta" && part.text.length > 0) {
+              await context.streamingResponse.queueTextChunk(part.text);
+            }
+          }
+        } finally {
+          await context.streamingResponse.endStream();
+        }
+      });
+
+  - name: invoke_activity_response
+    prompt: |
+      Create an invoke handler that returns an InvokeResponse activity for
+      feedback submissions.
+    expected_patterns:
+      - "ActivityTypes.InvokeResponse"
+      - "Activity.fromObject"
+      - "onActivity"
+    tags:
+      - invoke
+    mock_response: |
+      import { Activity, ActivityTypes } from "@microsoft/agents-activity";
+      import { AgentApplication, TurnContext, TurnState } from "@microsoft/agents-hosting";
+
+      const agent = new AgentApplication<TurnState>();
+
+      agent.onActivity("invoke", async (context: TurnContext) => {
+        const invokeResponse = Activity.fromObject({
+          type: ActivityTypes.InvokeResponse,
+          value: { status: 200 },
+        });
+
+        await context.sendActivity(invokeResponse);
+      });
+
+  - name: copilot_studio_client
+    prompt: |
+      Show how to configure CopilotStudioClient with a token provider, start
+      a conversation, and ask a question.
+    expected_patterns:
+      - "CopilotStudioClient"
+      - "startConversationAsync"
+      - "askQuestionAsync"
+      - "tokenProvider"
+    forbidden_patterns:
+      - "DirectLineClient"
+    tags:
+      - copilot-studio
+    mock_response: |
+      import { CopilotStudioClient } from "@microsoft/agents-copilotstudio-client";
+
+      const settings = {
+        environmentId: process.env.COPILOT_ENVIRONMENT_ID!,
+        schemaName: process.env.COPILOT_SCHEMA_NAME!,
+        clientId: process.env.COPILOT_CLIENT_ID!,
+      };
+
+      const tokenProvider = async (): Promise<string> => {
+        return process.env.COPILOT_BEARER_TOKEN!;
+      };
+
+      const client = new CopilotStudioClient(settings, tokenProvider);
+
+      const conversation = await client.startConversationAsync();
+      const reply = await client.askQuestionAsync("Hello!", conversation.id);
+      console.log(reply);


### PR DESCRIPTION
## Summary

Adds a new skill for the Microsoft 365 Agents SDK for Python, following the same pattern as the existing `m365-agents-dotnet` and `m365-agents-ts` skills.

## Changes

### New Skill: `m365-agents-py`

**SKILL.md** covers:
- aiohttp hosting with `start_agent_process` and `jwt_authorization_middleware`
- `AgentApplication` routing with decorators (`@AGENT_APP.message`, `@AGENT_APP.activity`, etc.)
- Streaming responses with Azure OpenAI
- OAuth / auto sign-in patterns with `auth_handlers`
- Copilot Studio client (Direct to Engine)
- Proper import patterns (`microsoft_agents` with underscores)

**Acceptance Criteria** (`references/acceptance-criteria.md`):
- Correct/incorrect import patterns (emphasizes `microsoft_agents` vs old `microsoft.agents`)
- Hosting pipeline patterns
- AgentApplication routing patterns
- OAuth/auto sign-in patterns
- Streaming response patterns
- Copilot Studio client patterns

**Test Scenarios** (6 scenarios):
1. `aiohttp_agent_hosting` - Basic hosting setup
2. `agent_application_routing` - Message handlers and routing
3. `streaming_response` - Azure OpenAI streaming
4. `oauth_auto_signin` - Auth-protected routes
5. `copilot_studio_client` - CopilotClient usage
6. `invoke_activity_response` - Invoke activity handling

### Documentation Updates
- Updated README.md skill counts (126 total, 42 Python, 24 TypeScript)
- Updated docs/index.html for GitHub Pages with correct counts and new skill entries

## Packages Covered

- `microsoft-agents-hosting-core`
- `microsoft-agents-hosting-aiohttp`
- `microsoft-agents-activity`
- `microsoft-agents-authentication-msal`
- `microsoft-agents-copilotstudio-client`

## References

- [Microsoft 365 Agents SDK](https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/)
- [GitHub: Agents-for-python](https://github.com/microsoft/Agents-for-python)
- [PyPI packages](https://pypi.org/search/?q=microsoft-agents)