### PR TITLE
fix: update Deep Wiki icon from wave to books emoji

### DIFF
--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -50,7 +50,7 @@ import mcpServers from '../data/mcp-servers.json';
 
         <!-- Deep Wiki -->
         <button type="button" class="doc-card plugin-card-btn" onclick="document.getElementById('deep-wiki-modal').showModal()">
-          <span class="doc-icon">🌊</span>
+          <span class="doc-icon">📚</span>
           <div class="doc-content">
             <h3 class="doc-title">Deep Wiki</h3>
             <p class="doc-desc">AI-powered wiki generator — Mermaid diagrams, architecture analysis, and source citations for any codebase</p>
@@ -64,7 +64,7 @@ import mcpServers from '../data/mcp-servers.json';
       <div class="modal-content">
         <div class="modal-header">
           <div class="modal-title-row">
-            <span class="modal-icon">🌊</span>
+            <span class="modal-icon">📚</span>
             <h2 class="modal-title">Deep Wiki</h2>
             <span class="modal-badge">v1.0.0</span>
           </div>


### PR DESCRIPTION
Updates the Deep Wiki icon from 🌊 (wave) to 📚 (books) in the docs site landing page. The books emoji better represents Deep Wiki's purpose as an AI-powered wiki generator.