### PR TITLE
Update Azure Identity SDK CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 .github/plugins/azure-skills/            @microsoft/ghcp4a
 
 # Azure Identity SDK skills
-.github/plugins/*/skills/azure-identity-*/SKILL.md      @scottaddie
+.github/plugins/*/skills/azure-identity-*/SKILL.md      @g2vinay
 
 # Community-contributed skill: Microsoft Entra Agent ID
 .github/skills/entra-agent-id/           @ArLucaID @rbinrais @thegovind


### PR DESCRIPTION
The Azure Identity SDK skills should now route ownership reviews to @g2vinay instead of @scottaddie.

This updates the CODEOWNERS rule for `.github/plugins/*/skills/azure-identity-*/SKILL.md` to assign @g2vinay. No other ownership rules were changed.