### PR TITLE
Add entra-agent-id skill for Microsoft Entra Agent ID (preview)

### DIFF
--- a/.github/skills/entra-agent-id/SKILL.md
+++ b/.github/skills/entra-agent-id/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: entra-agent-id
+description: |
+  Microsoft Entra Agent ID (preview) for creating OAuth2-capable AI agent identities via Microsoft Graph beta API.
+  Covers Agent Identity Blueprints, BlueprintPrincipals, Agent Identities, required permissions, sponsors, and Workload Identity Federation.
+  Triggers: "agent identity", "agent id", "Agent Identity Blueprint", "BlueprintPrincipal", "entra agent", "agent identity provisioning", "Graph agent identity".
+---
+
+# Microsoft Entra Agent ID
+
+Create and manage OAuth2-capable identities for AI agents using Microsoft Graph beta API.
+
+> **Preview API** — All Agent Identity endpoints are under `/beta` only. Not available in `/v1.0`.
+
+## Before You Start
+
+Search `microsoft-docs` MCP for the latest Agent ID documentation:
+- Query: "Microsoft Entra agent identity setup"
+- Verify: API parameters match current preview behavior
+
+## Conceptual Model
+
+```
+Agent Identity Blueprint (application)        ← one per agent type/project
+  └── BlueprintPrincipal (service principal)   ← MUST be created explicitly
+        ├── Agent Identity (SP): agent-1       ← one per agent instance
+        ├── Agent Identity (SP): agent-2
+        └── Agent Identity (SP): agent-3
+```
+
+## Prerequisites
+
+### PowerShell (recommended for interactive setup)
+
+```powershell
+# Requires PowerShell 7+
+Install-Module Microsoft.Graph.Beta.Applications -Scope CurrentUser -Force
+```
+
+### Python (for programmatic provisioning)
+
+```bash
+pip install azure-identity requests
+```
+
+### Required Entra Roles
+
+One of: **Agent Identity Developer**, **Agent Identity Administrator**, or **Application Administrator**.
+
+## Environment Variables
+
+```bash
+AZURE_TENANT_ID=<your-tenant-id>
+AZURE_CLIENT_ID=<app-registration-client-id>
+AZURE_CLIENT_SECRET=<app-registration-secret>
+```
+
+## Authentication
+
+> **⚠️ `DefaultAzureCredential` is NOT supported.** Azure CLI tokens contain
+> `Directory.AccessAsUser.All`, which Agent Identity APIs explicitly reject (403).
+> You MUST use a dedicated app registration with `client_credentials` flow or
+> connect via `Connect-MgGraph` with explicit delegated scopes.
+
+### PowerShell (delegated permissions)
+
+```powershell
+Connect-MgGraph -Scopes @(
+    "AgentIdentityBlueprint.Create",
+    "AgentIdentityBlueprint.ReadWrite.All",
+    "AgentIdentityBlueprintPrincipal.Create",
+    "User.Read"
+)
+Set-MgRequestContext -ApiVersion beta
+
+$currentUser = (Get-MgContext).Account
+$userId = (Get-MgUser -UserId $currentUser).Id
+```
+
+### Python (application permissions)
+
+```python
+import os
+import requests
+from azure.identity import ClientSecretCredential
+
+credential = ClientSecretCredential(
+    tenant_id=os.environ["AZURE_TENANT_ID"],
+    client_id=os.environ["AZURE_CLIENT_ID"],
+    client_secret=os.environ["AZURE_CLIENT_SECRET"],
+)
+token = credential.get_token("https://graph.microsoft.com/.default")
+
+GRAPH = "https://graph.microsoft.com/beta"
+headers = {
+    "Authorization": f"Bearer {token.token}",
+    "Content-Type": "application/json",
+    "OData-Version": "4.0",  # Required for all Agent Identity API calls
+}
+```
+
+## Core Workflow
+
+### Step 1: Create Agent Identity Blueprint
+
+Sponsors are required and **must be User objects** — ServicePrincipals and Groups are rejected.
+
+```python
+import subprocess
+
+# Get sponsor user ID (client_credentials has no user context, so use az CLI)
+result = subprocess.run(
+    ["az", "ad", "signed-in-user", "show", "--query", "id", "-o", "tsv"],
+    capture_output=True, text=True, check=True,
+)
+user_id = result.stdout.strip()
+
+blueprint_body = {
+    "@odata.type": "Microsoft.Graph.AgentIdentityBlueprint",
+    "displayName": "My Agent Blueprint",
+    "sponsors@odata.bind": [
+        f"https://graph.microsoft.com/beta/users/{user_id}"
+    ],
+}
+resp = requests.post(f"{GRAPH}/applications", headers=headers, json=blueprint_body)
+resp.raise_for_status()
+
+blueprint = resp.json()
+app_id = blueprint["appId"]
+blueprint_obj_id = blueprint["id"]
+```
+
+### Step 2: Create BlueprintPrincipal
+
+> **This step is mandatory.** Creating a Blueprint does NOT auto-create its
+> service principal. Without this, Agent Identity creation fails with:
+> `400: The Agent Blueprint Principal for the Agent Blueprint does not exist.`
+
+```python
+sp_body = {
+    "@odata.type": "Microsoft.Graph.AgentIdentityBlueprintPrincipal",
+    "appId": app_id,
+}
+resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=sp_body)
+resp.raise_for_status()
+```
+
+If implementing idempotent scripts, check for and create the BlueprintPrincipal
+even when the Blueprint already exists (a previous run may have created the Blueprint
+but crashed before creating the SP).
+
+### Step 3: Create Agent Identities
+
+```python
+agent_body = {
+    "@odata.type": "Microsoft.Graph.AgentIdentity",
+    "displayName": "my-agent-instance-1",
+    "agentIdentityBlueprintId": app_id,
+    "sponsors@odata.bind": [
+        f"https://graph.microsoft.com/beta/users/{user_id}"
+    ],
+}
+resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=agent_body)
+resp.raise_for_status()
+agent = resp.json()
+```
+
+## API Reference
+
+| Operation | Method | Endpoint | OData Type |
+|-----------|--------|----------|------------|
+| Create Blueprint | `POST` | `/applications` | `Microsoft.Graph.AgentIdentityBlueprint` |
+| Create BlueprintPrincipal | `POST` | `/servicePrincipals` | `Microsoft.Graph.AgentIdentityBlueprintPrincipal` |
+| Create Agent Identity | `POST` | `/servicePrincipals` | `Microsoft.Graph.AgentIdentity` |
+| List Agent Identities | `GET` | `/servicePrincipals?$filter=...` | — |
+| Delete Agent Identity | `DELETE` | `/servicePrincipals/{id}` | — |
+| Delete Blueprint | `DELETE` | `/applications/{id}` | — |
+
+All endpoints use base URL: `https://graph.microsoft.com/beta`
+
+## Required Permissions
+
+| Permission | Purpose |
+|-----------|---------|
+| `Application.ReadWrite.All` | Blueprint CRUD (application objects) |
+| `AgentIdentityBlueprint.Create` | Create new Blueprints |
+| `AgentIdentityBlueprint.ReadWrite.All` | Read/update Blueprints |
+| `AgentIdentityBlueprintPrincipal.Create` | Create BlueprintPrincipals |
+| `AgentIdentity.Create.All` | Create Agent Identities |
+| `AgentIdentity.ReadWrite.All` | Read/update Agent Identities |
+
+There are **18 Agent Identity-specific** Graph application permissions. Discover all:
+```bash
+az ad sp show --id 00000003-0000-0000-c000-000000000000 \
+  --query "appRoles[?contains(value, 'AgentIdentity')].{id:id, value:value}" -o json
+```
+
+Grant admin consent (required for application permissions):
+```bash
+az ad app permission admin-consent --id <client-id>
+```
+
+> Admin consent may fail with 404 if the service principal hasn't replicated. Retry with 10–40s backoff.
+
+## Cleanup
+
+```python
+# Delete Agent Identity
+requests.delete(f"{GRAPH}/servicePrincipals/{agent['id']}", headers=headers)
+
+# Delete BlueprintPrincipal (get SP ID first)
+sps = requests.get(
+    f"{GRAPH}/servicePrincipals?$filter=appId eq '{app_id}'",
+    headers=headers,
+).json()
+for sp in sps.get("value", []):
+    requests.delete(f"{GRAPH}/servicePrincipals/{sp['id']}", headers=headers)
+
+# Delete Blueprint
+requests.delete(f"{GRAPH}/applications/{blueprint_obj_id}", headers=headers)
+```
+
+## Best Practices
+
+1. **Always create BlueprintPrincipal after Blueprint** — not auto-created; implement idempotent checks on both
+2. **Use User objects as sponsors** — ServicePrincipals and Groups are rejected
+3. **Handle permission propagation delays** — after admin consent, wait 30–120s; retry with backoff on 403
+4. **Include `OData-Version: 4.0` header** on every Graph request
+5. **Use Workload Identity Federation for production auth** — for local dev, use a client secret on the Blueprint (see [references/oauth2-token-flow.md](references/oauth2-token-flow.md))
+6. **Set `identifierUris` on Blueprint** before using OAuth2 scoping (`api://{app-id}`)
+7. **Never use Azure CLI tokens** for API calls — they contain `Directory.AccessAsUser.All` which is hard-rejected
+8. **Check for existing resources** before creating — implement idempotent provisioning
+
+## References
+
+| File | Contents |
+|------|----------|
+| [references/oauth2-token-flow.md](references/oauth2-token-flow.md) | Production (Managed Identity + WIF) and local dev (client secret) token flows |
+| [references/known-limitations.md](references/known-limitations.md) | 29 known issues organized by category (from official preview known-issues page) |
+
+### External Links
+
+| Resource | URL |
+|----------|-----|
+| Official Setup Guide | https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/agent-id-setup-instructions |
+| AI-Guided Setup | https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/agent-id-ai-guided-setup |

