### PR TITLE
fix(docs-site): only apply grid collapse when items exceed visible limit

### DIFF
--- a/docs-site/src/components/SkillsSection.tsx
+++ b/docs-site/src/components/SkillsSection.tsx
@@ -37,6 +37,13 @@ export function SkillsSection({ skills }: SkillsSectionProps) {
   const COLLAPSED_ROWS = 2;
   const ITEMS_PER_ROW_DESKTOP = 4;
   const MAX_VISIBLE_COLLAPSED = COLLAPSED_ROWS * ITEMS_PER_ROW_DESKTOP;
+  
+  // Card height estimate: padding (24px * 2) + title (~24px) + description (~72px) + footer (~24px) + gaps (~16px) = ~184px
+  // Add some buffer for longer titles that wrap = ~200px per card
+  // Plus grid gap (24px) between rows
+  const CARD_HEIGHT_ESTIMATE = 200;
+  const GRID_GAP = 24; // var(--space-lg)
+  const COLLAPSED_HEIGHT = (CARD_HEIGHT_ESTIMATE * COLLAPSED_ROWS) + (GRID_GAP * (COLLAPSED_ROWS - 1)) + 40; // +40 for button overlap space
 
   const langCounts = useMemo(() => {
     return skills.reduce((acc, skill) => {


### PR DESCRIPTION
Previously, maxHeight was applied unconditionally to the skills grid, causing content to be cropped when filtered results fit in exactly 2 rows (e.g., Integration category with 7 skills).

Now maxHeight and overflow restrictions are only applied when there are more items than fit in the collapsed view (>8 items), allowing smaller result sets to display without cropping.