### PR TITLE
Fix: Rename link to Agents.md instead of AGENTS.md

### DIFF
--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -123,7 +123,7 @@ import hooks from '../data/hooks.json';
             </div>
             <div class="modal-row">
               <code class="modal-cmd">/deep-wiki:agents</code>
-              <span>Generate AGENTS.md for key folders</span>
+              <span>Generate Agents.md for key folders</span>
             </div>
             <div class="modal-row">
               <code class="modal-cmd">/deep-wiki:llms</code>
@@ -279,12 +279,12 @@ import hooks from '../data/hooks.json';
           </div>
         </a>
 
-        <!-- AGENTS.md -->
-        <a href="https://github.com/microsoft/skills/blob/main/AGENTS.md" target="_blank" rel="noopener" class="doc-card">
+        <!-- Agents.md -->
+        <a href="https://github.com/microsoft/skills/blob/main/Agents.md" target="_blank" rel="noopener" class="doc-card">
           <span class="doc-icon">🤖</span>
           <div class="doc-content">
             <h3 class="doc-title">
-              AGENTS.md Template
+              Agents.md Template
               <svg class="external-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
               </svg>


### PR DESCRIPTION
The AGENTS.md link is broken currently, so I fixed it.