### PR TITLE
Add .agents/skills symlink to .github/skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.github/skills


### PR DESCRIPTION
Adds a `.agents/skills` symlink pointing to `.github/skills`, providing an alternative path for agent skill discovery.