--- a/.github/skills/entra-agent-id/references/acceptance-criteria.md
+++ b/.github/skills/entra-agent-id/references/acceptance-criteria.md
@@ -1,0 +1,228 @@
+# Entra Agent ID Acceptance Criteria
+
+**Skill**: `entra-agent-id`
+**Purpose**: Create and manage OAuth2-capable AI agent identities via Microsoft Graph beta API
+**Focus**: Agent Identity Blueprints, BlueprintPrincipals, Agent Identities, authentication, permissions
+
+---
+
+## 1. Authentication
+
+### 1.1 ✅ CORRECT: ClientSecretCredential for Python
+
+```python
+from azure.identity import ClientSecretCredential
+
+credential = ClientSecretCredential(
+    tenant_id=os.environ["AZURE_TENANT_ID"],
+    client_id=os.environ["AZURE_CLIENT_ID"],
+    client_secret=os.environ["AZURE_CLIENT_SECRET"],
+)
+token = credential.get_token("https://graph.microsoft.com/.default")
+```
+
+### 1.2 ✅ CORRECT: Connect-MgGraph for PowerShell
+
+```powershell
+Connect-MgGraph -Scopes @(
+    "AgentIdentityBlueprint.Create",
+    "AgentIdentityBlueprint.ReadWrite.All",
+    "AgentIdentityBlueprintPrincipal.Create",
+    "User.Read"
+)
+Set-MgRequestContext -ApiVersion beta
+```
+
+### 1.3 ❌ INCORRECT: DefaultAzureCredential
+
+```python
+# WRONG — Azure CLI tokens contain Directory.AccessAsUser.All which is hard-rejected (403)
+from azure.identity import DefaultAzureCredential
+credential = DefaultAzureCredential()
+```
+
+### 1.4 ❌ INCORRECT: Missing explicit scopes in PowerShell
+
+```powershell
+# WRONG — no scopes specified, may not get Agent Identity permissions
+Connect-MgGraph
+```
+
+---
+
+## 2. Required Headers
+
+### 2.1 ✅ CORRECT: OData-Version header included
+
+```python
+headers = {
+    "Authorization": f"Bearer {token.token}",
+    "Content-Type": "application/json",
+    "OData-Version": "4.0",
+}
+```
+
+### 2.2 ❌ INCORRECT: Missing OData-Version header
+
+```python
+# WRONG — Agent Identity API calls may fail without OData-Version
+headers = {
+    "Authorization": f"Bearer {token.token}",
+    "Content-Type": "application/json",
+}
+```
+
+---
+
+## 3. API Base URL
+
+### 3.1 ✅ CORRECT: Beta endpoint
+
+```python
+GRAPH = "https://graph.microsoft.com/beta"
+resp = requests.post(f"{GRAPH}/applications", headers=headers, json=body)
+```
+
+### 3.2 ❌ INCORRECT: v1.0 endpoint
+
+```python
+# WRONG — Agent Identity APIs only exist in /beta, not /v1.0
+GRAPH = "https://graph.microsoft.com/v1.0"
+```
+
+---
+
+## 4. Blueprint Creation
+
+### 4.1 ✅ CORRECT: OData type and User sponsor
+
+```python
+blueprint_body = {
+    "@odata.type": "Microsoft.Graph.AgentIdentityBlueprint",
+    "displayName": "My Agent Blueprint",
+    "sponsors@odata.bind": [
+        f"https://graph.microsoft.com/beta/users/{user_id}"
+    ],
+}
+resp = requests.post(f"{GRAPH}/applications", headers=headers, json=blueprint_body)
+```
+
+### 4.2 ❌ INCORRECT: Missing @odata.type
+
+```python
+# WRONG — creates a regular application, not an Agent Identity Blueprint
+blueprint_body = {
+    "displayName": "My Agent Blueprint",
+}
+```
+
+### 4.3 ❌ INCORRECT: ServicePrincipal as sponsor
+
+```python
+# WRONG — sponsors must be User objects, not ServicePrincipals or Groups
+"sponsors@odata.bind": [
+    f"https://graph.microsoft.com/beta/servicePrincipals/{sp_id}"
+]
+```
+
+---
+
+## 5. BlueprintPrincipal Creation
+
+### 5.1 ✅ CORRECT: Explicit BlueprintPrincipal creation after Blueprint
+
+```python
+sp_body = {
+    "@odata.type": "Microsoft.Graph.AgentIdentityBlueprintPrincipal",
+    "appId": app_id,
+}
+resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=sp_body)
+```
+
+### 5.2 ❌ INCORRECT: Skipping BlueprintPrincipal
+
+```python
+# WRONG — Blueprint does NOT auto-create its service principal
+# Agent Identity creation will fail with:
+# "The Agent Blueprint Principal for the Agent Blueprint does not exist."
+blueprint = create_blueprint(...)
+agent = create_agent_identity(blueprint_app_id=blueprint["appId"])  # 400 error
+```
+
+---
+
+## 6. Agent Identity Creation
+
+### 6.1 ✅ CORRECT: Full Agent Identity with blueprint reference
+
+```python
+agent_body = {
+    "@odata.type": "Microsoft.Graph.AgentIdentity",
+    "displayName": "my-agent-instance-1",
+    "agentIdentityBlueprintId": app_id,
+    "sponsors@odata.bind": [
+        f"https://graph.microsoft.com/beta/users/{user_id}"
+    ],
+}
+resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=agent_body)
+```
+
+### 6.2 ❌ INCORRECT: Missing agentIdentityBlueprintId
+
+```python
+# WRONG — agent identity must reference its blueprint
+agent_body = {
+    "@odata.type": "Microsoft.Graph.AgentIdentity",
+    "displayName": "my-agent-instance-1",
+}
+```
+
+---
+
+## 7. Cleanup
+
+### 7.1 ✅ CORRECT: Delete in order (agents first, then blueprint)
+
+```python
+# Delete agent identities first
+requests.delete(f"{GRAPH}/servicePrincipals/{agent_sp_id}", headers=headers)
+
+# Then delete the blueprint (application)
+requests.delete(f"{GRAPH}/applications/{blueprint_obj_id}", headers=headers)
+```
+
+### 7.2 ❌ INCORRECT: Delete blueprint without cleaning up agents
+
+```python
+# WRONG — orphaned agent identities remain as unmanaged service principals
+requests.delete(f"{GRAPH}/applications/{blueprint_obj_id}", headers=headers)
+```
+
+---
+
+## 8. Idempotent Provisioning
+
+### 8.1 ✅ CORRECT: Check before create
+
+```python
+# Check if blueprint already exists
+resp = requests.get(
+    f"{GRAPH}/applications?$filter=displayName eq 'My Agent Blueprint'",
+    headers=headers,
+)
+existing = resp.json().get("value", [])
+if existing:
+    blueprint = existing[0]
+else:
+    blueprint = create_blueprint(...)
+
+# Always ensure BlueprintPrincipal exists (previous run may have crashed)
+ensure_blueprint_principal(blueprint["appId"])
+```
+
+### 8.2 ❌ INCORRECT: No existence check
+
+```python
+# WRONG — fails on rerun if blueprint already exists with same identifierUris
+blueprint = create_blueprint(...)  # May conflict
+```

