### PR TITLE
[docs-update] Update Foundry llms.txt documentation

### DIFF
--- a/docs/foundry-docs-manifest.json
+++ b/docs/foundry-docs-manifest.json
@@ -490,11 +490,6 @@
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/dall-e?view=foundry"
       },
       {
-        "title": "Image generation quickstart",
-        "href": "openai/dall-e-quickstart",
-        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/dall-e-quickstart?view=foundry"
-      },
-      {
         "title": "Video generation",
         "href": "openai/concepts/video-generation",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/video-generation?view=foundry"
@@ -516,8 +511,8 @@
       },
       {
         "title": "Realtime API for speech and audio quickstart",
-        "href": "openai/realtime-audio-quickstart",
-        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/realtime-audio-quickstart?view=foundry"
+        "href": "openai/how-to/realtime-audio#quickstart",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio#quickstart?view=foundry"
       },
       {
         "title": "Realtime API via WebRTC",
@@ -646,8 +641,8 @@
       },
       {
         "title": "Vision-enabled chats",
-        "href": "openai/gpt-v-quickstart",
-        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/gpt-v-quickstart?view=foundry"
+        "href": "openai/how-to/gpt-with-vision",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/gpt-with-vision?view=foundry"
       },
       {
         "title": "Image prompt engineering techniques",
@@ -848,6 +843,11 @@
         "title": "Azure OpenAI quotas and limits",
         "href": "openai/quotas-limits",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/quotas-limits?view=foundry"
+      },
+      {
+        "title": "Azure OpenAI model retirement",
+        "href": "openai/concepts/model-retirements",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements?view=foundry"
       }
     ],
     "Observability & Evaluation": [
@@ -1006,6 +1006,11 @@
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/monitor-models?view=foundry"
       },
       {
+        "title": "Configure Claude Code with Microsoft Foundry",
+        "href": "foundry-models/how-to/configure-claude-code",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/configure-claude-code?view=foundry"
+      },
+      {
         "title": "Endpoints for Foundry Models",
         "href": "foundry-models/concepts/endpoints",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/endpoints?view=foundry"
@@ -1083,16 +1088,6 @@
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/ai-template-get-started?view=foundry"
       },
       {
-        "title": "Use the Visual Studio Code extension for agent development",
-        "href": "how-to/develop/vs-code-agents",
-        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/vs-code-agents?view=foundry"
-      },
-      {
-        "title": "Use MCP Tools in the Visual Studio Code extension",
-        "href": "how-to/develop/vs-code-agents-mcp",
-        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/vs-code-agents-mcp?view=foundry"
-      },
-      {
         "title": "Microsoft Foundry SDKs",
         "href": "how-to/develop/sdk-overview",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/sdk-overview?view=foundry"
@@ -1141,6 +1136,11 @@
         "title": "Manage quotas for Foundry resources",
         "href": "how-to/quota",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/quota?view=foundry"
+      },
+      {
+        "title": "Hide preview features with Azure tags",
+        "href": "how-to/disable-preview-features",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/disable-preview-features?view=foundry"
       },
       {
         "title": "Configure private link",
@@ -1345,6 +1345,11 @@
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/how-to-create-guardrails?view=foundry"
       },
       {
+        "title": "Third party Guardrail integrations",
+        "href": "guardrails/third-party-integrations",
+        "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/third-party-integrations?view=foundry"
+      },
+      {
         "title": "Intervention points",
         "href": "guardrails/intervention-points",
         "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/intervention-points?view=foundry"
@@ -1398,6 +1403,6 @@
       }
     ]
   },
-  "total_pages": 272,
-  "generated_at": "2026-02-24T03:56:09Z"
+  "total_pages": 273,
+  "generated_at": "2026-02-26T03:55:41Z"
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -145,6 +145,7 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 - [Upgrade GitHub Models to Foundry Models](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/quickstart-github-models?view=foundry)
 - [Claude in Foundry Models](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude?view=foundry)
 - [Monitor model deployments](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/monitor-models?view=foundry)
+- [Configure Claude Code with Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/configure-claude-code?view=foundry)
 - [Endpoints for Foundry Models](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/endpoints?view=foundry)
 - [Get started with DeepSeek-R1 reasoning model](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/tutorials/get-started-deepseek-r1?view=foundry)
 - [Foundry Models quotas and limits](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/quotas-limits?view=foundry)
@@ -161,12 +162,11 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 - [Get started with model router](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/model-router?view=foundry)
 - [Use blocklists](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/use-blocklists?view=foundry)
 - [Image generation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/dall-e?view=foundry)
