### PR TITLE
Update Python skills auth

### DIFF
--- a/.github/plugins/azure-sdk-python/skills/agent-framework-azure-ai-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/agent-framework-azure-ai-py/SKILL.md
@@ -40,7 +40,7 @@ pip install agent-framework-azure-ai --pre
 export AZURE_AI_PROJECT_ENDPOINT="https://<project>.services.ai.azure.com/api/projects/<project-id>"
 export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
 export BING_CONNECTION_ID="your-bing-connection-id"  # For web search
-AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
+export AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication

--- a/.github/plugins/azure-sdk-python/skills/agent-framework-azure-ai-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/agent-framework-azure-ai-py/SKILL.md
@@ -40,18 +40,23 @@ pip install agent-framework-azure-ai --pre
 export AZURE_AI_PROJECT_ENDPOINT="https://<project>.services.ai.azure.com/api/projects/<project-id>"
 export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
 export BING_CONNECTION_ID="your-bing-connection-id"  # For web search
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity.aio import AzureCliCredential, DefaultAzureCredential
+from azure.identity.aio import AzureCliCredential, DefaultAzureCredential, ManagedIdentityCredential
 
 # Development
 credential = AzureCliCredential()
 
 # Production
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 ```
 
 ## Core Workflow

--- a/.github/plugins/azure-sdk-python/skills/agent-framework-azure-ai-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/agent-framework-azure-ai-py/SKILL.md
@@ -37,8 +37,8 @@ pip install agent-framework-azure-ai --pre
 ## Environment Variables
 
 ```bash
-export AZURE_AI_PROJECT_ENDPOINT="https://<project>.services.ai.azure.com/api/projects/<project-id>"
-export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
+export AZURE_AI_PROJECT_ENDPOINT="https://<project>.services.ai.azure.com/api/projects/<project-id>"  # Required for all auth methods
+export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"  # Required for all auth methods
 export BING_CONNECTION_ID="your-bing-connection-id"  # For web search
 export AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```

--- a/.github/plugins/azure-sdk-python/skills/agents-v2-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/agents-v2-py/SKILL.md
@@ -28,6 +28,7 @@ pip install azure-ai-projects>=2.0.0b3 azure-identity
 
 ```bash
 AZURE_AI_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Prerequisites
