### PR TITLE
docs: adds dnx to other install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ npx skills add microsoft/skills
 
 Select the skills you need from the wizard. Skills are installed to your chosen agent's directory (e.g., `.github/skills/` for GitHub Copilot) and symlinked if you use multiple agents.
 
+
+<details>
+<summary>Alternative installation methods</summary>
+
 **On .NET 10 or later?** `dnx` ships with the .NET 10 SDK and runs [`skillz`](https://www.nuget.org/packages/skillz), which is like `skills` but natively a .NET tool, no Node.js required:
 
 ```bash
 dnx skillz add microsoft/skills
 ```
-
-<details>
-<summary>Alternative installation methods</summary>
 
 **Manual installation (git clone)**
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npx skills add microsoft/skills
 
 Select the skills you need from the wizard. Skills are installed to your chosen agent's directory (e.g., `.github/skills/` for GitHub Copilot) and symlinked if you use multiple agents.
 
+**On .NET 10 or later?** `dnx` ships with the .NET 10 SDK and runs [`skillz`](https://www.nuget.org/packages/skillz), which is like `skills` but natively a .NET tool, no Node.js required:
+
+```bash
+dnx skillz add microsoft/skills
+```
+
 <details>
 <summary>Alternative installation methods</summary>
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Select the skills you need from the wizard. Skills are installed to your chosen 
 <details>
 <summary>Alternative installation methods</summary>
 
-**On .NET 10 or later?** `dnx` ships with the .NET 10 SDK and runs [`skillz`](https://www.nuget.org/packages/skillz), which is like `skills` but natively a .NET tool, no Node.js required:
+**On .NET 10 or later?** `dnx` ships with the .NET SDK and runs [`skillz`](https://www.nuget.org/packages/skillz), which is like `skills` but natively a .NET tool, no Node.js required:
 
 ```bash
 dnx skillz add microsoft/skills

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ npx skills add microsoft/skills
 
 Select the skills you need from the wizard. Skills are installed to your chosen agent's directory (e.g., `.github/skills/` for GitHub Copilot) and symlinked if you use multiple agents.
 
-
 <details>
 <summary>Alternative installation methods</summary>
 


### PR DESCRIPTION
## What

Adds dnx to the (by default collapsed) other install methods in  the readme

```bash
dnx skillz add microsoft/aspire-skills
```

## Why

We built [`skillz`](https://github.com/chillicream/skillz) to give .NET a native way to install agent skills: with the .NET 10 SDK, `dnx skillz add ...` runs the installer directly from NuGet, so the whole workflow stays in the .NET toolchain instead of requiring Node.js and the Vercel `skills` CLI.

i know aspire is not just .NET but probably a big chunk of the audience already has .net 10 installed. `skillz` is  [completely open source and ships with no telemetry]( https://github.com/chillicream/skillz), so it's a transparent, dependency-light alternative for anyone who'd rather not pull in the Node toolchain.