-- [Image generation quickstart](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/dall-e-quickstart?view=foundry)
 - [Video generation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/video-generation?view=foundry)
 - [Vision-enabled chats](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/gpt-with-vision?view=foundry)
 - [Image prompt engineering techniques](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/gpt-4-v-prompt-engineering?view=foundry)
 - [Realtime API for speech and audio](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio?view=foundry)
-- [Realtime API for speech and audio quickstart](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/realtime-audio-quickstart?view=foundry)
+- [Realtime API for speech and audio quickstart](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio#quickstart?view=foundry)
 - [Realtime API via WebRTC](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio-webrtc?view=foundry)
 - [Realtime API via WebSockets](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio-websockets?view=foundry)
 - [Realtime API via SIP](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio-sip?view=foundry)
@@ -192,7 +192,7 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 - [Embeddings](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/embeddings?view=foundry)
 - [Embeddings tutorial](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/tutorials/embeddings?view=foundry)
 - [Audio generation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/audio-completions-quickstart?view=foundry)
-- [Vision-enabled chats](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/gpt-v-quickstart?view=foundry)
+- [Vision-enabled chats](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/gpt-with-vision?view=foundry)
 - [Image prompt engineering techniques](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/gpt-4-v-prompt-engineering?view=foundry)
 - [Image prompt transformation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/prompt-transformation?view=foundry)
 - [Video generation (preview)](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/video-generation?view=foundry)
@@ -233,6 +233,7 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 - [Performance & latency](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/latency?view=foundry)
 - [Red teaming large language models (LLMs)](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/red-teaming?view=foundry)
 - [Azure OpenAI quotas and limits](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/quotas-limits?view=foundry)
+- [Azure OpenAI model retirement](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements?view=foundry)
 
 ## How-To Guides
 
@@ -247,8 +248,6 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 - [Set up your developer environment](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/install-cli-sdk?view=foundry)
 - [Work in VS Code](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/get-started-projects-vs-code?view=foundry)
 - [Start with an AI template](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/ai-template-get-started?view=foundry)
-- [Use the Visual Studio Code extension for agent development](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/vs-code-agents?view=foundry)
-- [Use MCP Tools in the Visual Studio Code extension](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/vs-code-agents-mcp?view=foundry)
 - [Microsoft Foundry SDKs](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/sdk-overview?view=foundry)
 - [Integrate with your applications](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/integrate-with-other-apps?view=foundry)
 - [Create resources using Bicep template](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/create-resource-template?view=foundry)
@@ -259,6 +258,7 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 - [Connect to your own storage in Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/bring-your-own-azure-storage-foundry?view=foundry)
 - [Connect to your own storage for Speech/Language](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/bring-your-own-azure-storage-speech-language-services?view=foundry)
 - [Manage quotas for Foundry resources](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/quota?view=foundry)
+- [Hide preview features with Azure tags](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/disable-preview-features?view=foundry)
 - [Configure private link](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/configure-private-link?view=foundry)
 - [Managed virtual network](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/managed-virtual-network?view=foundry)
 - [Network security perimeter](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/add-foundry-to-network-security-perimeter?view=foundry)
@@ -312,6 +312,7 @@ AZURE_AI_MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 
 - [Overview](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/guardrails-overview?view=foundry)
 - [How to configure Guardrails and controls](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/how-to-create-guardrails?view=foundry)
+- [Third party Guardrail integrations](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/third-party-integrations?view=foundry)
 - [Intervention points](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/intervention-points?view=foundry)
 
 ## Configuration

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -126,6 +126,7 @@ Important information:
 - [Upgrade GitHub Models to Foundry Models](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/quickstart-github-models?view=foundry)
 - [Claude in Foundry Models](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude?view=foundry)
 - [Monitor model deployments](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/monitor-models?view=foundry)
+- [Configure Claude Code with Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/configure-claude-code?view=foundry)
 - [Endpoints for Foundry Models](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/endpoints?view=foundry)
 - [Get started with DeepSeek-R1 reasoning model](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/tutorials/get-started-deepseek-r1?view=foundry)
 - [Foundry Models quotas and limits](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/quotas-limits?view=foundry)
@@ -142,12 +143,11 @@ Important information:
 - [Get started with model router](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/model-router?view=foundry)
 - [Use blocklists](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/use-blocklists?view=foundry)
 - [Image generation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/dall-e?view=foundry)
-- [Image generation quickstart](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/dall-e-quickstart?view=foundry)
 - [Video generation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/video-generation?view=foundry)
 - [Vision-enabled chats](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/gpt-with-vision?view=foundry)
 - [Image prompt engineering techniques](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/gpt-4-v-prompt-engineering?view=foundry)
 - [Realtime API for speech and audio](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio?view=foundry)
-- [Realtime API for speech and audio quickstart](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/realtime-audio-quickstart?view=foundry)
+- [Realtime API for speech and audio quickstart](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio#quickstart?view=foundry)
 - [Realtime API via WebRTC](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio-webrtc?view=foundry)
 - [Realtime API via WebSockets](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio-websockets?view=foundry)
 - [Realtime API via SIP](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio-sip?view=foundry)
@@ -173,7 +173,7 @@ Important information:
 - [Embeddings](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/embeddings?view=foundry)
 - [Embeddings tutorial](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/tutorials/embeddings?view=foundry)
 - [Audio generation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/audio-completions-quickstart?view=foundry)
-- [Vision-enabled chats](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/gpt-v-quickstart?view=foundry)
+- [Vision-enabled chats](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/gpt-with-vision?view=foundry)
 - [Image prompt engineering techniques](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/gpt-4-v-prompt-engineering?view=foundry)
 - [Image prompt transformation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/prompt-transformation?view=foundry)
 - [Video generation (preview)](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/video-generation?view=foundry)
@@ -214,6 +214,7 @@ Important information:
 - [Performance & latency](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/latency?view=foundry)
 - [Red teaming large language models (LLMs)](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/red-teaming?view=foundry)
 - [Azure OpenAI quotas and limits](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/quotas-limits?view=foundry)
+- [Azure OpenAI model retirement](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements?view=foundry)
 
 ## How-To Guides
 
@@ -228,8 +229,6 @@ Important information:
 - [Set up your developer environment](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/install-cli-sdk?view=foundry)
 - [Work in VS Code](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/get-started-projects-vs-code?view=foundry)
 - [Start with an AI template](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/ai-template-get-started?view=foundry)
-- [Use the Visual Studio Code extension for agent development](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/vs-code-agents?view=foundry)
-- [Use MCP Tools in the Visual Studio Code extension](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/vs-code-agents-mcp?view=foundry)
 - [Microsoft Foundry SDKs](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/sdk-overview?view=foundry)
 - [Integrate with your applications](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/integrate-with-other-apps?view=foundry)
 - [Create resources using Bicep template](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/create-resource-template?view=foundry)
@@ -240,6 +239,7 @@ Important information:
 - [Connect to your own storage in Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/bring-your-own-azure-storage-foundry?view=foundry)
 - [Connect to your own storage for Speech/Language](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/bring-your-own-azure-storage-speech-language-services?view=foundry)
 - [Manage quotas for Foundry resources](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/quota?view=foundry)
+- [Hide preview features with Azure tags](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/disable-preview-features?view=foundry)
 - [Configure private link](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/configure-private-link?view=foundry)
 - [Managed virtual network](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/managed-virtual-network?view=foundry)
 - [Network security perimeter](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/add-foundry-to-network-security-perimeter?view=foundry)
@@ -293,6 +293,7 @@ Important information:
 
 - [Overview](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/guardrails-overview?view=foundry)
 - [How to configure Guardrails and controls](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/how-to-create-guardrails?view=foundry)
+- [Third party Guardrail integrations](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/third-party-integrations?view=foundry)
 - [Intervention points](https://learn.microsoft.com/en-us/azure/ai-foundry/guardrails/intervention-points?view=foundry)
 
 ## Configuration


### PR DESCRIPTION
Regenerated `llms.txt`, `llms-full.txt`, and `foundry-docs-manifest.json` from the latest Microsoft Foundry Table of Contents fetched on 2026-02-26.

## Changes Summary

### New pages added
- **Foundry Models**: Configure Claude Code with Microsoft Foundry
- **Azure OpenAI**: Azure OpenAI model retirement
- **How-To Guides**: Hide preview features with Azure tags
- **Guardrails & Safety**: Third party Guardrail integrations

### Pages removed (deprecated/restructured in Microsoft docs)
- Image generation quickstart (URL moved/deprecated)
- Use the Visual Studio Code extension for agent development
- Use MCP Tools in the Visual Studio Code extension

### URLs updated
- Realtime API for speech and audio quickstart → updated to anchor link (`realtime-audio#quickstart`)
- Vision-enabled chats → updated to canonical how-to path (`openai/how-to/gpt-with-vision`)

## Stats
- **llms.txt**: 341 lines (was 340)
- **llms-full.txt**: 360 lines (was 359)
- **Total doc pages indexed**: 273 (was 270)


> AI generated by [Update Foundry llms.txt Documentation](https://github.com/microsoft/skills/actions/runs/22427069084)