### PR TITLE
[docs-update] Update Foundry llms.txt documentation

### DIFF
--- a/docs/foundry-docs-manifest.json
+++ b/docs/foundry-docs-manifest.json
@@ -56,14 +56,24 @@
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-benchmarks?view=foundry"
       },
       {
-        "title": "Observability basics",
+        "title": "Observability overview",
         "href": "concepts/observability",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/observability?view=foundry"
+      },
+      {
+        "title": "Rate limits, region and virtual network support",
+        "href": "concepts/evaluation-regions-limits-virtual-network",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-regions-limits-virtual-network?view=foundry"
       },
       {
         "title": "Transparency Note for safety evaluations",
         "href": "concepts/safety-evaluations-transparency-note",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/safety-evaluations-transparency-note?view=foundry"
+      },
+      {
+        "title": "Built-in evaluators reference",
+        "href": "concepts/built-in-evaluators",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/built-in-evaluators?view=foundry"
       },
       {
         "title": "General purpose evaluators",
@@ -1013,7 +1023,7 @@
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/benchmark-model-in-catalog?view=foundry"
       },
       {
-        "title": "Run evaluations in the cloud",
+        "title": "Run evaluations from the SDK",
         "href": "how-to/develop/cloud-evaluation",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/cloud-evaluation?view=foundry"
       },
@@ -1373,6 +1383,6 @@
       }
     ]
   },
-  "total_pages": 267,
-  "generated_at": "2026-02-16T03:59:31Z"
+  "total_pages": 269,
+  "generated_at": "2026-02-18T03:56:45Z"
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -49,8 +49,10 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 - [Retrieval Augmented Generation (RAG) overview](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/retrieval-augmented-generation?view=foundry)
 - [Playgrounds and quick evaluation](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/concept-playgrounds?view=foundry)
 - [Model leaderboards](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-benchmarks?view=foundry)
-- [Observability basics](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/observability?view=foundry)
+- [Observability overview](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/observability?view=foundry)
+- [Rate limits, region and virtual network support](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-regions-limits-virtual-network?view=foundry)
 - [Transparency Note for safety evaluations](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/safety-evaluations-transparency-note?view=foundry)
+- [Built-in evaluators reference](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/built-in-evaluators?view=foundry)
 - [General purpose evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/general-purpose-evaluators?view=foundry)
 - [Textual similarity evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/textual-similarity-evaluators?view=foundry)
 - [Retrieval Augmented Generation (RAG) evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/rag-evaluators?view=foundry)
@@ -233,7 +235,7 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 ## How-To Guides
 
 - [Compare models](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/benchmark-model-in-catalog?view=foundry)
-- [Run evaluations in the cloud](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/cloud-evaluation?view=foundry)
+- [Run evaluations from the SDK](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/cloud-evaluation?view=foundry)
 - [Run evaluations from the portal](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/evaluate-generative-ai-app?view=foundry)
 - [View evaluation results in the portal](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/evaluate-results?view=foundry)
 - [Run red teaming scans in the cloud](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/run-ai-red-teaming-cloud?view=foundry)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,8 +30,10 @@ Important information:
 - [Retrieval Augmented Generation (RAG) overview](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/retrieval-augmented-generation?view=foundry)
 - [Playgrounds and quick evaluation](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/concept-playgrounds?view=foundry)
 - [Model leaderboards](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-benchmarks?view=foundry)
-- [Observability basics](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/observability?view=foundry)
+- [Observability overview](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/observability?view=foundry)
+- [Rate limits, region and virtual network support](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-regions-limits-virtual-network?view=foundry)
 - [Transparency Note for safety evaluations](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/safety-evaluations-transparency-note?view=foundry)
+- [Built-in evaluators reference](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/built-in-evaluators?view=foundry)
 - [General purpose evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/general-purpose-evaluators?view=foundry)
 - [Textual similarity evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/textual-similarity-evaluators?view=foundry)
 - [Retrieval Augmented Generation (RAG) evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/rag-evaluators?view=foundry)
@@ -214,7 +216,7 @@ Important information:
 ## How-To Guides
 
 - [Compare models](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/benchmark-model-in-catalog?view=foundry)
-- [Run evaluations in the cloud](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/cloud-evaluation?view=foundry)
+- [Run evaluations from the SDK](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/cloud-evaluation?view=foundry)
 - [Run evaluations from the portal](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/evaluate-generative-ai-app?view=foundry)
 - [View evaluation results in the portal](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/evaluate-results?view=foundry)
 - [Run red teaming scans in the cloud](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/run-ai-red-teaming-cloud?view=foundry)


### PR DESCRIPTION
Regenerated `docs/llms.txt`, `docs/llms-full.txt`, and `docs/foundry-docs-manifest.json` from the latest Microsoft Learn Table of Contents for Azure AI Foundry (fetched 2026-02-18).

## Changes

### New pages added (2 new pages, total: 269 → was 267)
- **Rate limits, region and virtual network support** — `concepts/evaluation-regions-limits-virtual-network`
- **Built-in evaluators reference** — `concepts/built-in-evaluators`

### Updated page titles
- `Observability basics` → `Observability overview`
- `Run evaluations in the cloud` → `Run evaluations from the SDK`

## Files changed
- `docs/llms.txt` — Main documentation index
- `docs/llms-full.txt` — Full documentation index with SDK quick reference
- `docs/foundry-docs-manifest.json` — Structured manifest (used by generate_llms_full.py)

## How this was generated
The scraper fetched the live TOC from `https://learn.microsoft.com/en-us/azure/ai-foundry/toc.json?view=foundry` and regenerated all files using the scripts in `.github/scripts/`.


> AI generated by [Update Foundry llms.txt Documentation](https://github.com/microsoft/skills/actions/runs/22125821941)