--- a/.github/skills/entra-agent-id/references/known-limitations.md
+++ b/.github/skills/entra-agent-id/references/known-limitations.md
@@ -1,0 +1,57 @@
+# Known Limitations (Preview)
+
+Source: [Microsoft Entra Agent ID preview: Known issues and gaps](https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/preview-known-issues)
+
+## API & Object Model
+
+1. **Preview API only** — all endpoints are under `/beta`, not `/v1.0`
+2. **Sponsors must be Users** — ServicePrincipals and Groups are not accepted as sponsors
+3. **BlueprintPrincipal not auto-created** — requires explicit `POST /servicePrincipals` after Blueprint creation
+4. **Agent Identities cannot have password credentials** — credentials belong on the Blueprint only (`PropertyNotCompatibleWithAgentIdentity` error)
+5. **Agent Identities have no backing application object** — they are service-principal-only entities
+6. **Blueprint needs explicit `identifierUris`** — not set by default, required for OAuth2 scope resolution (`api://{app-id}/.default`)
+7. **No Graph relationship filtering for Agent IDs** — `/ownedObjects`, `/deletedItems`, `/owners` etc. return all types; must client-side filter by `odata.type`
+8. **Orphaned agent users after deletion** — deleting a blueprint or identity does NOT auto-delete its agent users; clean up manually via admin center or Graph API
+
+## Roles & Permissions
+
+9. **`Directory.AccessAsUser.All` hard rejection** — if present on the client, all other Agent ID delegated permissions are ignored → 403 Forbidden
+10. **No viable delegated permission for creating agent identities** — must use application permissions
+11. **No quick-start permission bundle** — must discover and grant 18+ individual Agent Identity permissions
+12. **Permission propagation delay** — 30–120+ seconds after admin consent before tokens include new claims; use delegated permissions where possible and add retry with exponential backoff
+13. **Global Reader cannot list agent identities** — `GET /servicePrincipals/graph.agentIdentity` returns 403; use `GET /servicePrincipals` instead
+14. **Custom roles cannot include Agent ID actions** — use built-in roles (Agent ID Administrator, Agent ID Developer)
+15. **Administrative units not supported** — cannot add agent identities, blueprints, or blueprint principals to admin units; use `owners` property instead
+16. **Agent ID Admin cannot update agent user photos** — use User Administrator role
+
+## Admin Center & Management
+
+17. **No blueprint management in Entra admin center** — must use Microsoft Graph APIs / PowerShell to create and edit blueprints
+18. **`/me` endpoint unavailable** in `client_credentials` flow — use `az ad signed-in-user show` or Graph delegated permissions for user context
+
+## Authentication & Consent
+
+19. **No SSO to web apps** — Agent IDs cannot sign in via Microsoft Entra ID sign-in pages (no OpenID Connect or SAML); use web APIs instead
+20. **Admin consent workflow (ACW) broken** — does not work properly for permissions requested by Agent IDs; contact tenant admin directly
+21. **Cannot grant app permissions to blueprint principals** — grant application permissions to individual agent identities instead
+22. **Cannot assign app roles where target resource is an agent identity** — use blueprint principal as the target resource
+23. **Risk-based step-up blocks consent silently** — no "risky" indication in the UX
+
+## Groups, Logs & Monitoring
+
+24. **No dynamic group membership** — agent identities and agent users cannot be added to dynamic groups; use security groups with fixed membership
+25. **Audit logs do not distinguish Agent IDs** — operations on blueprints/identities logged as `ApplicationManagement`, agent users as `User Management`; cross-reference object IDs via Graph to determine entity type
+26. **Graph activity logs do not distinguish Agent IDs** — agent identity requests logged as applications, agent user requests as users; join with sign-in logs
+
+## Performance & Scale
+
+27. **Sequential creation requests may fail** — creating multiple entities in quick succession (e.g., blueprint → principal → identity) can return `400 Bad Request: Object with id {id} not found`; especially with application permissions. Use delegated permissions where possible and add exponential backoff retry.
+
+## Product Integrations
+
+28. **Copilot Studio** — only custom engine agents are supported; Agent IDs are used for channel auth only (not connectors or tools)
+29. **MSAL complexity** — Agent ID scenarios require managing Federated Identity Credentials manually. For .NET use [Microsoft.Identity.Web.AgentIdentities](https://github.com/AzureAD/microsoft-identity-web/blob/master/src/Microsoft.Identity.Web.AgentIdentities/README.AgentIdentities.md). For other languages use the [Microsoft Entra SDK for Agent ID](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/overview).
+
+## Reporting Issues
+
+Report unlisted issues via [aka.ms/agentidfeedback](https://aka.ms/agentidfeedback).

--- a/.github/skills/entra-agent-id/references/oauth2-token-flow.md
+++ b/.github/skills/entra-agent-id/references/oauth2-token-flow.md
@@ -1,0 +1,155 @@
+# OAuth2 Token Flow
+
+Source: [Agent ID Setup Instructions](https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/agent-id-setup-instructions)
+
+Agent Identities authenticate at runtime using credentials configured on the **Blueprint** (not the Agent Identity itself). Two options are available:
+
+| Option | Use case | Credential type |
+|--------|----------|-----------------|
+| **Managed Identity + WIF** | Production (Azure-hosted) | Federated Identity Credential |
+| **Client secret** | Local development / testing | Password credential on Blueprint |
+
+---
+
+## Option A: Managed Identity + Workload Identity Federation (Production)
+
+### Architecture
+
+```
+Container App (user-assigned MI)
+  -> ManagedIdentityCredential.get_token("api://{blueprint-app-id}/.default")
+    -> Azure AD token exchange (MI token -> Agent ID token)
+      -> JWT with oid = MI principal, aud = api://{blueprint-app-id}
+        -> Backend validates JWT signature + claims
+```
+
+### 1. Set Application ID URI on Blueprint
+
+Required for OAuth2 scope resolution:
+
+```python
+requests.patch(
+    f"{GRAPH}/applications/{blueprint_obj_id}",
+    headers=headers,
+    json={"identifierUris": [f"api://{app_id}"]},
+)
+```
+
+### 2. Create Federated Identity Credential
+
+Create on the Blueprint (not the Agent Identity):
+
+```python
+fic_body = {
+    "name": "my-fic-name",
+    "issuer": f"https://login.microsoftonline.com/{tenant_id}/v2.0",
+    "subject": "{mi-principal-id}",  # The MI's object ID (principalId), NOT client ID
+    "audiences": ["api://AzureADTokenExchange"],
+}
+requests.post(
+    f"{GRAPH}/applications/{blueprint_obj_id}/microsoft.graph.agentIdentityBlueprint/federatedIdentityCredentials",
+    headers=headers,
+    json=fic_body,
+)
+```
+
+### 3. Acquire Token (Caller Side)
+
+```python
+from azure.identity import ManagedIdentityCredential
+
+cred = ManagedIdentityCredential(client_id=mi_client_id)
+token = cred.get_token(f"api://{blueprint_app_id}/.default")
+# Include in requests: Authorization: Bearer {token.token}
+```
+
+### 4. Validate Token (Backend)
+
+```python
+import jwt
+from jwt import PyJWKClient
+
+jwks_uri = f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
+jwks_client = PyJWKClient(jwks_uri)
+signing_key = jwks_client.get_signing_key_from_jwt(token_str)
+
+claims = jwt.decode(
+    token_str,
+    signing_key.key,
+    algorithms=["RS256"],
+    audience=f"api://{blueprint_app_id}",
+    issuer=f"https://sts.windows.net/{tenant_id}/",
+)
+```
+
+### Key Rules (WIF)
+
+- **Federated credentials go on the Blueprint**, not the Agent Identity SP. Use the `.../microsoft.graph.agentIdentityBlueprint/federatedIdentityCredentials` path.
+- **`subject` is the MI's principalId (object ID)**, not its client ID.
+- **`audiences` must be `["api://AzureADTokenExchange"]`**, not your API audience.
+- **Issuer format**: `https://login.microsoftonline.com/{tenant}/v2.0`
+- **Token issuer** (for validation): `https://sts.windows.net/{tenant}/` (note the trailing slash and different domain)
+
+---
+
+## Option B: Client Secret (Local Development / Testing Only)
+
+For local development where no Managed Identity is available.
+
+### 1. Add a Password Credential to the Blueprint
+
+Via PowerShell:
+
+```powershell
+$secretBody = @{
+    "passwordCredential" = @{
+        "displayName" = "Dev Secret"
+        "endDateTime" = "2027-01-01T00:00:00Z"
+    }
+}
+
+$credential = Invoke-MgGraphRequest -Method POST `
+    -Uri "https://graph.microsoft.com/beta/applications/<BLUEPRINT_OBJECT_ID>/addPassword" `
+    -Headers @{"OData-Version"="4.0"; "Content-Type"="application/json"} `
+    -Body ($secretBody | ConvertTo-Json -Depth 5) -OutputType PSObject
+
+$credential.secretText  # Save NOW — cannot be retrieved later
+```
+
+Or via Python (with an existing token):
+
+```python
+secret_body = {
+    "passwordCredential": {
+        "displayName": "Dev Secret",
+        "endDateTime": "2027-01-01T00:00:00Z",
+    }
+}
+resp = requests.post(
+    f"{GRAPH}/applications/{blueprint_obj_id}/addPassword",
+    headers=headers,
+    json=secret_body,
+)
+secret_text = resp.json()["secretText"]  # Save NOW
+```
+
+### 2. Acquire Token Locally
+
+```python
+from azure.identity import ClientSecretCredential
+
+credential = ClientSecretCredential(
+    tenant_id=TENANT_ID,
+    client_id=BLUEPRINT_APP_ID,       # Blueprint's appId
+    client_secret=SECRET_TEXT,         # From step 1
+)
+token = credential.get_token(f"api://{BLUEPRINT_APP_ID}/.default")
+```
+
+### Key Rules (Client Secret)
+
+- **Save `secretText` immediately** — it cannot be retrieved after creation.
+- **Secrets belong on the Blueprint only** — agent identities cannot have password credentials (`PropertyNotCompatibleWithAgentIdentity`).
+- **NOT for production** — use Managed Identity + WIF in production.
+- **Respect org policy** — if `endDateTime` exceeds your tenant's credential lifetime policy, reduce it.
+- **Use `ClientSecretCredential`**, not `DefaultAzureCredential`. Azure CLI tokens contain `Directory.AccessAsUser.All` which is rejected by Agent ID APIs.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 | Resource | Description |
 |----------|-------------|
-| **[127 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
+| **[128 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
 | **[Plugins](#plugins)** | Installable plugin packages (deep-wiki, azure-skills and more) |
 | **[Custom Agents](#agents)** | Role-specific agents (backend, frontend, infrastructure, planner) |
 | **[AGENTS.md](AGENTS.md)** | Template for configuring agent behavior in your projects |
@@ -74,7 +74,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 | Language | Count | Suffix | 
 |----------|-------|--------|
-| [Core](#core) | 8 | — |
+| [Core](#core) | 9 | — |
 | [Python](#python) | 41 | `-py` |
 | [.NET](#net) | 28 | `-dotnet` |
 | [TypeScript](#typescript) | 25 | `-ts` |
@@ -85,12 +85,13 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 ### Core
 
-> 8 skills — tooling, infrastructure, language-agnostic
+> 9 skills — tooling, infrastructure, language-agnostic
 
 | Skill | Description |
 |-------|-------------|
 | [cloud-solution-architect](.github/skills/cloud-solution-architect/) | Design well-architected Azure cloud systems. Architecture styles, 44 design patterns, technology choices, mission-critical design, WAF pillars. |
 | [copilot-sdk](.github/skills/copilot-sdk/) | Build applications powered by GitHub Copilot using the Copilot SDK. Session management, custom tools, streaming, hooks, MCP servers, BYOK, deployment patterns. |
+| [entra-agent-id](.github/skills/entra-agent-id/) | Microsoft Entra Agent ID (preview) — create OAuth2-capable AI agent identities via Microsoft Graph beta API. Blueprints, BlueprintPrincipals, permissions, WIF. |
 | [frontend-design-review](.github/skills/frontend-design-review/) | Review and create distinctive frontend interfaces. Design system compliance, quality pillars, accessibility, and creative aesthetics. |
 | [github-issue-creator](.github/skills/github-issue-creator/) | Convert raw notes, error logs, or screenshots into structured GitHub issues. |
 | [mcp-builder](.github/skills/mcp-builder/) | Build MCP servers for LLM tool integration. Python (FastMCP), Node/TypeScript, or C#/.NET. |
@@ -630,11 +631,11 @@ pnpm test
 
 ### Test Coverage Summary
 
-**127 skills with 1148 test scenarios** — all skills have acceptance criteria and test scenarios.
+**128 skills with 1158 test scenarios** — all skills have acceptance criteria and test scenarios.
 
 | Language | Skills | Scenarios | Top Skills by Scenarios |
 |----------|--------|-----------|-------------------------|
-| Core | 6 | 62 | `copilot-sdk` (11), `podcast-generation` (8), `skill-creator` (8) |
+| Core | 7 | 72 | `copilot-sdk` (11), `podcast-generation` (8), `skill-creator` (8) |
 | Python | 41 | 331 | `azure-ai-projects-py` (12), `pydantic-models-py` (12), `azure-ai-translation-text-py` (11) |
 | .NET | 29 | 290 | `azure-resource-manager-sql-dotnet` (14), `azure-resource-manager-redis-dotnet` (14), `azure-servicebus-dotnet` (13) |
 | TypeScript | 25 | 270 | `azure-storage-blob-ts` (17), `azure-servicebus-ts` (14), `aspire-ts` (13) |

--- a/tests/scenarios/entra-agent-id/scenarios.yaml
+++ b/tests/scenarios/entra-agent-id/scenarios.yaml
@@ -1,0 +1,345 @@
+# Test scenarios for entra-agent-id skill evaluation
+# Each scenario tests Agent Identity provisioning patterns via Microsoft Graph beta API
+
+config:
+  model: gpt-4
+  max_tokens: 2000
+  temperature: 0.3
+
+scenarios:
+  # Authentication Setup
+  - name: python_authentication
+    prompt: |
+      Write Python code to authenticate with Microsoft Graph beta API
+      for Agent Identity operations. Use environment variables for
+      tenant ID, client ID, and client secret.
+    expected_patterns:
+      - "ClientSecretCredential"
+      - "AZURE_TENANT_ID"
+      - "AZURE_CLIENT_ID"
+      - "AZURE_CLIENT_SECRET"
+      - "graph\\.microsoft\\.com/\\.default"
+      - "OData-Version.*4\\.0"
+      - "graph\\.microsoft\\.com/beta"
+    forbidden_patterns:
+      - "DefaultAzureCredential"
+      - "v1\\.0"
+      - "api_key.*=.*[\"']"
+    tags:
+      - authentication
+      - python
+    mock_response: |
+      import os
+      import requests
+      from azure.identity import ClientSecretCredential
+
+      credential = ClientSecretCredential(
+          tenant_id=os.environ["AZURE_TENANT_ID"],
+          client_id=os.environ["AZURE_CLIENT_ID"],
+          client_secret=os.environ["AZURE_CLIENT_SECRET"],
+      )
+      token = credential.get_token("https://graph.microsoft.com/.default")
+
+      GRAPH = "https://graph.microsoft.com/beta"
+      headers = {
+          "Authorization": f"Bearer {token.token}",
+          "Content-Type": "application/json",
+          "OData-Version": "4.0",
+      }
+
+  # PowerShell Authentication
+  - name: powershell_authentication
+    prompt: |
+      Write PowerShell code to connect to Microsoft Graph for Agent Identity
+      operations. Include the correct scopes and API version.
+    expected_patterns:
+      - "Connect-MgGraph"
+      - "Scopes"
+      - "AgentIdentityBlueprint"
+      - "Set-MgRequestContext.*beta|ApiVersion.*beta"
+    forbidden_patterns:
+      - "v1\\.0"
+      - "Directory\\.AccessAsUser\\.All"
+    tags:
+      - authentication
+      - powershell
+    mock_response: |
+      Connect-MgGraph -Scopes @(
+          "AgentIdentityBlueprint.Create",
+          "AgentIdentityBlueprint.ReadWrite.All",
+          "AgentIdentityBlueprintPrincipal.Create",
+          "User.Read"
+      )
+      Set-MgRequestContext -ApiVersion beta
+
+      $currentUser = (Get-MgContext).Account
+      $userId = (Get-MgUser -UserId $currentUser).Id
+
+  # Blueprint Creation
+  - name: create_blueprint
+    prompt: |
+      Create an Agent Identity Blueprint using the Microsoft Graph beta API
+      in Python. The blueprint should have a display name and a user sponsor.
+    expected_patterns:
+      - "@odata\\.type.*AgentIdentityBlueprint"
+      - "displayName"
+      - "sponsors@odata\\.bind"
+      - "/beta/users/"
+      - "POST.*applications|requests\\.post.*applications"
+    forbidden_patterns:
+      - "servicePrincipals"
+      - "v1\\.0"
+    tags:
+      - blueprint
+      - creation
+    mock_response: |
+      blueprint_body = {
+          "@odata.type": "Microsoft.Graph.AgentIdentityBlueprint",
+          "displayName": "My Agent Blueprint",
+          "sponsors@odata.bind": [
+              f"https://graph.microsoft.com/beta/users/{user_id}"
+          ],
+      }
+      resp = requests.post(f"{GRAPH}/applications", headers=headers, json=blueprint_body)
+      resp.raise_for_status()
+      blueprint = resp.json()
+      app_id = blueprint["appId"]
+
+  # BlueprintPrincipal Creation
+  - name: create_blueprint_principal
+    prompt: |
+      After creating an Agent Identity Blueprint, create the BlueprintPrincipal.
+      Explain why this step is required.
+    expected_patterns:
+      - "@odata\\.type.*AgentIdentityBlueprintPrincipal"
+      - "appId"
+      - "POST.*servicePrincipals|requests\\.post.*servicePrincipals"
+      - "mandatory|required|must|explicit"
+    forbidden_patterns:
+      - "auto.*creat"
+    tags:
+      - blueprint-principal
+      - creation
+    mock_response: |
+      # BlueprintPrincipal must be created explicitly — it is NOT auto-created
+      # with the Blueprint. Without it, Agent Identity creation fails with:
+      # "The Agent Blueprint Principal for the Agent Blueprint does not exist."
+
+      sp_body = {
+          "@odata.type": "Microsoft.Graph.AgentIdentityBlueprintPrincipal",
+          "appId": app_id,
+      }
+      resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=sp_body)
+      resp.raise_for_status()
+
+  # Agent Identity Creation
+  - name: create_agent_identity
+    prompt: |
+      Create an Agent Identity service principal linked to an existing
+      Agent Identity Blueprint. Use Python with the Graph beta API.
+    expected_patterns:
+      - "@odata\\.type.*AgentIdentity"
+      - "agentIdentityBlueprintId"
+      - "displayName"
+      - "sponsors@odata\\.bind"
+      - "POST.*servicePrincipals|requests\\.post.*servicePrincipals"
+    forbidden_patterns:
+      - "DefaultAzureCredential"
+      - "v1\\.0"
+    tags:
+      - agent-identity
+      - creation
+    mock_response: |
+      agent_body = {
+          "@odata.type": "Microsoft.Graph.AgentIdentity",
+          "displayName": "my-agent-instance-1",
+          "agentIdentityBlueprintId": app_id,
+          "sponsors@odata.bind": [
+              f"https://graph.microsoft.com/beta/users/{user_id}"
+          ],
+      }
+      resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=agent_body)
+      resp.raise_for_status()
+      agent = resp.json()
+
+  # Full Provisioning Workflow
+  - name: full_provisioning_workflow
+    prompt: |
+      Write a complete Python script that provisions an Agent Identity from
+      scratch: authenticate, create the Blueprint, create the BlueprintPrincipal,
+      and create an Agent Identity. Use environment variables for credentials.
+    expected_patterns:
+      - "ClientSecretCredential"
+      - "AgentIdentityBlueprint"
+      - "AgentIdentityBlueprintPrincipal"
+      - "AgentIdentity"
+      - "OData-Version.*4\\.0"
+      - "/beta"
+      - "raise_for_status|status_code"
+    forbidden_patterns:
+      - "DefaultAzureCredential"
+      - "v1\\.0"
+      - "api_key.*=.*[\"']"
+    tags:
+      - end-to-end
+      - python
+    mock_response: |
+      import os
+      import requests
+      from azure.identity import ClientSecretCredential
+
+      credential = ClientSecretCredential(
+          tenant_id=os.environ["AZURE_TENANT_ID"],
+          client_id=os.environ["AZURE_CLIENT_ID"],
+          client_secret=os.environ["AZURE_CLIENT_SECRET"],
+      )
+      token = credential.get_token("https://graph.microsoft.com/.default")
+
+      GRAPH = "https://graph.microsoft.com/beta"
+      headers = {
+          "Authorization": f"Bearer {token.token}",
+          "Content-Type": "application/json",
+          "OData-Version": "4.0",
+      }
+
+      # Step 1: Create Blueprint
+      blueprint_body = {
+          "@odata.type": "Microsoft.Graph.AgentIdentityBlueprint",
+          "displayName": "My Agent Blueprint",
+          "sponsors@odata.bind": [
+              f"https://graph.microsoft.com/beta/users/{user_id}"
+          ],
+      }
+      resp = requests.post(f"{GRAPH}/applications", headers=headers, json=blueprint_body)
+      resp.raise_for_status()
+      blueprint = resp.json()
+      app_id = blueprint["appId"]
+
+      # Step 2: Create BlueprintPrincipal (mandatory)
+      sp_body = {
+          "@odata.type": "Microsoft.Graph.AgentIdentityBlueprintPrincipal",
+          "appId": app_id,
+      }
+      resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=sp_body)
+      resp.raise_for_status()
+
+      # Step 3: Create Agent Identity
+      agent_body = {
+          "@odata.type": "Microsoft.Graph.AgentIdentity",
+          "displayName": "my-agent-instance-1",
+          "agentIdentityBlueprintId": app_id,
+          "sponsors@odata.bind": [
+              f"https://graph.microsoft.com/beta/users/{user_id}"
+          ],
+      }
+      resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=agent_body)
+      resp.raise_for_status()
+      agent = resp.json()
+
+  # Cleanup
+  - name: cleanup_resources
+    prompt: |
+      Write Python code to clean up Agent Identity resources. Delete the
+      agent identity service principal first, then delete the blueprint.
+      Explain the correct order.
+    expected_patterns:
+      - "DELETE.*servicePrincipals|requests\\.delete.*servicePrincipals"
+      - "DELETE.*applications|requests\\.delete.*applications"
+      - "agent.*first|order"
+    forbidden_patterns:
+      - "only.*blueprint"
+    tags:
+      - cleanup
+      - deletion
+    mock_response: |
+      # Delete in order: agent identities first, then blueprint
+      # Deleting the blueprint without cleaning agents leaves orphaned SPs
+
+      # Delete agent identity
+      requests.delete(f"{GRAPH}/servicePrincipals/{agent_sp_id}", headers=headers).raise_for_status()
+
+      # Delete blueprint (application object)
+      requests.delete(f"{GRAPH}/applications/{blueprint_obj_id}", headers=headers).raise_for_status()
+
+  # Error: DefaultAzureCredential
+  - name: error_default_credential
+    prompt: |
+      I'm getting a 403 error when calling the Agent Identity API using
+      DefaultAzureCredential. What's wrong and how do I fix it?
+    expected_patterns:
+      - "DefaultAzureCredential.*not.*support|Directory\\.AccessAsUser\\.All"
+      - "ClientSecretCredential|client_credentials"
+      - "403"
+    forbidden_patterns:
+      - "DefaultAzureCredential.*correct|use DefaultAzureCredential"
+    tags:
+      - error-handling
+      - authentication
+    mock_response: |
+      The 403 error occurs because `DefaultAzureCredential` resolves to Azure CLI
+      tokens that include the `Directory.AccessAsUser.All` scope, which Agent Identity
+      APIs explicitly reject.
+
+      Use `ClientSecretCredential` with a dedicated app registration instead:
+
+      ```python
+      from azure.identity import ClientSecretCredential
+
+      credential = ClientSecretCredential(
+          tenant_id=os.environ["AZURE_TENANT_ID"],
+          client_id=os.environ["AZURE_CLIENT_ID"],
+          client_secret=os.environ["AZURE_CLIENT_SECRET"],
+      )
+      token = credential.get_token("https://graph.microsoft.com/.default")
+      ```
+
+  # Idempotent Provisioning
+  - name: idempotent_provisioning
+    prompt: |
+      Write Python code that creates an Agent Identity Blueprint idempotently —
+      check if it already exists before creating, and always ensure the
+      BlueprintPrincipal exists.
+    expected_patterns:
+      - "\\$filter|filter.*displayName"
+      - "existing|already"
+      - "BlueprintPrincipal|blueprint.*principal"
+    forbidden_patterns:
+      - "try.*except.*pass"
+    tags:
+      - idempotent
+      - best-practice
+    mock_response: |
+      # Check if blueprint already exists
+      resp = requests.get(
+          f"{GRAPH}/applications?$filter=displayName eq 'My Agent Blueprint'",
+          headers=headers,
+      )
+      existing = resp.json().get("value", [])
+
+      if existing:
+          blueprint = existing[0]
+      else:
+          blueprint_body = {
+              "@odata.type": "Microsoft.Graph.AgentIdentityBlueprint",
+              "displayName": "My Agent Blueprint",
+              "sponsors@odata.bind": [
+                  f"https://graph.microsoft.com/beta/users/{user_id}"
+              ],
+          }
+          resp = requests.post(f"{GRAPH}/applications", headers=headers, json=blueprint_body)
+          resp.raise_for_status()
+          blueprint = resp.json()
+
+      app_id = blueprint["appId"]
+
+      # Always ensure BlueprintPrincipal exists (previous run may have crashed after blueprint creation)
+      sp_body = {
+          "@odata.type": "Microsoft.Graph.AgentIdentityBlueprintPrincipal",
+          "appId": app_id,
+      }
+      try:
+          resp = requests.post(f"{GRAPH}/servicePrincipals", headers=headers, json=sp_body)
+          resp.raise_for_status()
+      except requests.HTTPError as e:
+          if e.response.status_code != 409:  # 409 = already exists
+              raise


### PR DESCRIPTION
New core skill for creating OAuth2-capable AI agent identities via Microsoft Graph beta API. Covers Agent Identity Blueprints, BlueprintPrincipals, Agent Identities, required permissions, sponsors, and Workload Identity Federation.

Files:
- .github/skills/entra-agent-id/SKILL.md
- .github/skills/entra-agent-id/references/acceptance-criteria.md
- .github/skills/entra-agent-id/references/known-limitations.md
- .github/skills/entra-agent-id/references/oauth2-token-flow.md
- tests/scenarios/entra-agent-id/scenarios.yaml
- README.md (added to Core catalog, updated counts)