@@ -44,10 +45,14 @@ Before creating hosted agents:
 Always use `DefaultAzureCredential`:
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.ai.projects import AIProjectClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = AIProjectClient(
     endpoint=os.environ["AZURE_AI_PROJECT_ENDPOINT"],
     credential=credential

--- a/.github/plugins/azure-sdk-python/skills/agents-v2-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/agents-v2-py/SKILL.md
@@ -27,7 +27,7 @@ pip install azure-ai-projects>=2.0.0b3 azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_AI_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+AZURE_AI_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-contentsafety-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-contentsafety-py/SKILL.md
@@ -23,8 +23,8 @@ pip install azure-ai-contentsafety
 ## Environment Variables
 
 ```bash
-CONTENT_SAFETY_ENDPOINT=https://<resource>.cognitiveservices.azure.com
-CONTENT_SAFETY_KEY=<your-api-key>
+CONTENT_SAFETY_ENDPOINT=https://<resource>.cognitiveservices.azure.com  # Required for all auth methods
+CONTENT_SAFETY_KEY=<your-api-key>  # Only required for AzureKeyCredential auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-contentsafety-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-contentsafety-py/SKILL.md
@@ -25,6 +25,7 @@ pip install azure-ai-contentsafety
 ```bash
 CONTENT_SAFETY_ENDPOINT=https://<resource>.cognitiveservices.azure.com
 CONTENT_SAFETY_KEY=<your-api-key>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -46,11 +47,16 @@ client = ContentSafetyClient(
 
 ```python
 from azure.ai.contentsafety import ContentSafetyClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = ContentSafetyClient(
     endpoint=os.environ["CONTENT_SAFETY_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-contentunderstanding-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-contentunderstanding-py/SKILL.md
@@ -23,7 +23,7 @@ pip install azure-ai-contentunderstanding
 ## Environment Variables
 
 ```bash
-CONTENTUNDERSTANDING_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+CONTENTUNDERSTANDING_ENDPOINT=https://<resource>.cognitiveservices.azure.com/  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-contentunderstanding-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-contentunderstanding-py/SKILL.md
@@ -24,6 +24,7 @@ pip install azure-ai-contentunderstanding
 
 ```bash
 CONTENTUNDERSTANDING_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -31,10 +32,14 @@ CONTENTUNDERSTANDING_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
 ```python
 import os
 from azure.ai.contentunderstanding import ContentUnderstandingClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 
 endpoint = os.environ["CONTENTUNDERSTANDING_ENDPOINT"]
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = ContentUnderstandingClient(endpoint=endpoint, credential=credential)
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-ml-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-ml-py/SKILL.md
@@ -23,9 +23,9 @@ pip install azure-ai-ml
 ## Environment Variables
 
 ```bash
-AZURE_SUBSCRIPTION_ID=<your-subscription-id>
-AZURE_RESOURCE_GROUP=<your-resource-group>
-AZURE_ML_WORKSPACE_NAME=<your-workspace-name>
+AZURE_SUBSCRIPTION_ID=<your-subscription-id>  # Required for all auth methods
+AZURE_RESOURCE_GROUP=<your-resource-group>  # Required for all auth methods
+AZURE_ML_WORKSPACE_NAME=<your-workspace-name>  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-ml-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-ml-py/SKILL.md
@@ -26,16 +26,23 @@ pip install azure-ai-ml
 AZURE_SUBSCRIPTION_ID=<your-subscription-id>
 AZURE_RESOURCE_GROUP=<your-resource-group>
 AZURE_ML_WORKSPACE_NAME=<your-workspace-name>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
 from azure.ai.ml import MLClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+import os
 
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 ml_client = MLClient(
-    credential=DefaultAzureCredential(),
+    credential=credential,
     subscription_id=os.environ["AZURE_SUBSCRIPTION_ID"],
     resource_group_name=os.environ["AZURE_RESOURCE_GROUP"],
     workspace_name=os.environ["AZURE_ML_WORKSPACE_NAME"]

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-projects-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-projects-py/SKILL.md
@@ -21,8 +21,8 @@ pip install azure-ai-projects azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_AI_PROJECT_ENDPOINT="https://<resource>.services.ai.azure.com/api/projects/<project>"
-AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
+AZURE_AI_PROJECT_ENDPOINT="https://<resource>.services.ai.azure.com/api/projects/<project>"  # Required for all auth methods
+AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-projects-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-projects-py/SKILL.md
@@ -23,16 +23,21 @@ pip install azure-ai-projects azure-identity
 ```bash
 AZURE_AI_PROJECT_ENDPOINT="https://<resource>.services.ai.azure.com/api/projects/<project>"
 AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
 import os
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.ai.projects import AIProjectClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = AIProjectClient(
     endpoint=os.environ["AZURE_AI_PROJECT_ENDPOINT"],
     credential=credential,

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-textanalytics-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-textanalytics-py/SKILL.md
@@ -25,6 +25,7 @@ pip install azure-ai-textanalytics
 ```bash
 AZURE_LANGUAGE_ENDPOINT=https://<resource>.cognitiveservices.azure.com
 AZURE_LANGUAGE_KEY=<your-api-key>  # If using API key
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -46,11 +47,16 @@ client = TextAnalyticsClient(endpoint, AzureKeyCredential(key))
 
 ```python
 from azure.ai.textanalytics import TextAnalyticsClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = TextAnalyticsClient(
     endpoint=os.environ["AZURE_LANGUAGE_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-textanalytics-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-textanalytics-py/SKILL.md
@@ -23,8 +23,8 @@ pip install azure-ai-textanalytics
 ## Environment Variables
 
 ```bash
-AZURE_LANGUAGE_ENDPOINT=https://<resource>.cognitiveservices.azure.com
-AZURE_LANGUAGE_KEY=<your-api-key>  # If using API key
+AZURE_LANGUAGE_ENDPOINT=https://<resource>.cognitiveservices.azure.com  # Required for all auth methods
+AZURE_LANGUAGE_KEY=<your-api-key>  # Only required for AzureKeyCredential auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-translation-document-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-translation-document-py/SKILL.md
@@ -23,12 +23,11 @@ pip install azure-ai-translation-document
 ## Environment Variables
 
 ```bash
-AZURE_DOCUMENT_TRANSLATION_ENDPOINT=https://<resource>.cognitiveservices.azure.com
-AZURE_DOCUMENT_TRANSLATION_KEY=<your-api-key>  # If using API key
-
+AZURE_DOCUMENT_TRANSLATION_ENDPOINT=https://<resource>.cognitiveservices.azure.com  # Required for all auth methods
+AZURE_DOCUMENT_TRANSLATION_KEY=<your-api-key>  # Only required for AzureKeyCredential auth
 # Storage for source and target documents
-AZURE_SOURCE_CONTAINER_URL=https://<storage>.blob.core.windows.net/<container>?<sas>
-AZURE_TARGET_CONTAINER_URL=https://<storage>.blob.core.windows.net/<container>?<sas>
+AZURE_SOURCE_CONTAINER_URL=https://<storage>.blob.core.windows.net/<container>?<sas>  # Required for all auth methods
+AZURE_TARGET_CONTAINER_URL=https://<storage>.blob.core.windows.net/<container>?<sas>  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-translation-document-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-translation-document-py/SKILL.md
@@ -29,6 +29,7 @@ AZURE_DOCUMENT_TRANSLATION_KEY=<your-api-key>  # If using API key
 # Storage for source and target documents
 AZURE_SOURCE_CONTAINER_URL=https://<storage>.blob.core.windows.net/<container>?<sas>
 AZURE_TARGET_CONTAINER_URL=https://<storage>.blob.core.windows.net/<container>?<sas>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -50,11 +51,16 @@ client = DocumentTranslationClient(endpoint, AzureKeyCredential(key))
 
 ```python
 from azure.ai.translation.document import DocumentTranslationClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = DocumentTranslationClient(
     endpoint=os.environ["AZURE_DOCUMENT_TRANSLATION_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-translation-text-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-translation-text-py/SKILL.md
@@ -23,10 +23,10 @@ pip install azure-ai-translation-text
 ## Environment Variables
 
 ```bash
-AZURE_TRANSLATOR_KEY=<your-api-key>
-AZURE_TRANSLATOR_REGION=<your-region>  # e.g., eastus, westus2
+AZURE_TRANSLATOR_KEY=<your-api-key>  # Only required for AzureKeyCredential auth
+AZURE_TRANSLATOR_REGION=<your-region>  # e.g., eastus, westus2; required with API key auth
 # Or use custom endpoint
-AZURE_TRANSLATOR_ENDPOINT=https://<resource>.cognitiveservices.azure.com
+AZURE_TRANSLATOR_ENDPOINT=https://<resource>.cognitiveservices.azure.com  # Required for Entra ID auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-translation-text-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-translation-text-py/SKILL.md
@@ -27,6 +27,7 @@ AZURE_TRANSLATOR_KEY=<your-api-key>
 AZURE_TRANSLATOR_REGION=<your-region>  # e.g., eastus, westus2
 # Or use custom endpoint
 AZURE_TRANSLATOR_ENDPOINT=https://<resource>.cognitiveservices.azure.com
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -60,11 +61,18 @@ client = TextTranslationClient(
 ### Entra ID (Recommended)
 
 ```python
+import os
 from azure.ai.translation.text import TextTranslationClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 client = TextTranslationClient(
-    credential=DefaultAzureCredential(),
+    credential=credential,
     endpoint=os.environ["AZURE_TRANSLATOR_ENDPOINT"]
 )
 ```

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-vision-imageanalysis-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-vision-imageanalysis-py/SKILL.md
@@ -23,8 +23,8 @@ pip install azure-ai-vision-imageanalysis
 ## Environment Variables
 
 ```bash
-VISION_ENDPOINT=https://<resource>.cognitiveservices.azure.com
-VISION_KEY=<your-api-key>  # If using API key
+VISION_ENDPOINT=https://<resource>.cognitiveservices.azure.com  # Required for all auth methods
+VISION_KEY=<your-api-key>  # Only required for AzureKeyCredential auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-vision-imageanalysis-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-vision-imageanalysis-py/SKILL.md
@@ -25,6 +25,7 @@ pip install azure-ai-vision-imageanalysis
 ```bash
 VISION_ENDPOINT=https://<resource>.cognitiveservices.azure.com
 VISION_KEY=<your-api-key>  # If using API key
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -48,12 +49,19 @@ client = ImageAnalysisClient(
 ### Entra ID (Recommended)
 
 ```python
+import os
 from azure.ai.vision.imageanalysis import ImageAnalysisClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 client = ImageAnalysisClient(
     endpoint=os.environ["VISION_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-voicelive-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-voicelive-py/SKILL.md
@@ -24,18 +24,26 @@ pip install azure-ai-voicelive aiohttp azure-identity
 AZURE_COGNITIVE_SERVICES_ENDPOINT=https://<region>.api.cognitive.microsoft.com
 # For API key auth (not recommended for production)
 AZURE_COGNITIVE_SERVICES_KEY=<api-key>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 **DefaultAzureCredential (preferred)**:
 ```python
+import os
 from azure.ai.voicelive.aio import connect
-from azure.identity.aio import DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 async with connect(
     endpoint=os.environ["AZURE_COGNITIVE_SERVICES_ENDPOINT"],
-    credential=DefaultAzureCredential(),
+    credential=credential,
     model="gpt-4o-realtime-preview",
     credential_scopes=["https://cognitiveservices.azure.com/.default"]
 ) as conn:

--- a/.github/plugins/azure-sdk-python/skills/azure-ai-voicelive-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-ai-voicelive-py/SKILL.md
@@ -21,9 +21,9 @@ pip install azure-ai-voicelive aiohttp azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_COGNITIVE_SERVICES_ENDPOINT=https://<region>.api.cognitive.microsoft.com
+AZURE_COGNITIVE_SERVICES_ENDPOINT=https://<region>.api.cognitive.microsoft.com  # Required for all auth methods
 # For API key auth (not recommended for production)
-AZURE_COGNITIVE_SERVICES_KEY=<api-key>
+AZURE_COGNITIVE_SERVICES_KEY=<api-key>  # Only required for AzureKeyCredential auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-appconfiguration-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-appconfiguration-py/SKILL.md
@@ -23,9 +23,9 @@ pip install azure-appconfiguration
 ## Environment Variables
 
 ```bash
-AZURE_APPCONFIGURATION_CONNECTION_STRING=Endpoint=https://<name>.azconfig.io;Id=...;Secret=...
+AZURE_APPCONFIGURATION_CONNECTION_STRING=Endpoint=https://<name>.azconfig.io;Id=...;Secret=...  # Alternative to Entra ID auth
 # Or for Entra ID:
-AZURE_APPCONFIGURATION_ENDPOINT=https://<name>.azconfig.io
+AZURE_APPCONFIGURATION_ENDPOINT=https://<name>.azconfig.io  # Required for Entra ID auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-appconfiguration-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-appconfiguration-py/SKILL.md
@@ -26,6 +26,7 @@ pip install azure-appconfiguration
 AZURE_APPCONFIGURATION_CONNECTION_STRING=Endpoint=https://<name>.azconfig.io;Id=...;Secret=...
 # Or for Entra ID:
 AZURE_APPCONFIGURATION_ENDPOINT=https://<name>.azconfig.io
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -43,12 +44,19 @@ client = AzureAppConfigurationClient.from_connection_string(
 ### Entra ID
 
 ```python
+import os
 from azure.appconfiguration import AzureAppConfigurationClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 client = AzureAppConfigurationClient(
     base_url=os.environ["AZURE_APPCONFIGURATION_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-containerregistry-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-containerregistry-py/SKILL.md
@@ -23,7 +23,7 @@ pip install azure-containerregistry
 ## Environment Variables
 
 ```bash
-AZURE_CONTAINERREGISTRY_ENDPOINT=https://<registry-name>.azurecr.io
+AZURE_CONTAINERREGISTRY_ENDPOINT=https://<registry-name>.azurecr.io  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-containerregistry-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-containerregistry-py/SKILL.md
@@ -24,6 +24,7 @@ pip install azure-containerregistry
 
 ```bash
 AZURE_CONTAINERREGISTRY_ENDPOINT=https://<registry-name>.azurecr.io
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -31,12 +32,19 @@ AZURE_CONTAINERREGISTRY_ENDPOINT=https://<registry-name>.azurecr.io
 ### Entra ID (Recommended)
 
 ```python
+import os
 from azure.containerregistry import ContainerRegistryClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 client = ContainerRegistryClient(
     endpoint=os.environ["AZURE_CONTAINERREGISTRY_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-cosmos-db-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-cosmos-db-py/SKILL.md
@@ -21,11 +21,11 @@ pip install azure-cosmos azure-identity
 ## Environment Variables
 
 ```bash
-COSMOS_ENDPOINT=https://<account>.documents.azure.com:443/
-COSMOS_DATABASE_NAME=<database-name>
-COSMOS_CONTAINER_ID=<container-id>
+COSMOS_ENDPOINT=https://<account>.documents.azure.com:443/  # Required for all auth methods
+COSMOS_DATABASE_NAME=<database-name>  # Required for all auth methods
+COSMOS_CONTAINER_ID=<container-id>  # Required for all auth methods
 # For emulator only (not production)
-COSMOS_KEY=<emulator-key>
+COSMOS_KEY=<emulator-key>  # Only required for key-based auth or emulator
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-cosmos-db-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-cosmos-db-py/SKILL.md
@@ -26,18 +26,26 @@ COSMOS_DATABASE_NAME=<database-name>
 COSMOS_CONTAINER_ID=<container-id>
 # For emulator only (not production)
 COSMOS_KEY=<emulator-key>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 **DefaultAzureCredential (preferred)**:
 ```python
+import os
 from azure.cosmos import CosmosClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 client = CosmosClient(
     url=os.environ["COSMOS_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-cosmos-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-cosmos-py/SKILL.md
@@ -26,15 +26,22 @@ pip install azure-cosmos azure-identity
 COSMOS_ENDPOINT=https://<account>.documents.azure.com:443/
 COSMOS_DATABASE=mydb
 COSMOS_CONTAINER=mycontainer
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+import os
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.cosmos import CosmosClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 endpoint = "https://<account>.documents.azure.com:443/"
 
 client = CosmosClient(url=endpoint, credential=credential)

--- a/.github/plugins/azure-sdk-python/skills/azure-cosmos-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-cosmos-py/SKILL.md
@@ -23,9 +23,9 @@ pip install azure-cosmos azure-identity
 ## Environment Variables
 
 ```bash
-COSMOS_ENDPOINT=https://<account>.documents.azure.com:443/
-COSMOS_DATABASE=mydb
-COSMOS_CONTAINER=mycontainer
+COSMOS_ENDPOINT=https://<account>.documents.azure.com:443/  # Required for all auth methods
+COSMOS_DATABASE=mydb  # Required for all auth methods
+COSMOS_CONTAINER=mycontainer  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-data-tables-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-data-tables-py/SKILL.md
@@ -28,15 +28,22 @@ AZURE_STORAGE_ACCOUNT_URL=https://<account>.table.core.windows.net
 
 # Cosmos DB Table API
 COSMOS_TABLE_ENDPOINT=https://<account>.table.cosmos.azure.com
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+import os
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.data.tables import TableServiceClient, TableClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 endpoint = "https://<account>.table.core.windows.net"
 
 # Service client (manage tables)

--- a/.github/plugins/azure-sdk-python/skills/azure-data-tables-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-data-tables-py/SKILL.md
@@ -24,10 +24,10 @@ pip install azure-data-tables azure-identity
 
 ```bash
 # Azure Storage Tables
-AZURE_STORAGE_ACCOUNT_URL=https://<account>.table.core.windows.net
+AZURE_STORAGE_ACCOUNT_URL=https://<account>.table.core.windows.net  # Required for Azure Storage Tables
 
 # Cosmos DB Table API
-COSMOS_TABLE_ENDPOINT=https://<account>.table.cosmos.azure.com
+COSMOS_TABLE_ENDPOINT=https://<account>.table.cosmos.azure.com  # Required for Cosmos DB Table API
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-eventgrid-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-eventgrid-py/SKILL.md
@@ -23,8 +23,8 @@ pip install azure-eventgrid azure-identity
 ## Environment Variables
 
 ```bash
-EVENTGRID_TOPIC_ENDPOINT=https://<topic-name>.<region>.eventgrid.azure.net/api/events
-EVENTGRID_NAMESPACE_ENDPOINT=https://<namespace>.<region>.eventgrid.azure.net
+EVENTGRID_TOPIC_ENDPOINT=https://<topic-name>.<region>.eventgrid.azure.net/api/events  # Required for Event Grid topic publishing
+EVENTGRID_NAMESPACE_ENDPOINT=https://<namespace>.<region>.eventgrid.azure.net  # Required for namespace operations
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-eventgrid-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-eventgrid-py/SKILL.md
@@ -25,15 +25,22 @@ pip install azure-eventgrid azure-identity
 ```bash
 EVENTGRID_TOPIC_ENDPOINT=https://<topic-name>.<region>.eventgrid.azure.net/api/events
 EVENTGRID_NAMESPACE_ENDPOINT=https://<namespace>.<region>.eventgrid.azure.net
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+import os
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.eventgrid import EventGridPublisherClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 endpoint = "https://<topic-name>.<region>.eventgrid.azure.net/api/events"
 
 client = EventGridPublisherClient(endpoint, credential)

--- a/.github/plugins/azure-sdk-python/skills/azure-eventhub-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-eventhub-py/SKILL.md
@@ -29,15 +29,20 @@ EVENT_HUB_FULLY_QUALIFIED_NAMESPACE=<namespace>.servicebus.windows.net
 EVENT_HUB_NAME=my-eventhub
 STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net
 CHECKPOINT_CONTAINER=checkpoints
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.eventhub import EventHubProducerClient, EventHubConsumerClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 namespace = "<namespace>.servicebus.windows.net"
 eventhub_name = "my-eventhub"
 

--- a/.github/plugins/azure-sdk-python/skills/azure-eventhub-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-eventhub-py/SKILL.md
@@ -25,10 +25,10 @@ pip install azure-eventhub-checkpointstoreblob-aio
 ## Environment Variables
 
 ```bash
-EVENT_HUB_FULLY_QUALIFIED_NAMESPACE=<namespace>.servicebus.windows.net
-EVENT_HUB_NAME=my-eventhub
-STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net
-CHECKPOINT_CONTAINER=checkpoints
+EVENT_HUB_FULLY_QUALIFIED_NAMESPACE=<namespace>.servicebus.windows.net  # Required for all auth methods
+EVENT_HUB_NAME=my-eventhub  # Required for all auth methods
+STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net  # Required for checkpoint storage
+CHECKPOINT_CONTAINER=checkpoints  # Required for checkpoint storage
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-keyvault-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-keyvault-py/SKILL.md
@@ -33,7 +33,7 @@ pip install azure-keyvault-secrets azure-keyvault-keys azure-keyvault-certificat
 ## Environment Variables
 
 ```bash
-AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net/
+AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net/  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-keyvault-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-keyvault-py/SKILL.md
@@ -34,6 +34,7 @@ pip install azure-keyvault-secrets azure-keyvault-keys azure-keyvault-certificat
 
 ```bash
 AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net/
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Secrets
@@ -41,10 +42,14 @@ AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net/
 ### SecretClient Setup
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.keyvault.secrets import SecretClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 vault_url = "https://<vault-name>.vault.azure.net/"
 
 client = SecretClient(vault_url=vault_url, credential=credential)

--- a/.github/plugins/azure-sdk-python/skills/azure-messaging-webpubsubservice-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-messaging-webpubsubservice-py/SKILL.md
@@ -29,6 +29,7 @@ pip install azure-messaging-webpubsubclient
 ```bash
 AZURE_WEBPUBSUB_CONNECTION_STRING=Endpoint=https://<name>.webpubsub.azure.com;AccessKey=...
 AZURE_WEBPUBSUB_HUB=my-hub
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Service Client (Server-Side)
@@ -45,12 +46,18 @@ client = WebPubSubServiceClient.from_connection_string(
 )
 
 # Entra ID
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 client = WebPubSubServiceClient(
     endpoint="https://<name>.webpubsub.azure.com",
     hub="my-hub",
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-messaging-webpubsubservice-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-messaging-webpubsubservice-py/SKILL.md
@@ -27,8 +27,8 @@ pip install azure-messaging-webpubsubclient
 ## Environment Variables
 
 ```bash
-AZURE_WEBPUBSUB_CONNECTION_STRING=Endpoint=https://<name>.webpubsub.azure.com;AccessKey=...
-AZURE_WEBPUBSUB_HUB=my-hub
+AZURE_WEBPUBSUB_CONNECTION_STRING=Endpoint=https://<name>.webpubsub.azure.com;AccessKey=...  # Alternative to Entra ID auth
+AZURE_WEBPUBSUB_HUB=my-hub  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-apicenter-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-apicenter-py/SKILL.md
@@ -25,17 +25,24 @@ pip install azure-identity
 
 ```bash
 AZURE_SUBSCRIPTION_ID=your-subscription-id
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.mgmt.apicenter import ApiCenterMgmtClient
 import os
 
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 client = ApiCenterMgmtClient(
-    credential=DefaultAzureCredential(),
+    credential=credential,
     subscription_id=os.environ["AZURE_SUBSCRIPTION_ID"]
 )
 ```

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-apicenter-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-apicenter-py/SKILL.md
@@ -24,7 +24,7 @@ pip install azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_SUBSCRIPTION_ID=your-subscription-id
+AZURE_SUBSCRIPTION_ID=your-subscription-id  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-apimanagement-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-apimanagement-py/SKILL.md
@@ -24,7 +24,7 @@ pip install azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_SUBSCRIPTION_ID=your-subscription-id
+AZURE_SUBSCRIPTION_ID=your-subscription-id  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-apimanagement-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-apimanagement-py/SKILL.md
@@ -25,17 +25,24 @@ pip install azure-identity
 
 ```bash
 AZURE_SUBSCRIPTION_ID=your-subscription-id
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.mgmt.apimanagement import ApiManagementClient
 import os
 
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 client = ApiManagementClient(
-    credential=DefaultAzureCredential(),
+    credential=credential,
     subscription_id=os.environ["AZURE_SUBSCRIPTION_ID"]
 )
 ```

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-botservice-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-botservice-py/SKILL.md
@@ -25,16 +25,22 @@ pip install azure-identity
 ```bash
 AZURE_SUBSCRIPTION_ID=<your-subscription-id>
 AZURE_RESOURCE_GROUP=<your-resource-group>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.mgmt.botservice import AzureBotService
 import os
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 client = AzureBotService(
     credential=credential,
     subscription_id=os.environ["AZURE_SUBSCRIPTION_ID"]

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-botservice-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-botservice-py/SKILL.md
@@ -23,8 +23,8 @@ pip install azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_SUBSCRIPTION_ID=<your-subscription-id>
-AZURE_RESOURCE_GROUP=<your-resource-group>
+AZURE_SUBSCRIPTION_ID=<your-subscription-id>  # Required for all auth methods
+AZURE_RESOURCE_GROUP=<your-resource-group>  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-fabric-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-fabric-py/SKILL.md
@@ -25,16 +25,22 @@ pip install azure-identity
 ```bash
 AZURE_SUBSCRIPTION_ID=<your-subscription-id>
 AZURE_RESOURCE_GROUP=<your-resource-group>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.mgmt.fabric import FabricMgmtClient
 import os
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 client = FabricMgmtClient(
     credential=credential,
     subscription_id=os.environ["AZURE_SUBSCRIPTION_ID"]

--- a/.github/plugins/azure-sdk-python/skills/azure-mgmt-fabric-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-mgmt-fabric-py/SKILL.md
@@ -23,8 +23,8 @@ pip install azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_SUBSCRIPTION_ID=<your-subscription-id>
-AZURE_RESOURCE_GROUP=<your-resource-group>
+AZURE_SUBSCRIPTION_ID=<your-subscription-id>  # Required for all auth methods
+AZURE_RESOURCE_GROUP=<your-resource-group>  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-ingestion-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-ingestion-py/SKILL.md
@@ -25,13 +25,13 @@ pip install azure-identity
 
 ```bash
 # Data Collection Endpoint (DCE)
-AZURE_DCE_ENDPOINT=https://<dce-name>.<region>.ingest.monitor.azure.com
+AZURE_DCE_ENDPOINT=https://<dce-name>.<region>.ingest.monitor.azure.com  # Required for all auth methods
 
 # Data Collection Rule (DCR) immutable ID
-AZURE_DCR_RULE_ID=dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AZURE_DCR_RULE_ID=dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # Required for all auth methods
 
 # Stream name from DCR
-AZURE_DCR_STREAM_NAME=Custom-MyTable_CL
+AZURE_DCR_STREAM_NAME=Custom-MyTable_CL  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-ingestion-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-ingestion-py/SKILL.md
@@ -32,6 +32,7 @@ AZURE_DCR_RULE_ID=dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Stream name from DCR
 AZURE_DCR_STREAM_NAME=Custom-MyTable_CL
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Prerequisites
@@ -47,12 +48,18 @@ Before using this SDK, you need:
 
 ```python
 from azure.monitor.ingestion import LogsIngestionClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 import os
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 client = LogsIngestionClient(
     endpoint=os.environ["AZURE_DCE_ENDPOINT"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-exporter-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-exporter-py/SKILL.md
@@ -24,6 +24,7 @@ pip install azure-monitor-opentelemetry-exporter
 
 ```bash
 APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## When to Use
@@ -124,11 +125,17 @@ exporter = AzureMonitorTraceExporter()
 ## Azure AD Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter
 
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
+
 exporter = AzureMonitorTraceExporter(
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-exporter-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-exporter-py/SKILL.md
@@ -23,7 +23,7 @@ pip install azure-monitor-opentelemetry-exporter
 ## Environment Variables
 
 ```bash
-APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/
+APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-py/SKILL.md
@@ -24,6 +24,7 @@ pip install azure-monitor-opentelemetry
 
 ```bash
 APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Quick Start
@@ -183,10 +184,16 @@ configure_azure_monitor(
 
 ```python
 from azure.monitor.opentelemetry import configure_azure_monitor
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 configure_azure_monitor(
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-opentelemetry-py/SKILL.md
@@ -23,7 +23,7 @@ pip install azure-monitor-opentelemetry
 ## Environment Variables
 
 ```bash
-APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/
+APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://xxx.in.applicationinsights.azure.com/  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-query-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-query-py/SKILL.md
@@ -28,14 +28,19 @@ AZURE_LOG_ANALYTICS_WORKSPACE_ID=<workspace-id>
 
 # Metrics
 AZURE_METRICS_RESOURCE_URI=/subscriptions/<sub>/resourceGroups/<rg>/providers/<provider>/<type>/<name>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 ```
 
 ## Logs Query Client

--- a/.github/plugins/azure-sdk-python/skills/azure-monitor-query-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-monitor-query-py/SKILL.md
@@ -24,10 +24,10 @@ pip install azure-monitor-query
 
 ```bash
 # Log Analytics
-AZURE_LOG_ANALYTICS_WORKSPACE_ID=<workspace-id>
+AZURE_LOG_ANALYTICS_WORKSPACE_ID=<workspace-id>  # Required for log queries
 
 # Metrics
-AZURE_METRICS_RESOURCE_URI=/subscriptions/<sub>/resourceGroups/<rg>/providers/<provider>/<type>/<name>
+AZURE_METRICS_RESOURCE_URI=/subscriptions/<sub>/resourceGroups/<rg>/providers/<provider>/<type>/<name>  # Required for metric queries
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-search-documents-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-search-documents-py/SKILL.md
@@ -23,9 +23,9 @@ pip install azure-search-documents
 ## Environment Variables
 
 ```bash
-AZURE_SEARCH_ENDPOINT=https://<service-name>.search.windows.net
-AZURE_SEARCH_API_KEY=<your-api-key>
-AZURE_SEARCH_INDEX_NAME=<your-index-name>
+AZURE_SEARCH_ENDPOINT=https://<service-name>.search.windows.net  # Required for all auth methods
+AZURE_SEARCH_API_KEY=<your-api-key>  # Only required for AzureKeyCredential auth
+AZURE_SEARCH_INDEX_NAME=<your-index-name>  # Required for all auth methods
 ```
 
 ## Authentication
@@ -335,10 +335,10 @@ pip install azure-search-documents azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_SEARCH_ENDPOINT=https://<search-service>.search.windows.net
-AZURE_SEARCH_INDEX_NAME=<index-name>
+AZURE_SEARCH_ENDPOINT=https://<search-service>.search.windows.net  # Required for all auth methods
+AZURE_SEARCH_INDEX_NAME=<index-name>  # Required for all auth methods
 # For API key auth (not recommended for production)
-AZURE_SEARCH_API_KEY=<api-key>
+AZURE_SEARCH_API_KEY=<api-key>  # Only required for AzureKeyCredential auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-search-documents-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-search-documents-py/SKILL.md
@@ -339,16 +339,21 @@ AZURE_SEARCH_ENDPOINT=https://<search-service>.search.windows.net
 AZURE_SEARCH_INDEX_NAME=<index-name>
 # For API key auth (not recommended for production)
 AZURE_SEARCH_API_KEY=<api-key>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 **DefaultAzureCredential (preferred)**:
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.search.documents import SearchClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = SearchClient(endpoint, index_name, credential)
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-servicebus-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-servicebus-py/SKILL.md
@@ -27,15 +27,20 @@ SERVICEBUS_FULLY_QUALIFIED_NAMESPACE=<namespace>.servicebus.windows.net
 SERVICEBUS_QUEUE_NAME=myqueue
 SERVICEBUS_TOPIC_NAME=mytopic
 SERVICEBUS_SUBSCRIPTION_NAME=mysubscription
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.servicebus import ServiceBusClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 namespace = "<namespace>.servicebus.windows.net"
 
 client = ServiceBusClient(

--- a/.github/plugins/azure-sdk-python/skills/azure-servicebus-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-servicebus-py/SKILL.md
@@ -23,10 +23,10 @@ pip install azure-servicebus azure-identity
 ## Environment Variables
 
 ```bash
-SERVICEBUS_FULLY_QUALIFIED_NAMESPACE=<namespace>.servicebus.windows.net
-SERVICEBUS_QUEUE_NAME=myqueue
-SERVICEBUS_TOPIC_NAME=mytopic
-SERVICEBUS_SUBSCRIPTION_NAME=mysubscription
+SERVICEBUS_FULLY_QUALIFIED_NAMESPACE=<namespace>.servicebus.windows.net  # Required for all auth methods
+SERVICEBUS_QUEUE_NAME=myqueue  # Required for queue operations
+SERVICEBUS_TOPIC_NAME=mytopic  # Required for topic operations
+SERVICEBUS_SUBSCRIPTION_NAME=mysubscription  # Required for subscription operations
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-blob-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-blob-py/SKILL.md
@@ -23,9 +23,9 @@ pip install azure-storage-blob azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_STORAGE_ACCOUNT_NAME=<your-storage-account>
+AZURE_STORAGE_ACCOUNT_NAME=<your-storage-account>  # Required for all auth methods
 # Or use full URL
-AZURE_STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net
+AZURE_STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net  # Alternative to account name
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-blob-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-blob-py/SKILL.md
@@ -26,15 +26,20 @@ pip install azure-storage-blob azure-identity
 AZURE_STORAGE_ACCOUNT_NAME=<your-storage-account>
 # Or use full URL
 AZURE_STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.storage.blob import BlobServiceClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 account_url = "https://<account>.blob.core.windows.net"
 
 blob_service_client = BlobServiceClient(account_url, credential=credential)

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-file-datalake-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-file-datalake-py/SKILL.md
@@ -23,7 +23,7 @@ pip install azure-storage-file-datalake azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_STORAGE_ACCOUNT_URL=https://<account>.dfs.core.windows.net
+AZURE_STORAGE_ACCOUNT_URL=https://<account>.dfs.core.windows.net  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-file-datalake-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-file-datalake-py/SKILL.md
@@ -24,15 +24,20 @@ pip install azure-storage-file-datalake azure-identity
 
 ```bash
 AZURE_STORAGE_ACCOUNT_URL=https://<account>.dfs.core.windows.net
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.storage.filedatalake import DataLakeServiceClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 account_url = "https://<account>.dfs.core.windows.net"
 
 service_client = DataLakeServiceClient(account_url=account_url, credential=credential)

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-file-share-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-file-share-py/SKILL.md
@@ -22,9 +22,9 @@ pip install azure-storage-file-share
 ## Environment Variables
 
 ```bash
-AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...  # Alternative to Entra ID auth
 # Or
-AZURE_STORAGE_ACCOUNT_URL=https://<account>.file.core.windows.net
+AZURE_STORAGE_ACCOUNT_URL=https://<account>.file.core.windows.net  # Required for Entra ID auth
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-file-share-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-file-share-py/SKILL.md
@@ -25,6 +25,7 @@ pip install azure-storage-file-share
 AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...
 # Or
 AZURE_STORAGE_ACCOUNT_URL=https://<account>.file.core.windows.net
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -43,11 +44,17 @@ service = ShareServiceClient.from_connection_string(
 
 ```python
 from azure.storage.fileshare import ShareServiceClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 
 service = ShareServiceClient(
     account_url=os.environ["AZURE_STORAGE_ACCOUNT_URL"],
-    credential=DefaultAzureCredential()
+    credential=credential
 )
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-queue-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-queue-py/SKILL.md
@@ -24,15 +24,20 @@ pip install azure-storage-queue azure-identity
 
 ```bash
 AZURE_STORAGE_ACCOUNT_URL=https://<account>.queue.core.windows.net
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.storage.queue import QueueServiceClient, QueueClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 account_url = "https://<account>.queue.core.windows.net"
 
 # Service client

--- a/.github/plugins/azure-sdk-python/skills/azure-storage-queue-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/azure-storage-queue-py/SKILL.md
@@ -23,7 +23,7 @@ pip install azure-storage-queue azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_STORAGE_ACCOUNT_URL=https://<account>.queue.core.windows.net
+AZURE_STORAGE_ACCOUNT_URL=https://<account>.queue.core.windows.net  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/plugins/azure-sdk-python/skills/hosted-agents-v2-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/hosted-agents-v2-py/SKILL.md
@@ -24,6 +24,7 @@ pip install azure-ai-projects>=2.0.0b3 azure-identity
 
 ```bash
 AZURE_AI_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Prerequisites
@@ -40,10 +41,14 @@ Before creating hosted agents:
 Always use `DefaultAzureCredential`:
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.ai.projects import AIProjectClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = AIProjectClient(
     endpoint=os.environ["AZURE_AI_PROJECT_ENDPOINT"],
     credential=credential

--- a/.github/plugins/azure-sdk-python/skills/hosted-agents-v2-py/SKILL.md
+++ b/.github/plugins/azure-sdk-python/skills/hosted-agents-v2-py/SKILL.md
@@ -23,7 +23,7 @@ pip install azure-ai-projects>=2.0.0b3 azure-identity
 ## Environment Variables
 
 ```bash
-AZURE_AI_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+AZURE_AI_PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>  # Required for all auth methods
 AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used in production
 ```
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -116,8 +116,12 @@ For local development, use `DefaultAzureCredential` which supports multiple auth
 
 ```python
 # Python
-from azure.identity import DefaultAzureCredential
-credential = DefaultAzureCredential()
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = ServiceClient(endpoint, credential)
 ```
 
@@ -204,10 +208,14 @@ AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used i
 ## Authentication
 
 \`\`\`python
-from azure.identity import DefaultAzureCredential
+from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.ai.example import ExampleClient
 
-credential = DefaultAzureCredential()
+# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+credential = DefaultAzureCredential(require_envvar=True)
+# Or use a specific credential directly in production:
+# See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
+# credential = ManagedIdentityCredential()
 client = ExampleClient(
 endpoint=os.environ["AZURE_EXAMPLE_ENDPOINT"],
 credential=credential

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -103,7 +103,7 @@ Follow this structure (based on existing Azure SDK skills):
 
 1. **Title** — `# SDK Name`
 2. **Installation** — `pip install`, `npm install`, etc.
-3. **Environment Variables** — Required configuration. If using `DefaultAzureCredential`in production,include `AZURE_TOKEN_CREDENTIALS` (set to `prod` or `<specific_credential>`)
+3. **Environment Variables** — Required configuration, with an inline comment explaining when it's required . If using `DefaultAzureCredential`in production,include `AZURE_TOKEN_CREDENTIALS` (set to `prod` or `<specific_credential>`)
 4. **Authentication** — Use a specific Microsoft Entra Token credential like `ManagedIdentityCredential` or `WorkloadIdentityCredential` for production. `DefaultAzureCredential` is only recommended for local development. To use DefaultAzureCredential in production, set the environment variable `AZURE_TOKEN_CREDENTIALS` to `prod` or the specific target credential.
 5. **Core Workflow** — Minimal viable example
 6. **Feature Tables** — Clients, methods, tools


### PR DESCRIPTION
Update Python skills auth: require_envvar, ManagedIdentityCredential, env var, credential link

- Update 35 Python skills with ManagedIdentityCredential import and require_envvar=True
- Add AZURE_TOKEN_CREDENTIALS=prod to Environment Variables sections
- Add credential classes reference link in Authentication sections
- Update skill-creator Python snippet to match new pattern
- Skip azure-ai-transcription-py (key-based auth only) and azure-identity-py (reference skill)