### PR TITLE
feat: add obsidian skill for CLI, Markdown, Bases, and JSON Canvas

### DIFF
--- a/.github/skills/obsidian/SKILL.md
+++ b/.github/skills/obsidian/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: obsidian
+description: >
+  Interact with Obsidian vaults using the CLI, create Obsidian Flavored Markdown,
+  build Bases (.base) databases, and author JSON Canvas (.canvas) files.
+  Use when the user wants to read/write/search vault notes, manage tasks or properties,
+  automate vault workflows, create .base or .canvas files, or write Obsidian-specific
+  markdown with wikilinks, callouts, and embeds.
+  Triggers: "obsidian", "vault", "daily note", "wikilink", "callout", ".base file",
+  ".canvas file", "obsidian cli", "obsidian markdown", "obsidian bases".
+---
+
+# Obsidian
+
+Skill for working with Obsidian vaults — CLI operations, Obsidian Flavored Markdown,
+Bases databases, and JSON Canvas files.
+
+## Obsidian CLI
+
+The official CLI (v1.12+) controls a running Obsidian desktop instance via IPC.
+
+| Requirement | Details |
+|---|---|
+| Obsidian Desktop | **v1.12.0+** |
+| CLI enabled | Settings → General → Command line interface → ON |
+| Obsidian running | Desktop app **must be running** (IPC) |
+
+### Syntax
+
+```bash
+obsidian <command> [subcommand] [key=value ...] [flags]
+```
+
+- **Parameters**: `key=value` (quote values with spaces)
+- **Flags**: boolean switches, no value (e.g., `open`, `overwrite`)
+- **Vault targeting**: `vault="My Vault"` as first argument
+- **File targeting**: `file=<name>` (wikilink-style) or `path=<vault-relative-path>`
+
+### Core Commands
+
+```bash
+# Read & write notes
+obsidian read path="folder/note.md"
+obsidian create path="folder/note" content="# Title\n\nBody"
+obsidian create path="folder/note" template="meeting-notes"
+obsidian append path="folder/note.md" content="New paragraph"
+obsidian prepend path="folder/note.md" content="Top content"
+obsidian move path="old/note.md" to="new/note.md"
+obsidian delete path="folder/note.md"
+
+# Daily notes
+obsidian daily                          # Open today's daily note
+obsidian daily:read                     # Print content to stdout
+obsidian daily:append content="- [ ] New task"
+
+# Search
+obsidian search query="project alpha"
+obsidian search query="TODO" path="projects" limit=10
+obsidian search:context query="meeting"  # Returns matching lines
+
+# Properties & tags
+obsidian properties path="note.md"
+obsidian property:set path="note.md" name="status" value="active"
+obsidian tags counts sort=count
+obsidian tag name="project/alpha"
+
+# Tasks
+obsidian tasks todo                     # Incomplete tasks
+obsidian tasks daily                    # Tasks in today's daily note
+obsidian task path="note.md" line=12 toggle
+
+# Links & graph
+obsidian backlinks path="note.md"
+obsidian orphans                        # Notes with no links
+obsidian unresolved                     # Broken wikilinks
+
+# Developer
+obsidian eval code="app.vault.getFiles().length"
+obsidian dev:screenshot path="screenshot.png"
+obsidian plugin:reload id=my-plugin
+obsidian dev:errors
+```
+
+### Command Groups (130+ commands)
+
+| Group | Key Commands | Purpose |
+|---|---|---|
+| **files** | `read`, `create`, `append`, `prepend`, `move`, `rename`, `delete`, `files` | Note CRUD |
+| **daily** | `daily`, `daily:read`, `daily:append`, `daily:prepend` | Daily notes |
+| **search** | `search`, `search:context` | Full-text search |
+| **properties** | `properties`, `property:set`, `property:remove`, `property:read` | Frontmatter |
+| **tags** | `tags`, `tag` | Tag listing and filtering |
+| **tasks** | `tasks`, `task` | Task querying and toggling |
+| **links** | `backlinks`, `links`, `unresolved`, `orphans`, `deadends` | Graph analysis |
+| **templates** | `templates`, `template:read`, `template:insert` | Template operations |
+| **plugins** | `plugins`, `plugin:enable`, `plugin:install`, `plugin:reload` | Plugin management |
+| **sync** | `sync`, `sync:status`, `sync:history`, `sync:restore` | Obsidian Sync |
+| **bases** | `bases`, `base:query`, `base:views`, `base:create` | Bases database |
+| **dev** | `eval`, `dev:screenshot`, `dev:console`, `dev:errors`, `dev:dom` | Developer tools |
+| **vault** | `vault`, `vaults`, `version`, `reload`, `restart` | Vault/app control |
+
+### Tips
+
+1. **Paths are vault-relative** — use `folder/note.md`, not absolute paths.
+2. **`create` omits `.md`** — extension is added automatically.
+3. **`prepend` inserts after frontmatter**, not at byte 0.
+4. **Pipe-friendly** — plain text output works with `grep`, `awk`, `jq`.
+5. **`format=json`** on `search` returns a JSON array of file paths.
+6. **`eval` requires single-line JS** — for multiline, write to a temp file and use `$(cat /tmp/obs.js)`.
+7. **`property:set` stores values as strings** — for YAML arrays, edit frontmatter directly or use `eval`.
+
+### Agent Patterns
+
+```bash
+# Daily journal automation
+obsidian daily:append content="## $(date '+%H:%M') — Status Update\n- Done: merged PR\n- Next: code review"
+
+# Create note from template with metadata
+obsidian create path="projects/new-feature" template="project-template"
+obsidian property:set path="projects/new-feature.md" name="status" value="planning"
+
+# Vault analytics
+obsidian files total
+obsidian tags counts sort=count
+obsidian orphans
+obsidian unresolved
+
+# Plugin dev/test cycle
+obsidian plugin:reload id=my-plugin
+obsidian dev:errors
+obsidian dev:screenshot path=screenshot.png
+```
+
+---
+
+## Obsidian Flavored Markdown
+
+Obsidian extends CommonMark/GFM with wikilinks, embeds, callouts, properties, comments, and highlights.
+
+### Internal Links (Wikilinks)
+
+```markdown
+[[Note Name]]                          Link to note
+[[Note Name|Display Text]]             Custom display text
+[[Note Name#Heading]]                  Link to heading
+[[Note Name#^block-id]]                Link to block
+```
+
+### Embeds
+
+```markdown
+![[Note Name]]                         Embed full note
+![[image.png]]                         Embed image
+![[image.png|300]]                     Image with width
+![[document.pdf#page=3]]               PDF page
+```
+
+### Callouts
+
+```markdown
+> [!note]
+> Basic callout.
+
+> [!warning] Custom Title
+> Callout with custom title.
+
+> [!faq]- Collapsed by default
+> Foldable callout.
+```
+
+Types: `note`, `tip`, `warning`, `info`, `example`, `quote`, `bug`, `danger`, `success`, `failure`, `question`, `abstract`, `todo`.
+
+### Properties (Frontmatter)
+
+```yaml
+---
+title: My Note
+date: 2024-01-15
+tags:
+  - project
+  - active
+aliases:
+  - Alternative Name
+---
+```
+
+### Other Syntax
+
+```markdown
+==Highlighted text==                   Highlight
+%%Hidden comment%%                     Comment (hidden in reading view)
+#tag #nested/tag                       Inline tags
+$e^{i\pi} + 1 = 0$                    LaTeX math
+```
+
+---
+
+## Obsidian Bases
+
+Bases (v1.12+) are `.base` files containing YAML that create database views of vault notes.
+
+### Workflow
+
+1. Create a `.base` file with YAML content
+2. Define `filters` to select notes (by tag, folder, property)
+3. Add `formulas` for computed properties
+4. Configure `views` (table, cards, list, map)
+5. Validate YAML — check quoting, formula references
+
+### Quick Example
+
+```yaml
+filters:
+  and:
+    - file.hasTag("task")
+    - 'file.ext == "md"'
+
+formulas:
+  days_until_due: 'if(due, (date(due) - today()).days, "")'
+  priority_label: 'if(priority == 1, "🔴 High", if(priority == 2, "🟡 Medium", "🟢 Low"))'
+
+views:
+  - type: table
+    name: "Active Tasks"
+    filters:
+      and:
+        - 'status != "done"'
+    order:
+      - file.name
+      - status
+      - formula.priority_label
+      - due
+      - formula.days_until_due
+```
+
+### Key Rules
+
+- Use single quotes for formulas containing double quotes: `'if(done, "Yes", "No")'`
+- Duration math requires field access: `(now() - file.ctime).days` not `(now() - file.ctime).round(0)`
+- Guard nullable properties: `'if(due_date, (date(due_date) - today()).days, "")'`
+
+---
+
+## JSON Canvas
+
+Canvas files (`.canvas`) follow the [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/).
+
+### Structure
+
+```json
+{
+  "nodes": [],
+  "edges": []
+}
+```
+
+### Node Types
+
+| Type | Required Fields | Purpose |
+|------|----------------|---------|
+| `text` | `text` | Markdown content |
+| `file` | `file` | Vault file embed |
+| `link` | `url` | External URL |
+| `group` | — | Visual container |
+
+All nodes require: `id` (16-char hex), `type`, `x`, `y`, `width`, `height`.
+
+### Edges
+
+Connect nodes via `fromNode`/`toNode` IDs. Optional: `fromSide`/`toSide` (`top`, `right`, `bottom`, `left`), `label`, `color`.
+
+### Validation
+
+1. All `id` values unique across nodes and edges
+2. Every `fromNode`/`toNode` references an existing node
+3. Required fields present per node type
+4. JSON is valid and parseable
+
+---
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| [references/cli-commands.md](references/cli-commands.md) | Full 130+ command reference with parameters |
+| [references/bases-guide.md](references/bases-guide.md) | Bases schema, filters, views, complete examples |
+| [references/bases-functions.md](references/bases-functions.md) | All Bases functions by type (Date, String, Number, List, File) |
+| [references/json-canvas.md](references/json-canvas.md) | JSON Canvas spec, node/edge details, layout guidelines, examples |
+| [references/markdown-syntax.md](references/markdown-syntax.md) | Full Obsidian Flavored Markdown reference |
+| [references/callouts.md](references/callouts.md) | All callout types with aliases and CSS customization |
+| [references/embeds.md](references/embeds.md) | Embed syntax for notes, images, audio, PDF, search |
+| [references/properties.md](references/properties.md) | Frontmatter property types and tag rules |

