### PR TITLE
Update Java skills auth and env vars with requireEnvVars pattern

### DIFF
--- a/.github/plugins/azure-sdk-java/skills/azure-ai-agents-persistent-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-ai-agents-persistent-java/SKILL.md
@@ -27,8 +27,9 @@ Low-level SDK for creating and managing persistent AI agents with threads, messa
 ## Environment Variables
 
 ```bash
-PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
-MODEL_DEPLOYMENT_NAME=gpt-4o-mini
+PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project> # Required for project configuration
+MODEL_DEPLOYMENT_NAME=gpt-4o-mini # Required for agent model selection
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -36,12 +37,22 @@ MODEL_DEPLOYMENT_NAME=gpt-4o-mini
 ```java
 import com.azure.ai.agents.persistent.PersistentAgentsClient;
 import com.azure.ai.agents.persistent.PersistentAgentsClientBuilder;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 
 String endpoint = System.getenv("PROJECT_ENDPOINT");
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
+
 PersistentAgentsClient client = new PersistentAgentsClientBuilder()
     .endpoint(endpoint)
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 

--- a/.github/plugins/azure-sdk-java/skills/azure-ai-anomalydetector-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-ai-anomalydetector-java/SKILL.md
@@ -51,10 +51,20 @@ UnivariateClient univariateClient = new AnomalyDetectorClientBuilder()
 ### With DefaultAzureCredential
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 MultivariateClient client = new AnomalyDetectorClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint(endpoint)
     .buildMultivariateClient();
 ```
@@ -237,8 +247,9 @@ try {
 ## Environment Variables
 
 ```bash
-AZURE_ANOMALY_DETECTOR_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
-AZURE_ANOMALY_DETECTOR_API_KEY=<your-api-key>
+AZURE_ANOMALY_DETECTOR_ENDPOINT=https://<resource>.cognitiveservices.azure.com/ # Required for all auth methods
+AZURE_ANOMALY_DETECTOR_API_KEY=<your-api-key> # Only required for AzureKeyCredential auth
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-ai-contentsafety-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-ai-contentsafety-java/SKILL.md
@@ -50,10 +50,20 @@ BlocklistClient blocklistClient = new BlocklistClientBuilder()
 ### With DefaultAzureCredential
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 ContentSafetyClient client = new ContentSafetyClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint(endpoint)
     .buildClient();
 ```
@@ -263,8 +273,9 @@ try {
 ## Environment Variables
 
 ```bash
-CONTENT_SAFETY_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
-CONTENT_SAFETY_KEY=<your-api-key>
+CONTENT_SAFETY_ENDPOINT=https://<resource>.cognitiveservices.azure.com/ # Required for all auth methods
+CONTENT_SAFETY_KEY=<your-api-key> # Only required for AzureKeyCredential auth
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-ai-formrecognizer-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-ai-formrecognizer-java/SKILL.md
@@ -39,7 +39,8 @@ Search `microsoft-docs` MCP for current API patterns:
 ## Environment Variables
 
 ```bash
-DOCUMENT_INTELLIGENCE_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
+DOCUMENT_INTELLIGENCE_ENDPOINT=https://<resource>.cognitiveservices.azure.com/ # Required for all auth methods
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -49,11 +50,21 @@ DOCUMENT_INTELLIGENCE_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
 ```java
 import com.azure.ai.documentintelligence.DocumentIntelligenceClient;
 import com.azure.ai.documentintelligence.DocumentIntelligenceClientBuilder;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 DocumentIntelligenceClient client = new DocumentIntelligenceClientBuilder()
     .endpoint(System.getenv("DOCUMENT_INTELLIGENCE_ENDPOINT"))
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -73,10 +84,21 @@ DocumentIntelligenceClient client = new DocumentIntelligenceClientBuilder()
 ```java
 import com.azure.ai.documentintelligence.DocumentIntelligenceAdministrationClient;
 import com.azure.ai.documentintelligence.DocumentIntelligenceAdministrationClientBuilder;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 DocumentIntelligenceAdministrationClient adminClient = new DocumentIntelligenceAdministrationClientBuilder()
     .endpoint(System.getenv("DOCUMENT_INTELLIGENCE_ENDPOINT"))
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -84,10 +106,21 @@ DocumentIntelligenceAdministrationClient adminClient = new DocumentIntelligenceA
 
 ```java
 import com.azure.ai.documentintelligence.DocumentIntelligenceAsyncClient;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 DocumentIntelligenceAsyncClient asyncClient = new DocumentIntelligenceClientBuilder()
     .endpoint(System.getenv("DOCUMENT_INTELLIGENCE_ENDPOINT"))
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildAsyncClient();
 ```
 

--- a/.github/plugins/azure-sdk-java/skills/azure-ai-projects-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-ai-projects-java/SKILL.md
@@ -27,18 +27,29 @@ High-level SDK for Azure AI Foundry project management with access to connection
 ## Environment Variables
 
 ```bash
-PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project>
+PROJECT_ENDPOINT=https://<resource>.services.ai.azure.com/api/projects/<project> # Required for project configuration
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
 
 ```java
 import com.azure.ai.projects.AIProjectClientBuilder;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 AIProjectClientBuilder builder = new AIProjectClientBuilder()
     .endpoint(System.getenv("PROJECT_ENDPOINT"))
-    .credential(new DefaultAzureCredentialBuilder().build());
+    .credential(credential);
 ```
 
 ## Client Hierarchy

--- a/.github/plugins/azure-sdk-java/skills/azure-ai-vision-imageanalysis-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-ai-vision-imageanalysis-java/SKILL.md
@@ -54,11 +54,21 @@ ImageAnalysisAsyncClient asyncClient = new ImageAnalysisClientBuilder()
 ### With DefaultAzureCredential
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 ImageAnalysisClient client = new ImageAnalysisClientBuilder()
     .endpoint(endpoint)
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -268,8 +278,9 @@ try {
 ## Environment Variables
 
 ```bash
-VISION_ENDPOINT=https://<resource>.cognitiveservices.azure.com/
-VISION_KEY=<your-api-key>
+VISION_ENDPOINT=https://<resource>.cognitiveservices.azure.com/ # Required for all auth methods
+VISION_KEY=<your-api-key> # Only required for AzureKeyCredential auth
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Image Requirements

--- a/.github/plugins/azure-sdk-java/skills/azure-ai-voicelive-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-ai-voicelive-java/SKILL.md
@@ -27,8 +27,9 @@ Real-time, bidirectional voice conversations with AI assistants using WebSocket 
 ## Environment Variables
 
 ```bash
-AZURE_VOICELIVE_ENDPOINT=https://<resource>.openai.azure.com/
-AZURE_VOICELIVE_API_KEY=<your-api-key>
+AZURE_VOICELIVE_ENDPOINT=https://<resource>.openai.azure.com/ # Required for all auth methods
+AZURE_VOICELIVE_API_KEY=<your-api-key> # Only required for AzureKeyCredential auth
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Authentication
@@ -49,11 +50,21 @@ VoiceLiveAsyncClient client = new VoiceLiveClientBuilder()
 ### DefaultAzureCredential (Recommended)
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 VoiceLiveAsyncClient client = new VoiceLiveClientBuilder()
     .endpoint(System.getenv("AZURE_VOICELIVE_ENDPOINT"))
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildAsyncClient();
 ```
 

--- a/.github/plugins/azure-sdk-java/skills/azure-appconfiguration-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-appconfiguration-java/SKILL.md
@@ -55,8 +55,9 @@ Or use Azure SDK BOM:
 ## Environment Variables
 
 ```bash
-AZURE_APPCONFIG_CONNECTION_STRING=Endpoint=https://<store>.azconfig.io;Id=<id>;Secret=<secret>
-AZURE_APPCONFIG_ENDPOINT=https://<store>.azconfig.io
+AZURE_APPCONFIG_CONNECTION_STRING=Endpoint=https://<store>.azconfig.io;Id=<id>;Secret=<secret>  # Alternative to Entra ID auth
+AZURE_APPCONFIG_ENDPOINT=https://<store>.azconfig.io  # Required for all auth methods
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Client Creation
@@ -85,10 +86,21 @@ ConfigurationAsyncClient asyncClient = new ConfigurationClientBuilder()
 ### With Entra ID (Recommended)
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 ConfigurationClient configClient = new ConfigurationClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint(System.getenv("AZURE_APPCONFIG_ENDPOINT"))
     .buildClient();
 ```

--- a/.github/plugins/azure-sdk-java/skills/azure-communication-callautomation-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-communication-callautomation-java/SKILL.md
@@ -27,12 +27,23 @@ Build server-side call automation workflows including IVR systems, call routing,
 ```java
 import com.azure.communication.callautomation.CallAutomationClient;
 import com.azure.communication.callautomation.CallAutomationClientBuilder;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 // With DefaultAzureCredential
 CallAutomationClient client = new CallAutomationClientBuilder()
     .endpoint("https://<resource>.communication.azure.com")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 
 // With connection string
@@ -244,9 +255,10 @@ try {
 ## Environment Variables
 
 ```bash
-AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
-AZURE_COMMUNICATION_CONNECTION_STRING=endpoint=https://...;accesskey=...
-CALLBACK_BASE_URL=https://your-app.com/api/callbacks
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com  # Required for all auth methods
+AZURE_COMMUNICATION_CONNECTION_STRING=endpoint=https://...;accesskey=...  # Alternative to Entra ID auth
+CALLBACK_BASE_URL=https://your-app.com/api/callbacks  # Required for webhook callbacks
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Trigger Phrases

--- a/.github/plugins/azure-sdk-java/skills/azure-communication-sms-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-communication-sms-java/SKILL.md
@@ -27,12 +27,23 @@ Send SMS messages to single or multiple recipients with delivery reporting.
 ```java
 import com.azure.communication.sms.SmsClient;
 import com.azure.communication.sms.SmsClientBuilder;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 // With DefaultAzureCredential (recommended)
 SmsClient smsClient = new SmsClientBuilder()
     .endpoint("https://<resource>.communication.azure.com")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 
 // With connection string
@@ -257,9 +268,10 @@ public void handleDeliveryReport(String eventJson) {
 ## Environment Variables
 
 ```bash
-AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com
-AZURE_COMMUNICATION_CONNECTION_STRING=endpoint=https://...;accesskey=...
-SMS_FROM_NUMBER=+14255550100
+AZURE_COMMUNICATION_ENDPOINT=https://<resource>.communication.azure.com  # Required for all auth methods
+AZURE_COMMUNICATION_CONNECTION_STRING=endpoint=https://...;accesskey=...  # Alternative to Entra ID auth
+SMS_FROM_NUMBER=+14255550100  # Required for the sender phone number
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-compute-batch-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-compute-batch-java/SKILL.md
@@ -32,9 +32,10 @@ Client library for running large-scale parallel and high-performance computing (
 ## Environment Variables
 
 ```bash
-AZURE_BATCH_ENDPOINT=https://<account>.<region>.batch.azure.com
-AZURE_BATCH_ACCOUNT=<account-name>
-AZURE_BATCH_ACCESS_KEY=<account-key>
+AZURE_BATCH_ENDPOINT=https://<account>.<region>.batch.azure.com  # Required for all auth methods
+AZURE_BATCH_ACCOUNT=<account-name>  # Only required for shared key auth
+AZURE_BATCH_ACCESS_KEY=<account-key>  # Only required for shared key auth
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Client Creation
@@ -44,10 +45,21 @@ AZURE_BATCH_ACCESS_KEY=<account-key>
 ```java
 import com.azure.compute.batch.BatchClient;
 import com.azure.compute.batch.BatchClientBuilder;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 BatchClient batchClient = new BatchClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint(System.getenv("AZURE_BATCH_ENDPOINT"))
     .buildClient();
 ```
@@ -58,7 +70,7 @@ BatchClient batchClient = new BatchClientBuilder()
 import com.azure.compute.batch.BatchAsyncClient;
 
 BatchAsyncClient batchAsyncClient = new BatchClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint(System.getenv("AZURE_BATCH_ENDPOINT"))
     .buildAsyncClient();
 ```

--- a/.github/plugins/azure-sdk-java/skills/azure-data-tables-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-data-tables-java/SKILL.md
@@ -63,11 +63,22 @@ TableServiceClient serviceClient = new TableServiceClientBuilder()
 ### With DefaultAzureCredential (Storage only)
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 TableServiceClient serviceClient = new TableServiceClientBuilder()
     .endpoint("<your-table-account-url>")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -313,11 +324,12 @@ try {
 
 ```bash
 # Storage Account
-AZURE_TABLES_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
-AZURE_TABLES_ENDPOINT=https://<account>.table.core.windows.net
+AZURE_TABLES_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...  # Alternative to Entra ID auth
+AZURE_TABLES_ENDPOINT=https://<account>.table.core.windows.net  # Required for all auth methods
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 
 # Cosmos DB Table API
-COSMOS_TABLE_ENDPOINT=https://<account>.table.cosmosdb.azure.com
+COSMOS_TABLE_ENDPOINT=https://<account>.table.cosmosdb.azure.com  # Alternative endpoint for Cosmos DB Table API
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-eventgrid-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-eventgrid-java/SKILL.md
@@ -47,11 +47,22 @@ EventGridPublisherClient<CloudEvent> cloudClient = new EventGridPublisherClientB
 ### With DefaultAzureCredential
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 EventGridPublisherClient<EventGridEvent> client = new EventGridPublisherClientBuilder()
     .endpoint("<topic-endpoint>")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildEventGridEventPublisherClient();
 ```
 
@@ -287,8 +298,9 @@ try {
 ## Environment Variables
 
 ```bash
-EVENT_GRID_TOPIC_ENDPOINT=https://<topic-name>.<region>.eventgrid.azure.net/api/events
-EVENT_GRID_ACCESS_KEY=<your-access-key>
+EVENT_GRID_TOPIC_ENDPOINT=https://<topic-name>.<region>.eventgrid.azure.net/api/events  # Required for all auth methods
+EVENT_GRID_ACCESS_KEY=<your-access-key>  # Only required for AzureKeyCredential auth
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-eventhub-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-eventhub-java/SKILL.md
@@ -51,12 +51,23 @@ EventHubProducerClient producer = new EventHubClientBuilder()
 ### With DefaultAzureCredential
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 EventHubProducerClient producer = new EventHubClientBuilder()
     .fullyQualifiedNamespace("<namespace>.servicebus.windows.net")
     .eventHubName("<event-hub-name>")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildProducerClient();
 ```
 
@@ -336,9 +347,10 @@ try (EventHubProducerClient producer = new EventHubClientBuilder()
 ## Environment Variables
 
 ```bash
-EVENT_HUBS_CONNECTION_STRING=Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=...
-EVENT_HUBS_NAME=<event-hub-name>
-STORAGE_CONNECTION_STRING=<for-checkpointing>
+EVENT_HUBS_CONNECTION_STRING=Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=...  # Alternative to Entra ID auth
+EVENT_HUBS_NAME=<event-hub-name>  # Required for event hub name
+STORAGE_CONNECTION_STRING=<for-checkpointing>  # Alternative to Entra ID auth for checkpointing
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-messaging-webpubsub-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-messaging-webpubsub-java/SKILL.md
@@ -51,10 +51,21 @@ WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
 ### With DefaultAzureCredential
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 WebPubSubServiceClient client = new WebPubSubServiceClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint("<endpoint>")
     .hub("chat")
     .buildClient();
@@ -273,9 +284,10 @@ try {
 ## Environment Variables
 
 ```bash
-WEB_PUBSUB_CONNECTION_STRING=Endpoint=https://<resource>.webpubsub.azure.com;AccessKey=...
-WEB_PUBSUB_ENDPOINT=https://<resource>.webpubsub.azure.com
-WEB_PUBSUB_ACCESS_KEY=<your-access-key>
+WEB_PUBSUB_CONNECTION_STRING=Endpoint=https://<resource>.webpubsub.azure.com;AccessKey=...  # Alternative to Entra ID auth
+WEB_PUBSUB_ENDPOINT=https://<resource>.webpubsub.azure.com  # Required for AzureKeyCredential or TokenCredential auth
+WEB_PUBSUB_ACCESS_KEY=<your-access-key>  # Only required for AzureKeyCredential auth
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Client Roles

--- a/.github/plugins/azure-sdk-java/skills/azure-monitor-ingestion-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-monitor-ingestion-java/SKILL.md
@@ -57,9 +57,10 @@ Or use Azure SDK BOM:
 ## Environment Variables
 
 ```bash
-DATA_COLLECTION_ENDPOINT=https://<dce-name>.<region>.ingest.monitor.azure.com
-DATA_COLLECTION_RULE_ID=dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-STREAM_NAME=Custom-MyTable_CL
+DATA_COLLECTION_ENDPOINT=https://<dce-name>.<region>.ingest.monitor.azure.com  # Required for all auth methods
+DATA_COLLECTION_RULE_ID=dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # Required for log upload routing
+STREAM_NAME=Custom-MyTable_CL  # Required for the target DCR stream
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Client Creation
@@ -67,12 +68,20 @@ STREAM_NAME=Custom-MyTable_CL
 ### Synchronous Client
 
 ```java
-import com.azure.identity.DefaultAzureCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.azure.monitor.ingestion.LogsIngestionClient;
 import com.azure.monitor.ingestion.LogsIngestionClientBuilder;
 
-DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 LogsIngestionClient client = new LogsIngestionClientBuilder()
     .endpoint("<data-collection-endpoint>")
@@ -87,7 +96,7 @@ import com.azure.monitor.ingestion.LogsIngestionAsyncClient;
 
 LogsIngestionAsyncClient asyncClient = new LogsIngestionClientBuilder()
     .endpoint("<data-collection-endpoint>")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildAsyncClient();
 ```
 

--- a/.github/plugins/azure-sdk-java/skills/azure-monitor-query-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-monitor-query-java/SKILL.md
@@ -63,8 +63,9 @@ Or use Azure SDK BOM:
 ## Environment Variables
 
 ```bash
-LOG_ANALYTICS_WORKSPACE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-AZURE_RESOURCE_ID=/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{resource}
+LOG_ANALYTICS_WORKSPACE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx  # Required for Log Analytics workspace queries
+AZURE_RESOURCE_ID=/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{resource}  # Required for metrics queries against a resource
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Client Creation
@@ -72,12 +73,23 @@ AZURE_RESOURCE_ID=/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/
 ### LogsQueryClient (Sync)
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.azure.monitor.query.LogsQueryClient;
 import com.azure.monitor.query.LogsQueryClientBuilder;
 
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
+
 LogsQueryClient logsClient = new LogsQueryClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -87,7 +99,7 @@ LogsQueryClient logsClient = new LogsQueryClientBuilder()
 import com.azure.monitor.query.LogsQueryAsyncClient;
 
 LogsQueryAsyncClient logsAsyncClient = new LogsQueryClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildAsyncClient();
 ```
 
@@ -98,7 +110,7 @@ import com.azure.monitor.query.MetricsQueryClient;
 import com.azure.monitor.query.MetricsQueryClientBuilder;
 
 MetricsQueryClient metricsClient = new MetricsQueryClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -108,7 +120,7 @@ MetricsQueryClient metricsClient = new MetricsQueryClientBuilder()
 import com.azure.monitor.query.MetricsQueryAsyncClient;
 
 MetricsQueryAsyncClient metricsAsyncClient = new MetricsQueryClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildAsyncClient();
 ```
 
@@ -117,13 +129,13 @@ MetricsQueryAsyncClient metricsAsyncClient = new MetricsQueryClientBuilder()
 ```java
 // Azure China Cloud - Logs
 LogsQueryClient logsClient = new LogsQueryClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint("https://api.loganalytics.azure.cn/v1")
     .buildClient();
 
 // Azure China Cloud - Metrics
 MetricsQueryClient metricsClient = new MetricsQueryClientBuilder()
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .endpoint("https://management.chinacloudapi.cn")
     .buildClient();
 ```

--- a/.github/plugins/azure-sdk-java/skills/azure-security-keyvault-keys-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-security-keyvault-keys-java/SKILL.md
@@ -25,28 +25,39 @@ Manage cryptographic keys and perform cryptographic operations in Azure Key Vaul
 ## Client Creation
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.azure.security.keyvault.keys.KeyClient;
 import com.azure.security.keyvault.keys.KeyClientBuilder;
 import com.azure.security.keyvault.keys.cryptography.CryptographyClient;
 import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
-import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 // Key management client
 KeyClient keyClient = new KeyClientBuilder()
     .vaultUrl("https://<vault-name>.vault.azure.net")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 
 // Async client
 KeyAsyncClient keyAsyncClient = new KeyClientBuilder()
     .vaultUrl("https://<vault-name>.vault.azure.net")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildAsyncClient();
 
 // Cryptography client (for encrypt/decrypt/sign/verify)
 CryptographyClient cryptoClient = new CryptographyClientBuilder()
     .keyIdentifier("https://<vault-name>.vault.azure.net/keys/<key-name>/<key-version>")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -347,7 +358,8 @@ try {
 ## Environment Variables
 
 ```bash
-AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net
+AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net  # Required for vault URL
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-security-keyvault-secrets-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-security-keyvault-secrets-java/SKILL.md
@@ -25,20 +25,31 @@ Securely store and manage secrets like passwords, API keys, and connection strin
 ## Client Creation
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
-import com.azure.identity.DefaultAzureCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 // Sync client
 SecretClient secretClient = new SecretClientBuilder()
     .vaultUrl("https://<vault-name>.vault.azure.net")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 
 // Async client
 SecretAsyncClient secretAsyncClient = new SecretClientBuilder()
     .vaultUrl("https://<vault-name>.vault.azure.net")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildAsyncClient();
 ```
 
@@ -310,7 +321,8 @@ try {
 ## Environment Variables
 
 ```bash
-AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net
+AZURE_KEYVAULT_URL=https://<vault-name>.vault.azure.net  # Required for vault URL
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Best Practices

--- a/.github/plugins/azure-sdk-java/skills/azure-storage-blob-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-storage-blob-java/SKILL.md
@@ -45,11 +45,22 @@ BlobServiceClient serviceClient = new BlobServiceClientBuilder()
 ### With DefaultAzureCredential
 
 ```java
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureIdentityEnvVars;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 
 BlobServiceClient serviceClient = new BlobServiceClientBuilder()
     .endpoint("<storage-account-url>")
-    .credential(new DefaultAzureCredentialBuilder().build())
+    .credential(credential)
     .buildClient();
 ```
 
@@ -378,8 +389,9 @@ BlobServiceClient client = new BlobServiceClientBuilder()
 ## Environment Variables
 
 ```bash
-AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
-AZURE_STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...  # Alternative to Entra ID auth
+AZURE_STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net  # Required for all auth methods
+AZURE_TOKEN_CREDENTIALS=prod  # Required only if DefaultAzureCredential is used in production
 ```
 
 ## Trigger Phrases

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -127,13 +127,32 @@ client = ServiceClient(endpoint, credential)
 
 ```csharp
 // C#
-var credential = new DefaultAzureCredential();
+using Azure.Identity;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+var credential = new DefaultAzureCredential(
+    DefaultAzureCredential.DefaultEnvironmentVariableName
+);
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme?view=azure-dotnet#credential-classes
+// var credential = new ManagedIdentityCredential();
 var client = new ServiceClient(new Uri(endpoint), credential);
 ```
 
 ```java
 // Java
-TokenCredential credential = new DefaultAzureCredentialBuilder().build();
+import com.azure.identity.AzureIdentityEnvVars;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredential;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+// Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS)
+    .build();
+// Or use a specific credential directly in production:
+// See https://learn.microsoft.com/java/api/overview/azure/identity-readme?view=azure-java-stable#credential-classes
+// TokenCredential credential = new ManagedIdentityCredentialBuilder().build();
 ServiceClient client = new ServiceClientBuilder()
     .endpoint(endpoint)
     .credential(credential)


### PR DESCRIPTION
- Add requireEnvVars(AzureIdentityEnvVars.AZURE_TOKEN_CREDENTIALS) to DefaultAzureCredentialBuilder in 20 Java skills
- Add ManagedIdentityCredentialBuilder as production alternative with credential classes link
- Add AZURE_TOKEN_CREDENTIALS=prod to Environment Variables sections
- Add inline comments to all env vars explaining purpose
- Update skill-creator with Java and C# auth patterns