### PR TITLE
Add azure-skills to another marketplace.json

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -29,6 +29,18 @@
       "skills": "skills/",
       "agents": "agents/",
       "strict": true
+    },
+    {
+      "name": "azure-skills",
+      "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
+      "source": "./.github/plugins/azure-skills",
+      "author": {
+        "name": "microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/github-copilot-for-azure",
+      "repository": "https://github.com/microsoft/github-copilot-for-azure",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
There are two copies of marketplace.json in the repo. @thegovind What's the reason for having two copies of them?

https://github.com/microsoft/skills/blob/main/.github/plugin/marketplace.json
https://github.com/microsoft/skills/blob/main/marketplace.json