--- a/.github/skills/obsidian/references/acceptance-criteria.md
+++ b/.github/skills/obsidian/references/acceptance-criteria.md
@@ -1,0 +1,273 @@
+# Acceptance Criteria: obsidian
+
+**Skill**: `obsidian`
+**Source**: Obsidian Help Docs (https://help.obsidian.md/cli), JSON Canvas Spec, Obsidian Bases Docs
+**Purpose**: Skill testing acceptance criteria
+
+---
+
+## 1. CLI Command Patterns
+
+### 1.1 ✅ CORRECT: Read a note
+
+```bash
+obsidian read path="folder/note.md"
+```
+
+### 1.2 ✅ CORRECT: Create with template
+
+```bash
+obsidian create path="projects/new-feature" template="project-template"
+```
+
+### 1.3 ❌ INCORRECT: Create with .md extension
+
+```bash
+obsidian create path="projects/new-feature.md" content="# Title"
+# Wrong — create appends .md automatically
+```
+
+### 1.4 ✅ CORRECT: Daily note append
+
+```bash
+obsidian daily:append content="- [ ] New task"
+```
+
+### 1.5 ❌ INCORRECT: Absolute filesystem path
+
+```bash
+obsidian read path="/Users/me/vault/note.md"
+# Wrong — paths must be vault-relative
+```
+
+### 1.6 ✅ CORRECT: Search with JSON output
+
+```bash
+obsidian search query="meeting" format=json
+```
+
+### 1.7 ✅ CORRECT: Property set
+
+```bash
+obsidian property:set path="note.md" name="status" value="active"
+```
+
+### 1.8 ❌ INCORRECT: Property set for array values
+
+```bash
+obsidian property:set path="note.md" name="tags" value="[tag1, tag2]"
+# Wrong approach for arrays — stores literal string, not YAML array
+# Use: edit frontmatter directly or use eval
+```
+
+---
+
+## 2. Obsidian Markdown Patterns
+
+### 2.1 ✅ CORRECT: Wikilinks
+
+```markdown
+[[Note Name]]
+[[Note Name|Display Text]]
+[[Note Name#Heading]]
+```
+
+### 2.2 ❌ INCORRECT: Standard links for internal notes
+
+```markdown
+[Note Name](Note%20Name.md)
+<!-- Wrong — use wikilinks for internal vault notes -->
+```
+
+### 2.3 ✅ CORRECT: Image embed with width
+
+```markdown
+![[image.png|300]]
+```
+
+### 2.4 ❌ INCORRECT: Image embed with wrong syntax
+
+```markdown
+![[image.png|width=300]]
+<!-- Wrong — use pipe then number: ![[image.png|300]] -->
+```
+
+### 2.5 ✅ CORRECT: Callout syntax
+
+```markdown
+> [!warning] Important
+> This is a warning callout.
+```
+
+### 2.6 ❌ INCORRECT: Callout without bracket syntax
+
+```markdown
+> **Warning:** This is not a proper callout.
+<!-- Wrong — must use > [!type] syntax -->
+```
+
+### 2.7 ✅ CORRECT: Foldable callout
+
+```markdown
+> [!faq]- Click to expand
+> Hidden content.
+```
+
+### 2.8 ✅ CORRECT: Frontmatter properties
+
+```yaml
+---
+title: My Note
+tags:
+  - project
+  - active
+aliases:
+  - Alt Name
+---
+```
+
+### 2.9 ❌ INCORRECT: Tags with spaces
+
+```markdown
+#my tag
+<!-- Wrong — tags cannot contain spaces. Use #my-tag or #my_tag -->
+```
+
+### 2.10 ✅ CORRECT: Comment syntax
+
+```markdown
+%%This is hidden in reading view%%
+```
+
+---
+
+## 3. Bases Patterns
+
+### 3.1 ✅ CORRECT: Base file with filters and formulas
+
+```yaml
+filters:
+  and:
+    - file.hasTag("task")
+    - 'file.ext == "md"'
+
+formulas:
+  days_until_due: 'if(due, (date(due) - today()).days, "")'
+
+views:
+  - type: table
+    name: "Tasks"
+    order:
+      - file.name
+      - formula.days_until_due
+```
+
+### 3.2 ❌ INCORRECT: Duration without field access
+
+```yaml
+formulas:
+  age: '(now() - file.ctime).round(0)'
+  # Wrong — Duration doesn't support .round() directly
+  # Correct: '(now() - file.ctime).days.round(0)'
+```
+
+### 3.3 ❌ INCORRECT: Missing null guard
+
+```yaml
+formulas:
+  days_left: '(date(due_date) - today()).days'
+  # Wrong — crashes if due_date is empty
+  # Correct: 'if(due_date, (date(due_date) - today()).days, "")'
+```
+
+### 3.4 ❌ INCORRECT: Double quotes inside double quotes
+
+```yaml
+formulas:
+  label: "if(done, "Yes", "No")"
+  # YAML error — use single quotes wrapping double quotes
+  # Correct: 'if(done, "Yes", "No")'
+```
+
+### 3.5 ✅ CORRECT: Referencing formula in views
+
+```yaml
+formulas:
+  total: "price * quantity"
+
+views:
+  - type: table
+    order:
+      - formula.total
+```
+
+### 3.6 ❌ INCORRECT: Referencing undefined formula
+
+```yaml
+views:
+  - type: table
+    order:
+      - formula.total
+# Wrong — formula.total not defined in formulas section
+```
+
+---
+
+## 4. JSON Canvas Patterns
+
+### 4.1 ✅ CORRECT: Canvas structure
+
+```json
+{
+  "nodes": [
+    {"id": "6f0ad84f44ce9c17", "type": "text", "x": 0, "y": 0, "width": 300, "height": 150, "text": "# Hello"}
+  ],
+  "edges": []
+}
+```
+
+### 4.2 ❌ INCORRECT: Missing required fields
+
+```json
+{
+  "nodes": [
+    {"type": "text", "text": "Hello"}
+  ]
+}
+```
+Missing: `id`, `x`, `y`, `width`, `height`.
+
+### 4.3 ❌ INCORRECT: Dangling edge reference
+
+```json
+{
+  "nodes": [
+    {"id": "aaa", "type": "text", "x": 0, "y": 0, "width": 100, "height": 100, "text": "A"}
+  ],
+  "edges": [
+    {"id": "bbb", "fromNode": "aaa", "toNode": "nonexistent"}
+  ]
+}
+```
+`toNode` references a node that doesn't exist.
+
+### 4.4 ❌ INCORRECT: Literal backslash-n in text
+
+```json
+{"text": "Line 1\\nLine 2"}
+```
+Wrong — renders as literal `\n`. Use `\n` (single backslash in JSON string).
+
+### 4.5 ✅ CORRECT: Edge with label and sides
+
+```json
+{
+  "id": "0123456789abcdef",
+  "fromNode": "6f0ad84f44ce9c17",
+  "fromSide": "right",
+  "toNode": "a1b2c3d4e5f67890",
+  "toSide": "left",
+  "toEnd": "arrow",
+  "label": "leads to"
+}
+```

--- a/.github/skills/obsidian/references/bases-functions.md
+++ b/.github/skills/obsidian/references/bases-functions.md
@@ -1,0 +1,162 @@
+# Bases Functions Reference
+
+Complete reference for all Obsidian Bases formula functions.
+
+## Global Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date(string): date` | Parse string to date (`YYYY-MM-DD HH:mm:ss`) |
+| `duration()` | `duration(string): duration` | Parse duration string |
+| `now()` | `now(): date` | Current date and time |
+| `today()` | `today(): date` | Current date (time = 00:00:00) |
+| `if()` | `if(condition, trueResult, falseResult?)` | Conditional |
+| `min()` | `min(n1, n2, ...): number` | Smallest number |
+| `max()` | `max(n1, n2, ...): number` | Largest number |
+| `number()` | `number(any): number` | Convert to number |
+| `link()` | `link(path, display?): Link` | Create a link |
+| `list()` | `list(element): List` | Wrap in list if not already |
+| `file()` | `file(path): file` | Get file object |
+| `image()` | `image(path): image` | Create image for rendering |
+| `icon()` | `icon(name): icon` | Lucide icon by name |
+| `html()` | `html(string): html` | Render as HTML |
+| `escapeHTML()` | `escapeHTML(string): string` | Escape HTML characters |
+
+## Any Type
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isTruthy()` | `any.isTruthy(): boolean` | Coerce to boolean |
+| `isType()` | `any.isType(type): boolean` | Check type |
+| `toString()` | `any.toString(): string` | Convert to string |
+
+## Date
+
+**Fields:** `date.year`, `date.month`, `date.day`, `date.hour`, `date.minute`, `date.second`, `date.millisecond`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date.date(): date` | Remove time portion |
+| `format()` | `date.format(string): string` | Format with Moment.js pattern |
+| `time()` | `date.time(): string` | Get time as string |
+| `relative()` | `date.relative(): string` | Human-readable relative time |
+| `isEmpty()` | `date.isEmpty(): boolean` | Always false for dates |
+
+## Duration
+
+Subtracting two dates returns a Duration type.
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `duration.days` | Number | Total days |
+| `duration.hours` | Number | Total hours |
+| `duration.minutes` | Number | Total minutes |
+| `duration.seconds` | Number | Total seconds |
+| `duration.milliseconds` | Number | Total milliseconds |
+
+**IMPORTANT:** Duration does NOT support `.round()`, `.floor()`, `.ceil()` directly. Access a numeric field first.
+
+```yaml
+# CORRECT
+"(date(due_date) - today()).days"
+"(now() - file.ctime).days.round(0)"
+
+# WRONG
+# "(now() - file.ctime).round(0)"
+```
+
+### Date Arithmetic
+
+```yaml
+"now() + \"1 day\""       # Tomorrow
+"today() + \"7d\""        # Week from today
+"now() - file.ctime"      # Returns Duration
+"(now() - file.ctime).days"  # Get days as number
+```
+
+Duration units: `y/year/years`, `M/month/months`, `d/day/days`, `w/week/weeks`, `h/hour/hours`, `m/minute/minutes`, `s/second/seconds`.
+
+## String
+
+**Field:** `string.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `string.contains(value): boolean` | Check substring |
+| `containsAll()` | `string.containsAll(...values): boolean` | All substrings |
+| `containsAny()` | `string.containsAny(...values): boolean` | Any substring |
+| `startsWith()` | `string.startsWith(query): boolean` | Starts with |
+| `endsWith()` | `string.endsWith(query): boolean` | Ends with |
+| `isEmpty()` | `string.isEmpty(): boolean` | Empty or not present |
+| `lower()` | `string.lower(): string` | Lowercase |
+| `title()` | `string.title(): string` | Title Case |
+| `trim()` | `string.trim(): string` | Remove whitespace |
+| `replace()` | `string.replace(pattern, replacement): string` | Replace |
+| `repeat()` | `string.repeat(count): string` | Repeat |
+| `reverse()` | `string.reverse(): string` | Reverse |
+| `slice()` | `string.slice(start, end?): string` | Substring |
+| `split()` | `string.split(separator, n?): list` | Split to list |
+
+## Number
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `abs()` | `number.abs(): number` | Absolute value |
+| `ceil()` | `number.ceil(): number` | Round up |
+| `floor()` | `number.floor(): number` | Round down |
+| `round()` | `number.round(digits?): number` | Round to digits |
+| `toFixed()` | `number.toFixed(precision): string` | Fixed-point notation |
+| `isEmpty()` | `number.isEmpty(): boolean` | Not present |
+
+## List
+
+**Field:** `list.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `list.contains(value): boolean` | Element exists |
+| `containsAll()` | `list.containsAll(...values): boolean` | All exist |
+| `containsAny()` | `list.containsAny(...values): boolean` | Any exists |
+| `filter()` | `list.filter(expression): list` | Filter (uses `value`, `index`) |
+| `map()` | `list.map(expression): list` | Transform (uses `value`, `index`) |
+| `reduce()` | `list.reduce(expression, initial): any` | Reduce (uses `value`, `index`, `acc`) |
+| `flat()` | `list.flat(): list` | Flatten nested |
+| `join()` | `list.join(separator): string` | Join to string |
+| `reverse()` | `list.reverse(): list` | Reverse order |
+| `slice()` | `list.slice(start, end?): list` | Sublist |
+| `sort()` | `list.sort(): list` | Sort ascending |
+| `unique()` | `list.unique(): list` | Remove duplicates |
+| `isEmpty()` | `list.isEmpty(): boolean` | No elements |
+
+## File
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asLink()` | `file.asLink(display?): Link` | Convert to link |
+| `hasLink()` | `file.hasLink(otherFile): boolean` | Has link to file |
+| `hasTag()` | `file.hasTag(...tags): boolean` | Has any of the tags |
+| `hasProperty()` | `file.hasProperty(name): boolean` | Has property |
+| `inFolder()` | `file.inFolder(folder): boolean` | In folder or subfolder |
+
+## Link
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asFile()` | `link.asFile(): file` | Get file object |
+| `linksTo()` | `link.linksTo(file): boolean` | Links to file |
+
+## Object
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isEmpty()` | `object.isEmpty(): boolean` | No properties |
+| `keys()` | `object.keys(): list` | List of keys |
+| `values()` | `object.values(): list` | List of values |
+
+## RegExp
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `matches()` | `regexp.matches(string): boolean` | Test if matches |

--- a/.github/skills/obsidian/references/bases-guide.md
+++ b/.github/skills/obsidian/references/bases-guide.md
@@ -1,0 +1,361 @@
+# Obsidian Bases Guide
+
+Bases (v1.12+) are `.base` files containing YAML that create database-like views of vault notes.
+
+## Schema
+
+```yaml
+# Global filters — apply to ALL views
+filters:
+  and: []    # All conditions must be true
+  or: []     # Any condition can be true
+  not: []    # Exclude matching items
+
+# Computed properties
+formulas:
+  formula_name: 'expression'
+
+# Display name overrides
+properties:
+  property_name:
+    displayName: "Display Name"
+  formula.formula_name:
+    displayName: "Formula Display Name"
+
+# Custom summary formulas
+summaries:
+  custom_summary: 'values.mean().round(3)'
+
+# One or more views
+views:
+  - type: table | cards | list | map
+    name: "View Name"
+    limit: 10                    # Optional: limit results
+    groupBy:
+      property: property_name
+      direction: ASC | DESC
+    filters:                     # View-specific filters
+      and: []
+    order:                       # Properties to display
+      - file.name
+      - property_name
+      - formula.formula_name
+    summaries:
+      property_name: Average
+```
+
+## Filter Syntax
+
+### Simple Filters
+
+```yaml
+filters: 'status == "done"'
+```
+
+### Compound Filters
+
+```yaml
+# AND — all must be true
+filters:
+  and:
+    - 'status == "done"'
+    - 'priority > 3'
+
+# OR — any can be true
+filters:
+  or:
+    - file.hasTag("book")
+    - file.hasTag("article")
+
+# NOT — exclude
+filters:
+  not:
+    - file.hasTag("archived")
+
+# Nested
+filters:
+  or:
+    - file.hasTag("tag")
+    - and:
+        - file.hasTag("book")
+        - file.hasLink("Textbook")
+    - not:
+        - file.hasTag("book")
+        - file.inFolder("Required Reading")
+```
+
+### Filter Operators
+
+| Operator | Description |
+|----------|-------------|
+| `==` | Equals |
+| `!=` | Not equal |
+| `>` `<` `>=` `<=` | Comparisons |
+| `&&` | Logical and |
+| `\|\|` | Logical or |
+| `!` | Logical not |
+
+## Properties
+
+### Three Types
+
+1. **Note properties** — From frontmatter: `author` or `note.author`
+2. **File properties** — File metadata: `file.name`, `file.mtime`
+3. **Formula properties** — Computed: `formula.my_formula`
+
+### File Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `file.name` | String | File name |
+| `file.basename` | String | Name without extension |
+| `file.path` | String | Full path |
+| `file.folder` | String | Parent folder |
+| `file.ext` | String | Extension |
+| `file.size` | Number | Size in bytes |
+| `file.ctime` | Date | Created time |
+| `file.mtime` | Date | Modified time |
+| `file.tags` | List | All tags |
+| `file.links` | List | Internal links |
+| `file.backlinks` | List | Files linking here |
+| `file.embeds` | List | Embeds in note |
+| `file.properties` | Object | All frontmatter |
+
+## Formula Syntax
+
+Formulas compute values from properties.
+
+```yaml
+formulas:
+  # Arithmetic
+  total: "price * quantity"
+
+  # Conditional
+  status_icon: 'if(done, "✅", "⏳")'
+
+  # String formatting
+  formatted_price: 'if(price, price.toFixed(2) + " dollars")'
+
+  # Date formatting
+  created: 'file.ctime.format("YYYY-MM-DD")'
+
+  # Days since created
+  days_old: '(now() - file.ctime).days'
+
+  # Days until due (with null guard)
+  days_until_due: 'if(due_date, (date(due_date) - today()).days, "")'
+```
+
+### Duration Type
+
+Subtracting two dates returns a **Duration**, not a number.
+
+**Duration fields:** `.days`, `.hours`, `.minutes`, `.seconds`, `.milliseconds`
+
+```yaml
+# CORRECT
+"(date(due_date) - today()).days"              # Returns number
+"(now() - file.ctime).days.round(0)"          # Rounded days
+
+# WRONG — Duration doesn't support .round() directly
+# "(now() - file.ctime).round(0)"
+```
+
+### Date Arithmetic
+
+```yaml
+"now() + \"1 day\""       # Tomorrow
+"today() + \"7d\""        # Week from today
+"now() - file.ctime"      # Returns Duration
+```
+
+Duration units: `y/year/years`, `M/month/months`, `d/day/days`, `w/week/weeks`, `h/hour/hours`, `m/minute/minutes`, `s/second/seconds`.
+
+## View Types
+
+### Table
+
+```yaml
+views:
+  - type: table
+    name: "My Table"
+    order:
+      - file.name
+      - status
+      - due_date
+    summaries:
+      price: Sum
+      count: Average
+```
+
+### Cards
+
+```yaml
+views:
+  - type: cards
+    name: "Gallery"
+    order:
+      - cover
+      - file.name
+      - author
+```
+
+### List
+
+```yaml
+views:
+  - type: list
+    name: "Simple List"
+    order:
+      - file.name
+      - status
+```
+
+### Map
+
+Requires latitude/longitude properties and the Maps community plugin.
+
+## Default Summary Formulas
+
+| Name | Input | Description |
+|------|-------|-------------|
+| `Average` | Number | Mean |
+| `Min` / `Max` | Number | Extremes |
+| `Sum` | Number | Total |
+| `Range` | Number | Max - Min |
+| `Median` | Number | Median |
+| `Stddev` | Number | Standard deviation |
+| `Earliest` / `Latest` | Date | Extremes |
+| `Checked` / `Unchecked` | Boolean | Counts |
+| `Empty` / `Filled` | Any | Presence counts |
+| `Unique` | Any | Unique count |
+
+## Complete Examples
+
+### Task Tracker
+
+```yaml
+filters:
+  and:
+    - file.hasTag("task")
+    - 'file.ext == "md"'
+
+formulas:
+  days_until_due: 'if(due, (date(due) - today()).days, "")'
+  is_overdue: 'if(due, date(due) < today() && status != "done", false)'
+  priority_label: 'if(priority == 1, "🔴 High", if(priority == 2, "🟡 Medium", "🟢 Low"))'
+
+properties:
+  formula.days_until_due:
+    displayName: "Days Until Due"
+  formula.priority_label:
+    displayName: Priority
+
+views:
+  - type: table
+    name: "Active Tasks"
+    filters:
+      and:
+        - 'status != "done"'
+    order:
+      - file.name
+      - status
+      - formula.priority_label
+      - due
+      - formula.days_until_due
+    groupBy:
+      property: status
+      direction: ASC
+    summaries:
+      formula.days_until_due: Average
+
+  - type: table
+    name: "Completed"
+    filters:
+      and:
+        - 'status == "done"'
+    order:
+      - file.name
+      - completed_date
+```
+
+### Reading List
+
+```yaml
+filters:
+  or:
+    - file.hasTag("book")
+    - file.hasTag("article")
+
+formulas:
+  reading_time: 'if(pages, (pages * 2).toString() + " min", "")'
+  status_icon: 'if(status == "reading", "📖", if(status == "done", "✅", "📚"))'
+
+views:
+  - type: cards
+    name: "Library"
+    order:
+      - cover
+      - file.name
+      - author
+      - formula.status_icon
+    filters:
+      not:
+        - 'status == "dropped"'
+
+  - type: table
+    name: "Reading List"
+    filters:
+      and:
+        - 'status == "to-read"'
+    order:
+      - file.name
+      - author
+      - pages
+      - formula.reading_time
+```
+
+### Daily Notes Index
+
+```yaml
+filters:
+  and:
+    - file.inFolder("Daily Notes")
+    - '/^\d{4}-\d{2}-\d{2}$/.matches(file.basename)'
+
+formulas:
+  word_estimate: '(file.size / 5).round(0)'
+  day_of_week: 'date(file.basename).format("dddd")'
+
+views:
+  - type: table
+    name: "Recent Notes"
+    limit: 30
+    order:
+      - file.name
+      - formula.day_of_week
+      - formula.word_estimate
+      - file.mtime
+```
+
+## Embedding Bases
+
+```markdown
+![[MyBase.base]]
+![[MyBase.base#View Name]]
+```
+
+## YAML Quoting Rules
+
+- Single quotes for formulas with double quotes: `'if(done, "Yes", "No")'`
+- Double quotes for simple strings: `"My View Name"`
+- Strings with `:`, `{`, `}`, `[`, `]`, `#`, `!`, `>`, `<`, `=` must be quoted
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| YAML syntax error | Unquoted special characters | Quote strings with `:`, `#`, etc. |
+| Formula error | Duration math without field | Use `.days`, `.hours` before `.round()` |
+| Empty column | Undefined formula reference | Ensure `formula.X` has matching `formulas:` entry |
+| Wrong values | Missing null guard | Wrap with `if(prop, ..., "")` |

--- a/.github/skills/obsidian/references/callouts.md
+++ b/.github/skills/obsidian/references/callouts.md
@@ -1,0 +1,60 @@
+# Callouts Reference
+
+## Basic Callout
+
+```markdown
+> [!note]
+> This is a note callout.
+
+> [!info] Custom Title
+> Callout with a custom title.
+
+> [!tip] Title Only
+```
+
+## Foldable Callouts
+
+```markdown
+> [!faq]- Collapsed by default
+> Hidden until expanded.
+
+> [!faq]+ Expanded by default
+> Visible but can be collapsed.
+```
+
+## Nested Callouts
+
+```markdown
+> [!question] Outer callout
+> > [!note] Inner callout
+> > Nested content.
+```
+
+## Supported Types
+
+| Type | Aliases | Color / Icon |
+|------|---------|-------------|
+| `note` | — | Blue, pencil |
+| `abstract` | `summary`, `tldr` | Teal, clipboard |
+| `info` | — | Blue, info |
+| `todo` | — | Blue, checkbox |
+| `tip` | `hint`, `important` | Cyan, flame |
+| `success` | `check`, `done` | Green, checkmark |
+| `question` | `help`, `faq` | Yellow, question mark |
+| `warning` | `caution`, `attention` | Orange, warning |
+| `failure` | `fail`, `missing` | Red, X |
+| `danger` | `error` | Red, zap |
+| `bug` | — | Red, bug |
+| `example` | — | Purple, list |
+| `quote` | `cite` | Gray, quote |
+
+## Custom Callouts (CSS)
+
+Add custom callout types via CSS snippets:
+
+```css
+.callout[data-callout="custom-type"] {
+  --callout-color: 255, 0, 0;
+  --callout-icon: lucide-alert-circle;
+}
+```

--- a/.github/skills/obsidian/references/cli-commands.md
+++ b/.github/skills/obsidian/references/cli-commands.md
@@ -1,0 +1,452 @@
+# Obsidian CLI — Full Command Reference
+
+Complete reference for all official Obsidian CLI commands (v1.12+).
+
+**Syntax**: `obsidian [vault] <command> [subcommand] [key=value ...] [flags]`
+
+All parameters use `key=value` syntax. Quote values containing spaces: `content="hello world"`.
+
+---
+
+## Table of Contents
+
+1. [Files](#files)
+2. [Daily Notes](#daily-notes)
+3. [Search](#search)
+4. [Properties](#properties)
+5. [Tags](#tags)
+6. [Tasks](#tasks)
+7. [Links](#links)
+8. [Bookmarks](#bookmarks)
+9. [Templates](#templates)
+10. [Plugins](#plugins)
+11. [Sync](#sync)
+12. [Themes](#themes)
+13. [CSS Snippets](#css-snippets)
+14. [Commands & Hotkeys](#commands--hotkeys)
+15. [Obsidian Bases](#obsidian-bases)
+16. [History](#history)
+17. [Workspace & Tabs](#workspace--tabs)
+18. [Diff](#diff)
+19. [Developer](#developer)
+20. [Vault & System](#vault--system)
+21. [Output Formatting](#output-formatting)
+
+---
+
+## Files
+
+### Reading Notes
+
+```bash
+obsidian read path="folder/note.md"
+obsidian read file="Recipe"          # Wikilink-style resolution
+```
+
+### Creating Notes
+
+```bash
+obsidian create path="folder/note" content="# Title\n\nBody text"
+obsidian create path="folder/note" template="template-name"
+obsidian create name="Note" content="Hello" open overwrite
+```
+
+- Path should **not** include `.md` — appended automatically.
+- Use `template=` to create from a template file.
+- Flags: `overwrite`, `open`, `newtab`.
+
+### Appending & Prepending
+
+```bash
+obsidian append path="folder/note.md" content="Appended text"
+obsidian prepend path="folder/note.md" content="Prepended text"
+```
+
+- `prepend` adds content **after frontmatter**, not at byte 0.
+- Flag: `inline` (append without newline).
+
+### Moving & Renaming
+
+```bash
+obsidian move path="old/path/note.md" to="new/path/note.md"
+obsidian rename path="folder/note.md" name="new-name"
+```
+
+- `move` requires full vault-relative target path including `.md`.
+- `rename` takes just the new filename (no path, no extension).
+
+### Deleting
+
+```bash
+obsidian delete path="folder/note.md"           # Moves to trash
+obsidian delete path="folder/note.md" permanent  # Permanent
+```
+
+### File Discovery
+
+```bash
+obsidian files                       # List all files
+obsidian files ext=md                # Filter by extension
+obsidian files folder="subfolder"    # Files in folder
+obsidian files total                 # File count
+obsidian folders                     # List all folders
+obsidian file path="folder/note.md"  # File info (size, created, modified)
+obsidian random                      # Open random note
+obsidian random:read                 # Print random note content
+```
+
+---
+
+## Daily Notes
+
+Requires Daily Notes core plugin enabled.
+
+```bash
+obsidian daily                           # Open today's note
+obsidian daily:read                      # Print content to stdout
+obsidian daily:append content="text"     # Append to today's note
+obsidian daily:prepend content="text"    # Prepend (after frontmatter)
+obsidian daily:path                      # Print vault-relative path
+```
+
+- If today's note doesn't exist, `daily` creates it (using configured template).
+- `daily:append`/`daily:prepend` accept `inline` and `open` flags.
+
+---
+
+## Search
+
+```bash
+obsidian search query="search text"
+obsidian search query="text" path="folder"         # Scope to folder
+obsidian search query="text" limit=10               # Limit results
+obsidian search query="text" format=json            # JSON array of file paths
+obsidian search query="text" case                   # Case-sensitive
+obsidian search:context query="text"                # Returns matching lines
+obsidian search:open query="text"                   # Open search panel in UI
+```
+
+---
+
+## Properties
+
+```bash
+obsidian properties path="note.md"                              # All properties
+obsidian property:read path="note.md" name="status"             # Read single
+obsidian property:set path="note.md" name="status" value="active"  # Set value
+obsidian property:remove path="note.md" name="draft"            # Remove
+obsidian aliases path="note.md"                                 # List aliases
+```
+
+> **Note:** `property:set` stores values as strings. `value="[a, b]"` writes a literal string, not a YAML array. For array properties, edit frontmatter directly or use `eval`.
+
+---
+
+## Tags
+
+```bash
+obsidian tags                          # List all tags
+obsidian tags counts                   # With usage counts
+obsidian tags counts sort=count        # Sorted by frequency
+obsidian tags path="note.md"           # Tags in a specific file
+obsidian tag name="project/alpha"      # Notes with a specific tag
+```
+
+---
+
+## Tasks
+
+### Querying
+
+```bash
+obsidian tasks                         # All tasks (done + todo)
+obsidian tasks todo                    # Incomplete only
+obsidian tasks done                    # Completed only
+obsidian tasks daily                   # Tasks in today's daily note
+obsidian tasks path="note.md"          # Tasks in specific file
+obsidian tasks verbose                 # Group by file with line numbers
+```
+
+### Toggling
+
+```bash
+obsidian task path="note.md" line=12 toggle
+obsidian task ref="note.md:8" toggle
+obsidian task daily line=3 done
+obsidian task file=Recipe line=8 status=-   # Custom status character
+```
+
+---
+
+## Links
+
+```bash
+obsidian backlinks path="note.md"         # Notes linking TO this note
+obsidian backlinks path="note.md" counts  # With link counts
+obsidian links path="note.md"             # Outgoing links FROM this note
+obsidian unresolved                        # All unresolved wikilinks
+obsidian unresolved verbose                # With source files
+obsidian orphans                           # Notes with no incoming links
+obsidian deadends                          # Notes with no outgoing links
+```
+
+---
+
+## Bookmarks
+
+```bash
+obsidian bookmarks                                      # List all
+obsidian bookmark file="folder/note.md"                 # Bookmark a note
+obsidian bookmark file="note.md" subpath="#Heading"     # Bookmark a heading
+obsidian bookmark folder="projects"                     # Bookmark a folder
+obsidian bookmark search="query" title="My Search"      # Bookmark a search
+obsidian bookmark url="https://example.com" title="Link" # Bookmark a URL
+```
+
+---
+
+## Templates
+
+```bash
+obsidian templates                                      # List templates
+obsidian template:read name="weekly-review"             # Read template
+obsidian template:read name="weekly" resolve title="My Note"  # Render with variables
+obsidian template:insert name="weekly-review"           # Insert into active file
+```
+
+> **Note:** `template:insert` inserts into the currently active file in the UI. It does not accept `path=`. To create a new file from a template, use `obsidian create path="..." template="..."`.
+
+---
+
+## Plugins
+
+```bash
+obsidian plugins                         # List all plugins
+obsidian plugins:enabled                 # Enabled only
+obsidian plugins versions                # With version numbers
+obsidian plugin id="dataview"            # Plugin info
+obsidian plugin:enable id="canvas"
+obsidian plugin:disable id="canvas"
+obsidian plugin:install id="dataview"
+obsidian plugin:uninstall id="dataview"
+obsidian plugin:reload id="my-plugin"    # Reload (dev)
+obsidian plugins:restrict on|off         # Toggle restricted mode
+```
+
+---
+
+## Sync
+
+Requires active Obsidian Sync subscription.
+
+```bash
+obsidian sync                                   # Status summary
+obsidian sync on|off                            # Resume/pause
+obsidian sync:status                            # Detailed status
+obsidian sync:history path="note.md"            # Version history
+obsidian sync:read path="note.md" version=3     # Read version
+obsidian sync:restore path="note.md" version=3  # Restore version
+obsidian sync:deleted                           # Deleted files
+obsidian sync:open                              # Open Sync UI
+```
+
+---
+
+## Themes
+
+```bash
+obsidian themes                            # List installed
+obsidian themes versions                   # With versions
+obsidian theme                             # Active theme
+obsidian theme:set name="Minimal"          # Switch theme
+obsidian theme:set name=""                 # Default theme
+obsidian theme:install name="Minimal"
+obsidian theme:install name="Minimal" enable
+obsidian theme:uninstall name="Minimal"
+```
+
+---
+
+## CSS Snippets
+
+```bash
+obsidian snippets                          # List all
+obsidian snippets:enabled                  # Enabled only
+obsidian snippet:enable name="my-style"
+obsidian snippet:disable name="my-style"
+```
+
+---
+
+## Commands & Hotkeys
+
+```bash
+obsidian commands                          # List all command IDs
+obsidian commands filter="canvas"          # Filter by prefix
+obsidian command id="app:reload"           # Execute a command
+obsidian hotkeys                           # List all hotkeys
+obsidian hotkey id="app:open-settings"     # Get hotkey for command
+```
+
+---
+
+## Obsidian Bases
+
+```bash
+obsidian bases                                    # List .base files
+obsidian base:query file="tasks" format=json      # Query default view
+obsidian base:query file="tasks" view="Kanban"    # Query specific view
+obsidian base:views file="tasks"                  # List views
+obsidian base:create file="tasks" title="Buy milk"  # Add item
+```
+
+Supported output formats: `json` (default), `csv`, `tsv`, `md`, `paths`.
+
+---
+
+## History
+
+File version history (File Recovery core plugin).
+
+```bash
+obsidian history:list                             # Files with history
+obsidian history path="folder/note.md"            # List versions
+obsidian history:read path="note.md"              # Latest version
+obsidian history:read path="note.md" version=3    # Specific version
+obsidian history:restore path="note.md" version=3
+obsidian history:open path="note.md"              # Open recovery UI
+```
+
+---
+
+## Workspace & Tabs
+
+```bash
+obsidian workspace                                # Workspace tree
+obsidian tabs                                     # Open tabs
+obsidian tab:open file="folder/note.md"           # Open in new tab
+obsidian tab:open view="graph"                    # Open view type
+obsidian recents                                  # Recently opened
+```
+
+---
+
+## Diff
+
+Compare local and sync versions.
+
+```bash
+obsidian diff path="note.md"               # List versions
+obsidian diff path="note.md" from=1 to=2   # Compare two versions
+obsidian diff path="note.md" filter=local   # Local only
+obsidian diff path="note.md" filter=sync    # Sync only
+```
+
+---
+
+## Developer
+
+### Screenshots
+
+```bash
+obsidian dev:screenshot path="folder/screenshot.png"
+```
+
+Path must be **vault-relative**.
+
+### JavaScript Evaluation
+
+```bash
+obsidian eval code="app.vault.getFiles().length"
+obsidian eval code="app.vault.getMarkdownFiles().map(f => f.path).join('\n')"
+```
+
+> **Multiline JS:** Write to temp file, then `obsidian eval code="$(cat /tmp/obs.js)"`.
+
+### Console & Errors
+
+```bash
+obsidian dev:debug on              # Start capturing (required before dev:console)
+obsidian dev:debug off
+obsidian dev:console limit=20      # Recent console output
+obsidian dev:errors                # Recent errors
+```
+
+### DOM & CSS Inspection
+
+```bash
+obsidian dev:dom selector=".view-content"             # outerHTML
+obsidian dev:dom selector=".view-content" text         # Text content
+obsidian dev:dom selector=".view-content" total        # Count
+obsidian dev:css selector=".view-content"              # CSS with sources
+obsidian dev:css selector=".view-content" prop=color   # Specific property
+```
+
+### Other Developer Tools
+
+```bash
+obsidian devtools                   # Toggle Electron DevTools
+obsidian dev:mobile on|off          # Mobile emulation
+obsidian dev:cdp method="Runtime.evaluate" params='{"expression":"1+1"}'
+```
+
+---
+
+## Vault & System
+
+```bash
+obsidian vault                         # Name, path, file/folder counts
+obsidian vaults                        # All known vaults
+obsidian version                       # Version info
+obsidian outline path="note.md"        # Heading structure
+obsidian wordcount path="note.md"      # Word/character count
+obsidian reload                        # Reload vault
+obsidian restart                       # Restart app
+```
+
+---
+
+## Output Formatting
+
+| Format | Description | Best for |
+|---|---|---|
+| `text` | Plain text (default) | Piping to grep/awk/sed |
+| `json` | JSON array or object | Processing with jq, AI agents |
+| `csv` | Comma-separated | Spreadsheet import |
+| `tsv` | Tab-separated | Shell parsing |
+| `yaml` | YAML output | Config-style |
+| `md` | Markdown table | Embedding in notes |
+| `paths` | One path per line | Batch file operations |
+| `tree` | Tree view | Visual hierarchy |
+
+Not all formats are supported by every command. Use `text` or `json` when in doubt.
+
+### Piping Examples
+
+```bash
+obsidian files folder="projects" | wc -l
+obsidian tag name="urgent" | while read -r note; do obsidian read path="$note"; done
+obsidian search query="meeting" format=json | jq '.[]'
+obsidian base:query file="tasks" format=csv
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| Empty output / hangs | Obsidian not running | Start Obsidian |
+| Command not found | CLI not in PATH | Re-enable CLI in Settings; restart terminal |
+| Wrong vault targeted | Multi-vault ambiguity | Pass vault name as first arg |
+| Colon+params exit 127 (Windows) | Missing `Obsidian.com` | Reinstall latest from obsidian.md/download |
+| Colon+params exit 127 (Git Bash) | Bash resolves to `.exe` not `.com` | Create wrapper script |
+| IPC socket not found (Linux) | `PrivateTmp=true` in systemd | Set `PrivateTmp=false` |
+| Snap confinement | Snap restricts IPC | Use `.deb` package |
+| `property:set` list is string | CLI stores value as-is | Edit frontmatter directly or use `eval` |
+
+### Platform Notes
+
+- **macOS**: Binary registered in PATH via `~/.zprofile`. For non-zsh shells, add manually.
+- **Windows**: Requires `Obsidian.com` redirector alongside `Obsidian.exe`. Must use normal-privilege terminal.
+- **Linux**: Symlink at `/usr/local/bin/obsidian`. Use `.deb` for headless (not snap). Run under `xvfb`.

--- a/.github/skills/obsidian/references/embeds.md
+++ b/.github/skills/obsidian/references/embeds.md
@@ -1,0 +1,72 @@
+# Embeds Reference
+
+## Embed Notes
+
+```markdown
+![[Note Name]]                         Full note
+![[Note Name#Heading]]                 Section under heading
+![[Note Name#^block-id]]               Specific block
+```
+
+## Embed Images
+
+```markdown
+![[image.png]]                         Full size
+![[image.png|300]]                     Width only (maintains ratio)
+![[image.png|640x480]]                 Width x Height
+```
+
+## External Images
+
+```markdown
+![Alt text](https://example.com/image.png)
+![Alt text|300](https://example.com/image.png)
+```
+
+## Embed Audio
+
+```markdown
+![[audio.mp3]]
+![[audio.ogg]]
+```
+
+Supported formats: mp3, webm, wav, m4a, ogg, 3gp, flac.
+
+## Embed Video
+
+```markdown
+![[video.mp4]]
+![[video.webm]]
+```
+
+Supported formats: mp4, webm, ogv.
+
+## Embed PDF
+
+```markdown
+![[document.pdf]]
+![[document.pdf#page=3]]
+![[document.pdf#height=400]]
+```
+
+## Embed Lists
+
+The list must have a block ID:
+
+```markdown
+- Item 1
+- Item 2
+- Item 3
+
+^list-id
+```
+
+Then embed: `![[Note#^list-id]]`
+
+## Embed Search Results
+
+````markdown
+```query
+tag:#project status:done
+```
+````

--- a/.github/skills/obsidian/references/json-canvas.md
+++ b/.github/skills/obsidian/references/json-canvas.md
@@ -1,0 +1,232 @@
+# JSON Canvas Reference
+
+Canvas files (`.canvas`) follow the [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/).
+
+## File Structure
+
+```json
+{
+  "nodes": [],
+  "edges": []
+}
+```
+
+## Nodes
+
+Array order determines z-index: first = bottom, last = top.
+
+### Common Attributes (All Nodes)
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `id` | Yes | string | Unique 16-char hex identifier |
+| `type` | Yes | string | `text`, `file`, `link`, or `group` |
+| `x` | Yes | integer | X position in pixels |
+| `y` | Yes | integer | Y position in pixels |
+| `width` | Yes | integer | Width in pixels |
+| `height` | Yes | integer | Height in pixels |
+| `color` | No | canvasColor | Preset `"1"`-`"6"` or hex `"#FF0000"` |
+
+### Text Nodes
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `text` | Yes | Plain text with Markdown syntax |
+
+```json
+{
+  "id": "6f0ad84f44ce9c17",
+  "type": "text",
+  "x": 0, "y": 0, "width": 400, "height": 200,
+  "text": "# Hello World\n\nThis is **Markdown** content."
+}
+```
+
+Use `\n` for line breaks. Do **not** use literal `\\n`.
+
+### File Nodes
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `file` | Yes | Path to file within vault |
+| `subpath` | No | Link to heading or block (`#heading`) |
+
+```json
+{
+  "id": "a1b2c3d4e5f67890",
+  "type": "file",
+  "x": 500, "y": 0, "width": 400, "height": 300,
+  "file": "Attachments/diagram.png"
+}
+```
+
+### Link Nodes
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `url` | Yes | External URL |
+
+```json
+{
+  "id": "c3d4e5f678901234",
+  "type": "link",
+  "x": 1000, "y": 0, "width": 400, "height": 200,
+  "url": "https://obsidian.md"
+}
+```
+
+### Group Nodes
+
+Visual containers for organizing other nodes. Position children inside bounds.
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `label` | No | Text label |
+| `background` | No | Path to background image |
+| `backgroundStyle` | No | `cover`, `ratio`, or `repeat` |
+
+```json
+{
+  "id": "d4e5f6789012345a",
+  "type": "group",
+  "x": -50, "y": -50, "width": 1000, "height": 600,
+  "label": "Project Overview",
+  "color": "4"
+}
+```
+
+## Edges
+
+Connect nodes via `fromNode` and `toNode` IDs.
+
+| Attribute | Required | Type | Default | Description |
+|-----------|----------|------|---------|-------------|
+| `id` | Yes | string | — | Unique identifier |
+| `fromNode` | Yes | string | — | Source node ID |
+| `fromSide` | No | string | — | `top`, `right`, `bottom`, `left` |
+| `fromEnd` | No | string | `none` | `none` or `arrow` |
+| `toNode` | Yes | string | — | Target node ID |
+| `toSide` | No | string | — | `top`, `right`, `bottom`, `left` |
+| `toEnd` | No | string | `arrow` | `none` or `arrow` |
+| `color` | No | canvasColor | — | Line color |
+| `label` | No | string | — | Text label |
+
+```json
+{
+  "id": "0123456789abcdef",
+  "fromNode": "6f0ad84f44ce9c17",
+  "fromSide": "right",
+  "toNode": "a1b2c3d4e5f67890",
+  "toSide": "left",
+  "toEnd": "arrow",
+  "label": "leads to"
+}
+```
+
+## Colors
+
+| Preset | Color |
+|--------|-------|
+| `"1"` | Red |
+| `"2"` | Orange |
+| `"3"` | Yellow |
+| `"4"` | Green |
+| `"5"` | Cyan |
+| `"6"` | Purple |
+
+Also accepts hex strings: `"#FF0000"`.
+
+## ID Generation
+
+16-character lowercase hexadecimal strings (64-bit random):
+
+```
+"6f0ad84f44ce9c17"
+"a3b2c1d0e9f8a7b6"
+```
+
+## Layout Guidelines
+
+- Coordinates can be negative (canvas extends infinitely)
+- `x` increases right, `y` increases down; position is top-left corner
+- Space nodes 50-100px apart; 20-50px padding inside groups
+- Align to multiples of 10 or 20
+
+| Node Type | Width | Height |
+|-----------|-------|--------|
+| Small text | 200-300 | 80-150 |
+| Medium text | 300-450 | 150-300 |
+| Large text | 400-600 | 300-500 |
+| File preview | 300-500 | 200-400 |
+| Link preview | 250-400 | 100-200 |
+
+## Workflows
+
+### Create a New Canvas
+
+1. Create `.canvas` file with `{"nodes": [], "edges": []}`
+2. Generate unique 16-char hex IDs for each node
+3. Add nodes with required fields
+4. Add edges referencing valid node IDs
+5. Validate: parse JSON, verify all edge references
+
+### Add Node to Existing Canvas
+
+1. Read and parse existing `.canvas`
+2. Generate unique ID (no collisions)
+3. Position to avoid overlaps (50-100px spacing)
+4. Append to `nodes` array
+5. Optionally add connecting edges
+6. Validate all IDs and references
+
+### Connect Two Nodes
+
+1. Identify source and target node IDs
+2. Generate unique edge ID
+3. Set `fromNode`, `toNode`, and optionally `fromSide`/`toSide`
+4. Append to `edges` array
+
+## Validation Checklist
+
+1. All `id` values unique across nodes and edges
+2. Every `fromNode`/`toNode` references existing node
+3. Required fields present per node type
+4. `type` is `text`, `file`, `link`, or `group`
+5. `fromSide`/`toSide` is `top`, `right`, `bottom`, or `left`
+6. `fromEnd`/`toEnd` is `none` or `arrow`
+7. Colors are `"1"`-`"6"` or valid hex
+8. JSON is valid and parseable
+
+## Examples
+
+### Simple Mind Map
+
+```json
+{
+  "nodes": [
+    {"id": "8a9b0c1d2e3f4a5b", "type": "text", "x": 0, "y": 0, "width": 300, "height": 150, "text": "# Main Idea\n\nCentral concept."},
+    {"id": "1a2b3c4d5e6f7a8b", "type": "text", "x": 400, "y": -100, "width": 250, "height": 100, "text": "## Point A\n\nDetails."},
+    {"id": "2b3c4d5e6f7a8b9c", "type": "text", "x": 400, "y": 100, "width": 250, "height": 100, "text": "## Point B\n\nMore details."}
+  ],
+  "edges": [
+    {"id": "3c4d5e6f7a8b9c0d", "fromNode": "8a9b0c1d2e3f4a5b", "fromSide": "right", "toNode": "1a2b3c4d5e6f7a8b", "toSide": "left"},
+    {"id": "4d5e6f7a8b9c0d1e", "fromNode": "8a9b0c1d2e3f4a5b", "fromSide": "right", "toNode": "2b3c4d5e6f7a8b9c", "toSide": "left"}
+  ]
+}
+```
+
+### Project Board with Groups
+
+```json
+{
+  "nodes": [
+    {"id": "5e6f7a8b9c0d1e2f", "type": "group", "x": 0, "y": 0, "width": 300, "height": 500, "label": "To Do", "color": "1"},
+    {"id": "6f7a8b9c0d1e2f3a", "type": "group", "x": 350, "y": 0, "width": 300, "height": 500, "label": "In Progress", "color": "3"},
+    {"id": "7a8b9c0d1e2f3a4b", "type": "group", "x": 700, "y": 0, "width": 300, "height": 500, "label": "Done", "color": "4"},
+    {"id": "8b9c0d1e2f3a4b5c", "type": "text", "x": 20, "y": 50, "width": 260, "height": 80, "text": "## Task 1\n\nImplement feature X"},
+    {"id": "9c0d1e2f3a4b5c6d", "type": "text", "x": 370, "y": 50, "width": 260, "height": 80, "text": "## Task 2\n\nReview PR #123", "color": "2"},
+    {"id": "0d1e2f3a4b5c6d7e", "type": "text", "x": 720, "y": 50, "width": 260, "height": 80, "text": "## Task 3\n\n~~Setup CI/CD~~"}
+  ],
+  "edges": []
+}
+```

--- a/.github/skills/obsidian/references/markdown-syntax.md
+++ b/.github/skills/obsidian/references/markdown-syntax.md
@@ -1,0 +1,233 @@
+# Obsidian Flavored Markdown Reference
+
+Obsidian extends CommonMark and GFM with wikilinks, embeds, callouts, properties, comments, highlights, and more. This covers only Obsidian-specific extensions — standard Markdown is assumed knowledge.
+
+## Internal Links (Wikilinks)
+
+```markdown
+[[Note Name]]                          Link to note
+[[Note Name|Display Text]]             Custom display text
+[[Note Name#Heading]]                  Link to heading
+[[Note Name#^block-id]]                Link to block
+[[#Heading in same note]]              Same-note heading link
+```
+
+### Block IDs
+
+Append `^block-id` to any paragraph:
+
+```markdown
+This paragraph can be linked to. ^my-block-id
+```
+
+For lists and quotes, place block ID on a separate line after the block:
+
+```markdown
+> A quote block
+
+^quote-id
+```
+
+> Use `[[wikilinks]]` for vault notes (Obsidian tracks renames) and `[text](url)` for external URLs.
+
+## Embeds
+
+Prefix any wikilink with `!` to embed inline:
+
+```markdown
+![[Note Name]]                         Full note
+![[Note Name#Heading]]                 Section
+![[Note Name#^block-id]]               Block
+![[image.png]]                         Image
+![[image.png|300]]                     Image with width
+![[image.png|640x480]]                 Image with dimensions
+![[document.pdf]]                      PDF
+![[document.pdf#page=3]]               PDF page
+![[audio.mp3]]                         Audio
+```
+
+External images:
+
+```markdown
+![Alt text](https://example.com/image.png)
+![Alt text|300](https://example.com/image.png)
+```
+
+Embed search results:
+
+````markdown
+```query
+tag:#project status:done
+```
+````
+
+See [embeds.md](embeds.md) for complete embed reference.
+
+## Callouts
+
+```markdown
+> [!note]
+> Basic callout.
+
+> [!warning] Custom Title
+> Callout with custom title.
+
+> [!faq]- Collapsed by default
+> Foldable callout (- collapsed, + expanded).
+
+> [!question] Outer
+> > [!note] Nested
+> > Nested callout content.
+```
+
+Types: `note`, `abstract` (`summary`, `tldr`), `info`, `todo`, `tip` (`hint`, `important`), `success` (`check`, `done`), `question` (`help`, `faq`), `warning` (`caution`, `attention`), `failure` (`fail`, `missing`), `danger` (`error`), `bug`, `example`, `quote` (`cite`).
+
+See [callouts.md](callouts.md) for full reference with CSS customization.
+
+## Properties (Frontmatter)
+
+YAML frontmatter at the start of a note:
+
+```yaml
+---
+title: My Note
+date: 2024-01-15
+tags:
+  - project
+  - active
+aliases:
+  - Alternative Name
+cssclasses:
+  - custom-class
+status: in-progress
+rating: 4.5
+completed: false
+due: 2024-02-01T14:30:00
+---
+```
+
+### Property Types
+
+| Type | Example |
+|------|---------|
+| Text | `title: My Title` |
+| Number | `rating: 4.5` |
+| Checkbox | `completed: true` |
+| Date | `date: 2024-01-15` |
+| Date & Time | `due: 2024-01-15T14:30:00` |
+| List | `tags: [one, two]` or YAML list |
+| Links | `related: "[[Other Note]]"` |
+
+### Default Properties
+
+- `tags` — Searchable labels, shown in graph view
+- `aliases` — Alternative names for link suggestions
+- `cssclasses` — CSS classes applied to the note
+
+See [properties.md](properties.md) for complete reference.
+
+## Tags
+
+```markdown
+#tag                    Inline tag
+#nested/tag             Nested tag hierarchy
+#tag-with-dashes
+#tag_with_underscores
+```
+
+Tags can contain: letters (any language), numbers (not first character), underscores `_`, hyphens `-`, forward slashes `/`.
+
+Also definable in frontmatter:
+
+```yaml
+---
+tags:
+  - tag1
+  - nested/tag2
+---
+```
+
+## Comments
+
+```markdown
+This is visible %%but this is hidden%% text.
+
+%%
+This entire block is hidden in reading view.
+%%
+```
+
+## Highlights
+
+```markdown
+==Highlighted text==
+```
+
+## Math (LaTeX)
+
+```markdown
+Inline: $e^{i\pi} + 1 = 0$
+
+Block:
+$$
+\frac{a}{b} = c
+$$
+```
+
+## Diagrams (Mermaid)
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Do this]
+    B -->|No| D[Do that]
+```
+````
+
+Link Mermaid nodes to Obsidian notes with `class NodeName internal-link;`.
+
+## Footnotes
+
+```markdown
+Text with a footnote[^1].
+
+[^1]: Footnote content.
+
+Inline footnote.^[This is inline.]
+```
+
+## Complete Example
+
+````markdown
+---
+title: Project Alpha
+date: 2024-01-15
+tags:
+  - project
+  - active
+status: in-progress
+---
+
+# Project Alpha
+
+This project aims to [[improve workflow]] using modern techniques.
+
+> [!important] Key Deadline
+> The first milestone is due on ==January 30th==.
+
+## Tasks
+
+- [x] Initial planning
+- [ ] Development phase
+  - [ ] Backend implementation
+  - [ ] Frontend design
+
+## Notes
+
+The algorithm uses $O(n \log n)$ sorting. See [[Algorithm Notes#Sorting]] for details.
+
+![[Architecture Diagram.png|600]]
+
+Reviewed in [[Meeting Notes 2024-01-10#Decisions]].
+````

--- a/.github/skills/obsidian/references/properties.md
+++ b/.github/skills/obsidian/references/properties.md
@@ -1,0 +1,72 @@
+# Properties (Frontmatter) Reference
+
+Properties use YAML frontmatter at the start of a note:
+
+```yaml
+---
+title: My Note Title
+date: 2024-01-15
+tags:
+  - project
+  - important
+aliases:
+  - My Note
+  - Alternative Name
+cssclasses:
+  - custom-class
+status: in-progress
+rating: 4.5
+completed: false
+due: 2024-02-01T14:30:00
+---
+```
+
+## Property Types
+
+| Type | Example |
+|------|---------|
+| Text | `title: My Title` |
+| Number | `rating: 4.5` |
+| Checkbox | `completed: true` / `completed: false` |
+| Date | `date: 2024-01-15` |
+| Date & Time | `due: 2024-01-15T14:30:00` |
+| List | `tags: [one, two]` or YAML list syntax |
+| Links | `related: "[[Other Note]]"` |
+
+## Default Properties
+
+- **`tags`** — Searchable labels, shown in graph view and tag pane
+- **`aliases`** — Alternative names for the note (used in link suggestions and search)
+- **`cssclasses`** — CSS classes applied to the note in reading/editing view
+
+## Tags
+
+### Inline Tags
+
+```markdown
+#tag
+#nested/tag
+#tag-with-dashes
+#tag_with_underscores
+```
+
+### Frontmatter Tags
+
+```yaml
+---
+tags:
+  - tag1
+  - nested/tag2
+---
+```
+
+### Tag Rules
+
+Tags can contain:
+- Letters (any language/script)
+- Numbers (not as first character)
+- Underscores `_`
+- Hyphens `-`
+- Forward slashes `/` (for nesting)
+
+Tags **cannot** contain spaces or other special characters.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Skills, custom agents, AGENTS.md templates, and MCP configurations for AI coding
 
 > **Blog post:** [Context-Driven Development: Agent Skills for Microsoft Foundry and Azure](https://devblogs.microsoft.com/all-things-azure/context-driven-development-agent-skills-for-microsoft-foundry-and-azure/)
 
-> **🔍 Skill Explorer:** [Browse all 132 skills with 1-click install](https://microsoft.github.io/skills/)
+> **🔍 Skill Explorer:** [Browse all 133 skills with 1-click install](https://microsoft.github.io/skills/)
 
 ## Quick Start
 
@@ -70,11 +70,11 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 ## Skill Catalog
 
-> 132 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
+> 133 skills in `.github/skills/` — flat structure with language suffixes for automatic discovery
 
 | Language | Count | Suffix | 
 |----------|-------|--------|
-| [Core](#core) | 9 | — |
+| [Core](#core) | 10 | — |
 | [Python](#python) | 41 | `-py` |
 | [.NET](#net) | 28 | `-dotnet` |
 | [TypeScript](#typescript) | 25 | `-ts` |
@@ -85,7 +85,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 ### Core
 
-> 9 skills — tooling, infrastructure, language-agnostic
+> 10 skills — tooling, infrastructure, language-agnostic
 
 | Skill | Description |
 |-------|-------------|
@@ -95,6 +95,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 | [frontend-design-review](.github/skills/frontend-design-review/) | Review and create distinctive frontend interfaces. Design system compliance, quality pillars, accessibility, and creative aesthetics. |
 | [github-issue-creator](.github/skills/github-issue-creator/) | Convert raw notes, error logs, or screenshots into structured GitHub issues. |
 | [mcp-builder](.github/skills/mcp-builder/) | Build MCP servers for LLM tool integration. Python (FastMCP), Node/TypeScript, or C#/.NET. |
+| [obsidian](.github/skills/obsidian/) | Interact with Obsidian vaults — CLI operations, Obsidian Flavored Markdown, Bases databases, and JSON Canvas files. |
 | [podcast-generation](.github/skills/podcast-generation/) | Generate podcast-style audio with Azure OpenAI Realtime API. Full-stack React + FastAPI + WebSocket. |
 | [skill-creator](.github/skills/skill-creator/) | Guide for creating effective skills for AI coding agents. |
 
@@ -631,11 +632,11 @@ pnpm test
 
 ### Test Coverage Summary
 
-**128 skills with 1158 test scenarios** — all skills have acceptance criteria and test scenarios.
+**129 skills with 1168 test scenarios** — all skills have acceptance criteria and test scenarios.
 
 | Language | Skills | Scenarios | Top Skills by Scenarios |
 |----------|--------|-----------|-------------------------|
-| Core | 7 | 72 | `copilot-sdk` (11), `podcast-generation` (8), `skill-creator` (8) |
+| Core | 8 | 82 | `copilot-sdk` (11), `obsidian` (10), `podcast-generation` (8) |
 | Python | 41 | 331 | `azure-ai-projects-py` (12), `pydantic-models-py` (12), `azure-ai-translation-text-py` (11) |
 | .NET | 29 | 290 | `azure-resource-manager-sql-dotnet` (14), `azure-resource-manager-redis-dotnet` (14), `azure-servicebus-dotnet` (13) |
 | TypeScript | 25 | 270 | `azure-storage-blob-ts` (17), `azure-servicebus-ts` (14), `aspire-ts` (13) |

--- a/tests/scenarios/obsidian/scenarios.yaml
+++ b/tests/scenarios/obsidian/scenarios.yaml
@@ -1,0 +1,236 @@
+config:
+  model: gpt-4
+  max_tokens: 2000
+  temperature: 0.3
+
+scenarios:
+  - name: cli_read_note
+    prompt: |
+      Read the contents of a note at "projects/roadmap.md" from my Obsidian vault using the CLI.
+    expected_patterns:
+      - "obsidian read"
+      - 'path="projects/roadmap.md"'
+    forbidden_patterns:
+      - "/Users/"
+      - "/home/"
+      - "cat "
+    tags:
+      - cli
+      - basic
+    mock_response: |
+      To read the note, run:
+      ```bash
+      obsidian read path="projects/roadmap.md"
+      ```
+      This prints the raw markdown content of the note to stdout. The path is vault-relative.
+
+  - name: cli_daily_append_task
+    prompt: |
+      Add a new task "Review PR #42" to my daily note in Obsidian.
+    expected_patterns:
+      - "daily:append"
+      - "content="
+      - "[ ]"
+    forbidden_patterns:
+      - "daily:prepend"
+      - "append path="
+    tags:
+      - cli
+      - daily
+    mock_response: |
+      ```bash
+      obsidian daily:append content="- [ ] Review PR #42"
+      ```
+      This appends the task to the end of today's daily note.
+
+  - name: cli_create_from_template
+    prompt: |
+      Create a new note called "Trip to Tokyo" using my "Travel" template in Obsidian.
+    expected_patterns:
+      - "obsidian create"
+      - 'template='
+      - "Travel"
+    forbidden_patterns:
+      - ".md"
+      - "template:insert"
+    tags:
+      - cli
+      - templates
+    mock_response: |
+      ```bash
+      obsidian create path="Trip to Tokyo" template="Travel"
+      ```
+      Note: `create` automatically appends `.md` — don't include the extension in the path.
+
+  - name: cli_search_json
+    prompt: |
+      Search my vault for notes about "architecture decisions" and return results as JSON.
+    expected_patterns:
+      - "obsidian search"
+      - "query="
+      - "format=json"
+    forbidden_patterns:
+      - "grep"
+      - "find "
+    tags:
+      - cli
+      - search
+    mock_response: |
+      ```bash
+      obsidian search query="architecture decisions" format=json
+      ```
+      This returns a JSON array of matching file paths: `["folder/note.md", ...]`
+
+  - name: markdown_wikilinks
+    prompt: |
+      Create a note about Project Alpha that links to related notes "Design Spec" and "Meeting Notes" using Obsidian syntax.
+    expected_patterns:
+      - "[["
+      - "]]"
+    forbidden_patterns:
+      - "](Design"
+      - ".md)"
+    tags:
+      - markdown
+      - wikilinks
+    mock_response: |
+      ```markdown
+      ---
+      title: Project Alpha
+      tags:
+        - project
+      ---
+
+      # Project Alpha
+
+      See the [[Design Spec]] for technical details.
+
+      Discussed in [[Meeting Notes#Decisions]].
+      ```
+
+  - name: markdown_callout
+    prompt: |
+      Add a warning callout to an Obsidian note about a deadline.
+    expected_patterns:
+      - "> [!warning]"
+    forbidden_patterns:
+      - "**Warning:**"
+      - "> Warning:"
+    tags:
+      - markdown
+      - callouts
+    mock_response: |
+      ```markdown
+      > [!warning] Deadline Approaching
+      > The submission deadline is ==Friday at 5 PM==. Ensure all reviews are complete.
+      ```
+
+  - name: bases_task_tracker
+    prompt: |
+      Create an Obsidian Base file (.base) that shows all notes tagged "task" in a table with name, status, and due date columns.
+    expected_patterns:
+      - "file.hasTag"
+      - "task"
+      - "type: table"
+      - "order:"
+      - "file.name"
+    forbidden_patterns:
+      - "dataview"
+      - "```dataview"
+    tags:
+      - bases
+      - basic
+    mock_response: |
+      ```yaml
+      filters:
+        and:
+          - file.hasTag("task")
+          - 'file.ext == "md"'
+
+      views:
+        - type: table
+          name: "Tasks"
+          order:
+            - file.name
+            - status
+            - due
+      ```
+
+  - name: bases_formula_duration
+    prompt: |
+      Create an Obsidian Base formula that calculates how many days until a due date property.
+    expected_patterns:
+      - "formulas:"
+      - "today()"
+      - ".days"
+      - "if("
+    forbidden_patterns:
+      - ".round(0)\"" 
+      - "/ 86400"
+    tags:
+      - bases
+      - formulas
+    mock_response: |
+      ```yaml
+      formulas:
+        days_until_due: 'if(due, (date(due) - today()).days, "")'
+      ```
+      Key points:
+      - Guard with `if()` since `due` may be empty
+      - Subtracting dates returns a Duration — access `.days` for the number
+      - Duration does NOT support `.round()` directly; use `.days.round(0)` if needed
+
+  - name: canvas_create_mindmap
+    prompt: |
+      Create a JSON Canvas mind map with a central "Project Plan" node connected to three subtopics.
+    expected_patterns:
+      - '"nodes"'
+      - '"edges"'
+      - '"type": "text"'
+      - '"fromNode"'
+      - '"toNode"'
+    forbidden_patterns:
+      - '"type": "canvas"'
+      - "mermaid"
+    tags:
+      - canvas
+      - basic
+    mock_response: |
+      ```json
+      {
+        "nodes": [
+          {"id": "a1b2c3d4e5f67890", "type": "text", "x": 0, "y": 0, "width": 300, "height": 150, "text": "# Project Plan"},
+          {"id": "b2c3d4e5f6789012", "type": "text", "x": 400, "y": -120, "width": 250, "height": 100, "text": "## Design"},
+          {"id": "c3d4e5f678901234", "type": "text", "x": 400, "y": 0, "width": 250, "height": 100, "text": "## Development"},
+          {"id": "d4e5f6789012345a", "type": "text", "x": 400, "y": 120, "width": 250, "height": 100, "text": "## Testing"}
+        ],
+        "edges": [
+          {"id": "e5f6789012345abc", "fromNode": "a1b2c3d4e5f67890", "fromSide": "right", "toNode": "b2c3d4e5f6789012", "toSide": "left"},
+          {"id": "f6789012345abcde", "fromNode": "a1b2c3d4e5f67890", "fromSide": "right", "toNode": "c3d4e5f678901234", "toSide": "left"},
+          {"id": "789012345abcdef0", "fromNode": "a1b2c3d4e5f67890", "fromSide": "right", "toNode": "d4e5f6789012345a", "toSide": "left"}
+        ]
+      }
+      ```
+
+  - name: cli_vault_relative_paths
+    prompt: |
+      How do I read a file at /Users/me/obsidian-vault/notes/readme.md using the Obsidian CLI?
+    expected_patterns:
+      - "vault-relative"
+      - "obsidian read"
+      - 'path="notes/readme.md"'
+    forbidden_patterns:
+      - "/Users/me/"
+      - "cat "
+      - "open "
+    tags:
+      - cli
+      - paths
+    mock_response: |
+      The Obsidian CLI uses **vault-relative paths**, not absolute filesystem paths:
+
+      ```bash
+      obsidian read path="notes/readme.md"
+      ```
+
+      All paths are relative to the vault root. Do not use absolute paths like `/Users/me/obsidian-vault/...`.


### PR DESCRIPTION
## Summary

Adds a comprehensive **obsidian** skill (cross-language/core) covering four Obsidian domains:

### SKILL.md (292 lines)
Distilled quick references for CLI operations, Obsidian Flavored Markdown, Bases databases, and JSON Canvas files.

### 8 Reference Files
| File | Lines | Contents |
|------|-------|----------|
| `cli-commands.md` | 452 | Full 130+ command reference with parameters and troubleshooting |
| `bases-guide.md` | 361 | YAML schema, filters, formulas, views, complete examples |
| `bases-functions.md` | 162 | All functions by type (Date, String, Number, List, File, Duration) |
| `json-canvas.md` | 232 | Spec, nodes/edges, layout guidelines, mind map & project board examples |
| `markdown-syntax.md` | 233 | Wikilinks, embeds, callouts, properties, tags, math, Mermaid |
| `callouts.md` | 60 | All 13 callout types with aliases and CSS customization |
| `embeds.md` | 72 | Notes, images, audio, video, PDF, search embeds |
| `properties.md` | 72 | Frontmatter types and tag rules |

### Testing
- `acceptance-criteria.md` — 20 correct/incorrect patterns across all 4 domains
- `scenarios.yaml` — 10 test scenarios (CLI, Markdown, Bases, Canvas)

### README Updates
- Skill count: 132 → 133
- Core count: 9 → 10
- Test coverage: 128 → 129 skills, 1158 → 1168 scenarios

## Context
Obsidian CLI was released in v1.12 (Feb 2026). This skill enables AI agents to interact with Obsidian vaults via CLI, write Obsidian-specific Markdown, create .base database files, and author .canvas visual files.