### PR TITLE
feat(eval): add verbose CLI reporting and CI failure annotations

### DIFF
--- a/.github/workflows/skill-evaluation.yml
+++ b/.github/workflows/skill-evaluation.yml
@@ -126,10 +126,43 @@ jobs:
           path: |
             tests/results.md
             tests/results.json
+          retention-days: 7
+          if-no-files-found: warn
 
       - name: Check evaluation results
         if: always()
         run: |
           if [ "${{ steps.harness.outputs.exit_code }}" != "0" ]; then
             echo "::warning::Some skills have failing scenarios in real SDK evaluation"
+          fi
+
+      - name: Add detailed failure annotations
+        if: always()
+        working-directory: tests
+        run: |
+          if [ "${{ steps.harness.outputs.exit_code }}" != "0" ] && [ -f results.json ]; then
+            node - <<'EOF'
+            const fs = require('fs');
+
+            const raw = fs.readFileSync('results.json', 'utf-8');
+            const data = JSON.parse(raw);
+            const skills = data.skills ?? [];
+
+            for (const skill of skills) {
+              const results = skill.results ?? [];
+              for (const result of results) {
+                if (result.passed) continue;
+                const findings = result.findings ?? [];
+                const failures = findings.filter(f => f.severity === 'error');
+                if (failures.length === 0) continue;
+
+                const top = failures.slice(0, 3);
+                const details = top.map(f => `- ${f.message}${f.suggestion ? ` (💡 ${f.suggestion})` : ''}`).join(' ');
+                const summary = `${skill.skill_name} / ${result.scenario} failed (score: ${Number(result.score).toFixed(1)})`;
+                const message = `${summary} ${details}`;
+
+                console.log(`::error::${message}`);
+              }
+            }
+            EOF
           fi


### PR DESCRIPTION
## Summary

- **`tests/harness/runner.ts`**: Add detailed verbose output for scenario evaluations and ralph loop results — prints pattern checks, acceptance criteria matches, individual findings with severity/suggestion/code-snippet, and per-skill failure summaries in the CLI. Enrich the markdown report's Failed Scenarios section with severity labels, suggestions, and matched/incorrect acceptance-criteria sections.
- **`.github/workflows/skill-evaluation.yml`**: Add a new step that emits `::error::` annotations for every failed scenario (surfacing top-3 errors inline in the Actions UI). Set artifact `retention-days: 7` and `if-no-files-found: warn` on the results upload step.

The goal is to make evaluation failures visible directly in the CLI and in the GitHub Actions summary without needing to download artifacts.

## Testing

- `pnpm typecheck` — passed locally.
- Note: LSP diagnostics could not run because `typescript-language-server` is not installed in this environment.
- No runtime tests were executed; changes are additive console output and workflow steps.