### PR TITLE
Add global-chat-mcp-ts skill for cross-protocol agent discovery

### DIFF
--- a/.github/skills/global-chat-mcp-ts/SKILL.md
+++ b/.github/skills/global-chat-mcp-ts/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: global-chat-mcp-ts
+description: Discover and search AI agents across MCP, A2A, and agents.txt protocols. Use when finding MCP servers, searching agent registries, validating agents.txt files, looking up agent capabilities across protocols, or building multi-agent systems that need discovery. TypeScript MCP server.
+---
+
+# Global Chat — Cross-Protocol Agent Discovery
+
+Search and discover AI agents across MCP, A2A, agents.txt, and other protocols from a single MCP server. Aggregates 18K+ MCP servers across 6+ registries with cross-search.
+
+## When to Use
+
+- Finding MCP servers for a specific capability or domain
+- Searching agent registries across multiple protocols
+- Validating an agents.txt file against the specification
+- Looking up agent metadata, endpoints, or capabilities
+- Building multi-agent systems that need runtime discovery
+
+## Quick Start
+
+```json
+{
+  "mcpServers": {
+    "global-chat": {
+      "command": "npx",
+      "args": ["-y", "@global-chat/mcp-server"]
+    }
+  }
+}
+```
+
+No API key required. Works with Copilot, VS Code, Claude Code, Cursor, and any MCP client.
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `search_mcp_servers` | Search across 18K+ MCP servers by keyword, category, or capability |
+| `get_mcp_server` | Get detailed info for a specific MCP server (config, tools, setup) |
+| `search_a2a_agents` | Search agents using Google's Agent-to-Agent protocol |
+| `validate_agents_txt` | Validate an agents.txt file against the specification |
+| `get_agents_txt` | Fetch and parse an agents.txt file from any domain |
+
+## Example Workflows
+
+### Find MCP servers for a task
+
+```
+Agent: "I need to interact with GitHub repositories"
+→ search_mcp_servers({ query: "github" })
+→ Returns matching servers with install configs
+```
+
+### Validate agents.txt before deploying
+
+```
+Agent: "Check if our agents.txt is valid"
+→ validate_agents_txt({ url: "https://example.com/agents.txt" })
+→ Returns validation results with errors and warnings
+```
+
+### Discover A2A agents
+
+```
+Agent: "Find agents that can process invoices"
+→ search_a2a_agents({ query: "invoice processing" })
+→ Returns A2A-compatible agents with endpoints
+```
+
+## Supported Protocols
+
+| Protocol | Description |
+|----------|-------------|
+| MCP | Model Context Protocol — tool integration for LLMs |
+| A2A | Google Agent-to-Agent — inter-agent communication |
+| agents.txt | Web standard for publishing agent capabilities |
+
+## Resources
+
+- Website: https://global-chat.io
+- npm: https://www.npmjs.com/package/@global-chat/mcp-server
+- GitHub: https://github.com/pumanitro/global-chat
+- agents.txt validator: https://global-chat.io/agents-txt

--- a/.github/skills/global-chat-mcp-ts/references/mcp-config.md
+++ b/.github/skills/global-chat-mcp-ts/references/mcp-config.md
@@ -1,0 +1,103 @@
+# MCP Server Configuration
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "global-chat": {
+      "command": "npx",
+      "args": ["-y", "@global-chat/mcp-server"]
+    }
+  }
+}
+```
+
+No environment variables or API keys required.
+
+## Agent Configurations
+
+### GitHub Copilot (VS Code)
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "global-chat": {
+      "command": "npx",
+      "args": ["-y", "@global-chat/mcp-server"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to `.claude/settings.json` or use:
+
+```bash
+claude mcp add global-chat -- npx -y @global-chat/mcp-server
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "global-chat": {
+      "command": "npx",
+      "args": ["-y", "@global-chat/mcp-server"]
+    }
+  }
+}
+```
+
+## Tool Details
+
+### search_mcp_servers
+
+Search the aggregated directory of MCP servers.
+
+**Parameters:**
+- `query` (string, required) — Search term (e.g., "database", "github", "slack")
+
+**Returns:** Array of matching MCP servers with name, description, install command, and source registry.
+
+### get_mcp_server
+
+Get detailed information about a specific MCP server.
+
+**Parameters:**
+- `name` (string, required) — Server name or package name
+
+**Returns:** Full server metadata including tools list, configuration, and setup instructions.
+
+### search_a2a_agents
+
+Search agents using Google's Agent-to-Agent protocol.
+
+**Parameters:**
+- `query` (string, required) — Search term for agent capabilities
+
+**Returns:** Array of A2A-compatible agents with endpoints and capability descriptions.
+
+### validate_agents_txt
+
+Validate an agents.txt file against the specification.
+
+**Parameters:**
+- `url` (string, required) — URL of the agents.txt file to validate
+
+**Returns:** Validation report with errors, warnings, and parsed agent entries.
+
+### get_agents_txt
+
+Fetch and parse an agents.txt file from a domain.
+
+**Parameters:**
+- `domain` (string, required) — Domain to fetch agents.txt from
+
+**Returns:** Parsed agents.txt content with all agent entries and metadata.


### PR DESCRIPTION
Adds a TypeScript MCP skill for [Global Chat](https://global-chat.io) — a cross-protocol agent discovery platform.

## Use case

AI agents building multi-agent systems or searching for MCP servers currently need to query individual registries one by one. This skill provides a single MCP server that aggregates 18K+ MCP servers across 6+ registries and supports searching across MCP, A2A, and agents.txt protocols.

## Contents

- `.github/skills/global-chat-mcp-ts/SKILL.md` with tool documentation and example workflows
- `.github/skills/global-chat-mcp-ts/references/mcp-config.md` with setup for Copilot, Claude Code, and Cursor

## Why this fits

- TypeScript MCP server following the `-ts` suffix convention
- npm package (`@global-chat/mcp-server`) compatible with Copilot, VS Code, Claude Code, Cursor
- No API key required — works out of the box with `npx -y @global-chat/mcp-server`
- 5 tools: search MCP servers, get server details, search A2A agents, validate agents.txt, fetch agents.txt
- Solves the fragmented agent registry problem — agents can discover other agents across protocols

## Links

- npm: https://www.npmjs.com/package/@global-chat/mcp-server
- Website: https://global-chat.io
- GitHub: https://github.com/pumanitro/global-chat
- agents.txt validator: https://global-chat.io/agents-txt