### PR TITLE
feat: add deep-wiki plugin for Copilot CLI

### DIFF
--- a/.github/plugins/deep-wiki/.claude-plugin/plugin.json
+++ b/.github/plugins/deep-wiki/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "thegovind"
   },
-  "homepage": "https://github.com/thegovind/deep-wiki",
-  "repository": "https://github.com/thegovind/deep-wiki",
+  "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/deep-wiki",
+  "repository": "https://github.com/microsoft/skills",
   "license": "MIT"
 }

--- a/.github/plugins/deep-wiki/README.md
+++ b/.github/plugins/deep-wiki/README.md
@@ -1,21 +1,22 @@
 # 🌊 Deep Wiki
 
-**AI-Powered Wiki Generator for Code Repositories — Claude Code Plugin**
+**AI-Powered Wiki Generator for Code Repositories — GitHub Copilot CLI Plugin**
 
 Generate comprehensive, structured, Mermaid-rich documentation wikis for any codebase. Distilled from the prompt architectures of [OpenDeepWiki](https://github.com/AIDotNet/OpenDeepWiki) and [deepwiki-open](https://github.com/AsyncFuncAI/deepwiki-open).
 
 ## Installation
 
+### From a marketplace
+
+```bash
+copilot marketplace add microsoft/skills
+copilot plugin install deep-wiki@skills
+```
+
 ### Local development
 
 ```bash
-claude --plugin-dir ./deep-wiki
-```
-
-### From a marketplace
-
-```
-/plugin install deep-wiki
+copilot --plugin-dir ./deep-wiki
 ```
 
 ## Commands
@@ -52,8 +53,8 @@ View available agents: `/agents`
 ## Quick Start
 
 ```bash
-# Start Claude Code with the plugin
-claude --plugin-dir ./deep-wiki
+# Install the plugin
+copilot plugin install deep-wiki@skills
 
 # Generate a full wiki
 /deep-wiki:generate
@@ -109,7 +110,7 @@ deep-wiki/
 │   ├── changelog.md
 │   ├── research.md
 │   └── ask.md
-├── skills/                   # Auto-invoked by Claude based on context
+├── skills/                   # Auto-invoked based on context
 │   ├── wiki-architect/
 │   │   └── SKILL.md
 │   ├── wiki-page-writer/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) are po
 | Resource | Description |
 |----------|-------------|
 | **[125 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
+| **[Plugins](#plugins)** | Installable plugin packages (deep-wiki, and more) |
 | **[Custom Agents](#agents)** | Role-specific agents (backend, frontend, infrastructure, planner) |
 | **[AGENTS.md](AGENTS.md)** | Template for configuring agent behavior in your projects |
 | **[MCP Configs](#mcp-servers)** | Pre-configured servers for docs, GitHub, browser automation |
@@ -506,6 +507,8 @@ AGENTS.md                # Agent configuration template
 
 .github/
 ├── skills/              # All 132 skills (flat structure)
+├── plugins/             # Installable plugin packages
+│   └── deep-wiki/       # AI-powered wiki generator
 ├── prompts/             # Reusable prompt templates
 ├── agents/              # Agent persona definitions
 ├── scripts/             # Automation scripts (doc scraping)
@@ -526,6 +529,21 @@ skills/                  # Symlinks for backward compatibility
 .vscode/
 └── mcp.json             # MCP server configurations
 ```
+
+---
+
+## Plugins
+
+Plugins are installable packages containing curated sets of agents, commands, and skills. Install via the Copilot CLI:
+
+```bash
+copilot marketplace add microsoft/skills
+copilot plugin install <plugin-name>@skills
+```
+
+| Plugin | Description | Commands |
+|--------|-------------|----------|
+| [deep-wiki](.github/plugins/deep-wiki/) | AI-powered wiki generator with Mermaid diagrams, architecture analysis, and source citations | `/deep-wiki:generate`, `/deep-wiki:catalogue`, `/deep-wiki:page`, `/deep-wiki:changelog`, `/deep-wiki:research`, `/deep-wiki:ask` |
 
 ---
 

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -47,6 +47,20 @@ import mcpServers from '../data/mcp-servers.json';
             <p class="doc-desc">Curated list of skills, prompts, plugins, cookbooks, custom agents and more</p>
           </div>
         </a>
+
+        <!-- Deep Wiki -->
+        <a href="https://github.com/microsoft/skills/tree/main/.github/plugins/deep-wiki" target="_blank" rel="noopener" class="doc-card">
+          <span class="doc-icon">🌊</span>
+          <div class="doc-content">
+            <h3 class="doc-title">
+              Deep Wiki
+              <svg class="external-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
+              </svg>
+            </h3>
+            <p class="doc-desc">AI-powered wiki generator — Mermaid diagrams, architecture analysis, and source citations for any codebase</p>
+          </div>
+        </a>
       </div>
     </section>
 
@@ -258,7 +272,7 @@ import mcpServers from '../data/mcp-servers.json';
   /* Plugins Section */
   .plugins-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: var(--space-lg);
   }
 


### PR DESCRIPTION
## What

Add the **deep-wiki** plugin — an AI-powered wiki generator for code repositories that produces Mermaid-rich, citation-heavy documentation via GitHub Copilot CLI.

### Install

```bash
copilot marketplace add microsoft/skills
copilot plugin install deep-wiki@skills
```

## Plugin Contents

| Type | Count | Details |
|------|-------|---------|
| Commands | 6 | `generate`, `catalogue`, `page`, `changelog`, `research`, `ask` |
| Skills | 5 | wiki-architect, wiki-page-writer, wiki-changelog, wiki-researcher, wiki-qa |
| Agents | 3 | wiki-architect, wiki-writer, wiki-researcher |

## Also Included

- **Generic plugin validation tests** (`tests/plugins/`) — 42 Vitest tests validating any plugin in `.github/plugins/` (structure, frontmatter, cross-refs)
- **Acceptance criteria** for 3 skills (wiki-architect, wiki-page-writer, wiki-qa)
- **Docs-site update** — deep-wiki card added to the Plugins section
- **README update** — new Plugins section with install instructions
- **`.claude/plugins` symlink** → `.github/plugins/`

## Tests

```
Test Files  3 passed (3)
     Tests  87 passed (87)
```