### PR TITLE
feat: add block-no-verify hook to prevent git hook bypass

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,15 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
         "matcher": "Task",
         "hooks": [
           {

--- a/Agents.md
+++ b/Agents.md
@@ -87,6 +87,18 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ---
 
+## Git Hook Safety
+
+**Never bypass git hooks.**
+
+- Do not use `--no-verify` on `git commit` or `git push`
+- Do not override `core.hooksPath` to disable hooks
+- If a hook fails, fix the underlying issue — do not skip the hook
+
+Git hooks enforce quality gates (tests, linting, secret scanning). Bypassing them defeats those safeguards. The `.claude/settings.json` in this repo includes [`block-no-verify`](https://github.com/tupe12334/block-no-verify) to enforce this automatically.
+
+---
+
 ## Clean Architecture
 
 Follow these layered boundaries when building features:


### PR DESCRIPTION
## Summary

- Adds `block-no-verify@1.1.2` as a PreToolUse hook in `.claude/settings.json` to block git commands that attempt to bypass hooks
- Documents the git hook safety policy in `Agents.md` under a new "Git Hook Safety" section

## Problem

The current `.claude/settings.json` has PreToolUse hooks for `Task` — but nothing prevents an agent from using the bypass flags on `git commit` or `git push`, which silently skips all pre-commit/pre-push hooks (tests, linting, secret scanning, etc).

## Solution

[`block-no-verify`](https://github.com/tupe12334/block-no-verify) is a purpose-built hook that reads Claude Code's PreToolUse stdin payload and exits non-zero if it detects:

- The `--no-verify` flag on any git subcommand
- The `-n` shorthand on `git commit`
- A `core.hooksPath` override pointing to `/dev/null`

Zero configuration — just add it as a `Bash` PreToolUse hook.

## Changes

```
.claude/settings.json  — add block-no-verify Bash PreToolUse hook
Agents.md              — add Git Hook Safety section
```

## Test plan

- [ ] Run `git commit` normally — should pass through
- [ ] Run `git commit` with bypass flags — should be blocked with a clear message
- [ ] Verify `Agents.md` renders cleanly in GitHub

Closes #202
