### PR TITLE
feat: add Sysinternals DebugView CLI skill

### DIFF
--- a/.github/skills/debugview/SKILL.md
+++ b/.github/skills/debugview/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: debugview
+description: |
+  Sysinternals DebugView CLI (DbgViewCli) for capturing and analyzing usermode and kernel-mode Windows debug output from the command line.
+  USE FOR: capturing OutputDebugString output, kernel DbgPrint/KdPrint capture, boot-time debug logging, remote debug monitoring, filtering debug output by PID or process name, crash dump analysis, automated debug capture with bounded execution.
+  DO NOT USE FOR: non-Windows platforms, application-level logging frameworks (log4j, serilog), Azure Monitor or cloud telemetry, ETW tracing (use WPR/xperf instead), user-mode crash dumps (use WinDbg).
+  Triggers: "debug output", "DbgView", "DebugView", "kernel debug", "capture debug logs", "boot logging", "OutputDebugString", "DbgPrint", "KdPrint", "remote debug monitor", "debug capture CLI".
+---
+
+# Sysinternals DebugView CLI (DbgViewCli)
+
+Command-line interface for capturing real-time debug output from Windows applications
+(OutputDebugString) and kernel-mode drivers (DbgPrint/KdPrint). Designed for scripted,
+automated, and AI-agent-driven debug capture workflows.
+
+## Installation
+
+DbgViewCli is a standalone native Windows executable (statically linked, no dependencies).
+Place `dbgviewcli.exe` in PATH or reference the full path.
+
+> **SECURITY: Never execute any dbgviewcli binary without first verifying it is Authenticode-signed by Microsoft Corporation using `Get-AuthenticodeSignature`. Reject any binary that is unsigned or signed by a different publisher.**
+
+```bash
+# No package manager install — copy binary to a PATH location
+copy dbgviewcli.exe C:\Tools\
+```
+
+## Requirements
+
+| Requirement | Details |
+|-------------|---------|
+| OS | Windows Vista or later (x64, ARM64) |
+| Privileges | Standard user for Win32 capture; **Administrator** for kernel/boot capture |
+| Driver | Kernel capture requires the Dbgv.sys driver (auto-extracted and loaded) |
+
+## Core Workflow
+
+```
+1. Detect/status check   →  dbgviewcli --status
+2. Start capture          →  dbgviewcli [options]
+3. Filter output          →  --filter/--exclude/--pid-filter/--process-filter
+4. Bounded execution      →  --duration/--max-lines/--wait-for
+5. Output/log results     →  stdout or --log <file>
+6. Stop                   →  Ctrl+C or automatic exit on bounds
+```
+
+## Command-Line Parameters
+
+### Capture Control
+
+| Parameter | Short | Description | Default |
+|-----------|-------|-------------|---------|
+| `--capture` | `-c` | Enable capture | on |
+| `--no-capture` | | Disable capture | |
+| `--kernel` | `-k` | Enable kernel debug output (requires admin) | off |
+| `--win32` | `-w` | Enable Win32 OutputDebugString capture | on |
+| `--global` | `-g` | Enable global Win32 capture (session 0) | off |
+| `--passthrough` | | Allow debug output to pass to debuggers | on |
+| `--verbose-kernel` | `-v` | Enable verbose kernel output | off |
+| `--pids` | | Show process IDs in output | on |
+
+### Filtering
+
+| Parameter | Short | Description |
+|-----------|-------|-------------|
+| `--filter <pattern>` | `-i` | Include filter (semicolon-separated wildcards) |
+| `--exclude <pattern>` | `-e` | Exclude filter (semicolon-separated wildcards) |
+| `--pid-filter <pid>` | | Show only output from specific PID |
+| `--process-filter <name>` | | Show only output from named process (substring match) |
+
+### Bounded Execution (AI-Agent Friendly)
+
+| Parameter | Description |
+|-----------|-------------|
+| `--duration <seconds>` | Auto-stop after N seconds |
+| `--max-lines <N>` | Auto-stop after N lines captured |
+| `--wait-for <pattern>` | Capture until pattern matches, then exit |
+| `--tail <N>` | Buffer last N lines, flush on exit |
+| `--no-banner` | Suppress version banner (clean for piped output) |
+| `--status` | Print machine-readable status and exit |
+
+### Time Display
+
+| Parameter | Description |
+|-----------|-------------|
+| `--elapsed` | Elapsed time since start (default) |
+| `--clock` | Wall-clock time HH:MM:SS |
+| `--clock-ms` | Wall-clock with milliseconds HH:MM:SS.mmm |
+
+### Output Format
+
+| Parameter | Description |
+|-----------|-------------|
+| `--format text` | Tab-separated text (default) |
+| `--format csv` | Comma-separated values |
+| `--format xml` | XML elements |
+
+### Logging
+
+| Parameter | Description |
+|-----------|-------------|
+| `--log <file>` | Log output to file |
+| `--log-append` | Append to existing log |
+| `--log-limit <MB>` | Max log file size in MB |
+| `--log-wrap` | Wrap log when full |
+| `--log-daily` | New log file each day |
+
+### Boot Logging (Requires Admin)
+
+| Parameter | Description |
+|-----------|-------------|
+| `--boot-enable` | Enable boot-time kernel debug logging |
+| `--boot-disable` | Disable boot-time logging |
+| `--boot-status` | Show boot logging status and exit |
+
+### Remote Monitoring
+
+| Parameter | Description |
+|-----------|-------------|
+| `--connect <computer>` | Connect to remote DbgView instance |
+| `--disconnect` | Disconnect from remote |
+
+### Crash Dump & File Operations
+
+| Parameter | Description |
+|-----------|-------------|
+| `--crashdump <file>` | Analyze crash dump for debug output |
+| `--load <file>` | Load saved log file |
+| `--save <file>` | Save captured output on exit |
+
+### Runtime Control (Inter-Process)
+
+| Parameter | Description |
+|-----------|-------------|
+| `--pause` | Pause a running DbgViewCli instance via named event |
+| `--resume` | Resume a paused DbgViewCli instance |
+| `--stop` | Stop a running DbgViewCli instance gracefully |
+
+### Miscellaneous
+
+| Parameter | Short | Description |
+|-----------|-------|-------------|
+| `--quit` | `-q` | Terminate running GUI DbgView instance |
+| `--accepteula` | | Accept the EULA (writes registry key, skips prompt) |
+| `--version` | | Show version and exit |
+| `--help` | `-?` | Show help |
+
+## Usage Examples
+
+### Basic Win32 Capture (bounded)
+
+```bash
+# Capture for 30 seconds, no banner, output as text
+dbgviewcli --no-banner --duration 30
+
+# Capture until a specific error appears
+dbgviewcli --no-banner --wait-for "*ERROR*" --max-lines 10000
+```
+
+### Kernel Debug Capture (requires admin)
+
+```bash
+# Run as Administrator
+dbgviewcli --kernel --no-banner --duration 60 --format csv --log kernel_debug.csv
+```
+
+### Process-Specific Filtering
+
+```bash
+# Filter by PID
+dbgviewcli --no-banner --pid-filter 1234 --duration 10
+
+# Filter by process name
+dbgviewcli --no-banner --process-filter "myapp.exe" --max-lines 500
+```
+
+### Pattern-Based Filtering
+
+```bash
+# Include only lines matching pattern
+dbgviewcli --no-banner --filter "MyDriver*" --exclude "verbose*"
+```
+
+### Tail Mode (recent context)
+
+```bash
+# Capture but only output last 50 lines on exit
+dbgviewcli --no-banner --tail 50 --duration 30
+```
+
+### Status Check (machine-readable)
+
+```bash
+dbgviewcli --status
+# Output:
+# running=true
+# paused=false
+# elevated=true
+```
+
+### Boot Logging
+
+```bash
+# Enable (requires admin, persists across reboot)
+dbgviewcli --boot-enable
+
+# Check status
+dbgviewcli --boot-status
+
+# Disable
+dbgviewcli --boot-disable
+```
+
+### Remote Monitoring
+
+```bash
+dbgviewcli --connect SERVER01 --no-banner --duration 60
+```
+
+### Runtime Control (Pause/Resume/Stop)
+
+```bash
+# Pause a running instance from another terminal
+dbgviewcli --pause
+
+# Resume the paused instance
+dbgviewcli --resume
+
+# Gracefully stop a running instance
+dbgviewcli --stop
+```
+
+### EULA Acceptance (Unattended)
+
+```bash
+# Accept EULA non-interactively for automated/scripted deployments
+dbgviewcli --accepteula --no-banner --duration 30
+```
+
+## Architecture
+
+| Module | File | Purpose |
+|--------|------|---------|
+| Main | `dbgviewcli.c` | Entry point, arg parsing, capture loop, Ctrl+C handler |
+| Capture | `cli_capture.c` | DBWIN shared memory, kernel driver read |
+| Driver | `cli_driver.c` | Kernel driver load/unload, privilege elevation |
+| Filter | `cli_filter.c` | Wildcard include/exclude matching |
+| Output | `cli_output.c` | Console emit, log files, CSV/XML/text formats |
+| Boot Log | `cli_bootlog.c` | Registry config for boot-time driver loading |
+| Remote | `cli_remote.c` | TCP socket connect/read for remote monitoring |
+
+## Key Design Decisions
+
+1. **Static CRT linking** — No DLL dependencies, runs on any Windows system
+2. **stdout/stderr separation** — Debug output → stdout; errors/status → stderr
+3. **Bounded execution** — `--duration`, `--max-lines`, `--wait-for` ensure guaranteed exit for automation
+4. **Clean output** — `--no-banner` suppresses noise for pipe/agent consumption
+5. **Machine-readable status** — `--status` outputs key=value pairs for programmatic checks
+6. **Graceful shutdown** — `SetConsoleCtrlHandler` ensures clean driver unload on Ctrl+C
+
+## Best Practices
+
+1. **Always use `--no-banner` for scripted/automated use.** Banner text pollutes structured output and confuses parsers.
+2. **Always bound execution** with `--duration`, `--max-lines`, or `--wait-for`. Unbounded capture will run indefinitely.
+3. **Check status before capture** — Use `--status` to detect if another instance is already running.
+4. **Use `--format csv` or `--format xml`** when output will be parsed programmatically.
+5. **Prefer `--pid-filter` or `--process-filter`** over broad capture to reduce noise.
+6. **Run as Administrator only when needed** — kernel and boot logging require elevation; Win32 capture does not.
+7. **Combine bounds for safety** — Use `--duration 60 --max-lines 10000` together so whichever triggers first wins.
+8. **Use `--tail`** for "what just happened" queries instead of capturing full history.
+
+## Bundled Resources
+
+| Type | File | Purpose |
+|------|------|---------|
+| Script | `scripts/detect-dbgview.ps1` | Locate dbgviewcli.exe on PATH or common directories |
+| Script | `scripts/capture-wrapper.ps1` | Safe bounded capture with parameter validation |
+| Script | `scripts/boot-logging-workflow.ps1` | End-to-end boot logging lifecycle management |
+| Reference | `references/driver-ioctls.md` | Kernel driver IOCTL codes and buffer structures |
+| Reference | `references/output-formats.md` | Text/CSV/XML output format specifications |
+| Reference | `references/remote-protocol.md` | TCP remote monitoring wire protocol |
+
+## Troubleshooting
+
+| Issue | Resolution |
+|-------|-----------|
+| "Access denied" on kernel capture | Run as Administrator |
+| No output from Win32 capture | Verify target app uses `OutputDebugString`; check no debugger is attached |
+| Another instance running | Use `--status` to check; use `--quit` to terminate existing GUI instance |
+| Boot logging not capturing | Ensure `--boot-enable` was run as admin; driver must be in System32\Drivers |
+| Remote connection fails | Verify target has DbgView running with remote enabled on ports 2020-2030 |

--- a/.github/skills/debugview/references/driver-ioctls.md
+++ b/.github/skills/debugview/references/driver-ioctls.md
@@ -1,0 +1,159 @@
+# Driver IOCTLs and Buffer Formats
+
+Reference documentation for the Dbgv.sys kernel driver interface used by DbgViewCli.
+
+---
+
+## Device Identity
+
+| Property | Value |
+|----------|-------|
+| Device Type | `FILE_DEVICE_DBGMON` (`0x00008305`) |
+| Driver File | `Dbgv.sys` |
+| Service Name | `DBGV` |
+| Registry Key | `HKLM\System\CurrentControlSet\Services\Dbgv` |
+| Version | `0x320` |
+
+---
+
+## IOCTL Commands
+
+All IOCTLs use `CTL_CODE(FILE_DEVICE_DBGMON, function, method, access)`.
+
+| IOCTL Name | Function | Method | Description |
+|------------|----------|--------|-------------|
+| `DBGMON_hook` | `0x00` | `METHOD_BUFFERED` | Hook kernel debug output (start capturing DbgPrint) |
+| `DBGMON_unhook` | `0x01` | `METHOD_BUFFERED` | Unhook kernel debug output (stop capturing) |
+| `DBGMON_zerostats` | `0x02` | `METHOD_BUFFERED` | Clear the driver's internal output buffer |
+| `DBGMON_getstats` | `0x03` | `METHOD_NEITHER` | Read accumulated debug output from driver buffer |
+| `DBGMON_swallow` | `0x04` | `METHOD_BUFFERED` | Suppress pass-through of debug output to attached debuggers |
+| `DBGMON_dontswallow` | `0x05` | `METHOD_BUFFERED` | Allow debug output to pass through to debuggers |
+| `DBGMON_hookW32` | `0x06` | `METHOD_BUFFERED` | Hook Win32 debug output (session 0 global) |
+| `DBGMON_unhookW32` | `0x07` | `METHOD_BUFFERED` | Unhook Win32 debug output |
+| `DBGMON_getsequence` | `0x08` | `METHOD_BUFFERED` | Get current sequence number from driver |
+| `DBGMON_version` | `0x09` | `METHOD_BUFFERED` | Get driver version (handshake) |
+| `DBGMON_gettime` | `0x0A` | `METHOD_BUFFERED` | Get driver timer resolution |
+| `DBGMON_remotequit` | `0x0B` | `METHOD_BUFFERED` | Signal remote agent to quit |
+| `DBGMON_connect` | `0x0C` | `METHOD_BUFFERED` | Remote connection notification |
+| `DBGMON_forcecr` | `0x0D` | `METHOD_BUFFERED` | Force carriage return on output lines |
+| `DBGMON_dontforcecr` | `0x0E` | `METHOD_BUFFERED` | Don't force carriage return |
+| `DBGMON_enabledbgfilter` | `0x0F` | `METHOD_BUFFERED` | Enable debug output filtering in driver |
+| `DBGMON_restoredbgfilter` | `0x10` | `METHOD_BUFFERED` | Restore default debug output filtering |
+
+---
+
+## Buffer Structures
+
+### STORE_BUF — Driver Output Buffer
+
+The driver accumulates debug messages in a linked list of `STORE_BUF` pages.
+
+```c
+#define NUM_STORE_PAGES  1
+#define MAX_STORE        (PAGE_SIZE * NUM_STORE_PAGES - 4 * sizeof(ULONG))
+#define STORE_SIGNATURE  0xFEADDEAF
+
+#pragma pack(1)
+typedef struct _store {
+    ULONG           Signature;       // Must be STORE_SIGNATURE
+    ULONG           UpdateSequence;  // Incremented on each write
+    struct _store * Next;            // Pointer to next buffer in chain
+    ULONG           Len;             // Bytes used in Data[]
+    char            Data[MAX_STORE]; // Packed ENTRY records
+} STORE_BUF, *PSTORE_BUF;
+#pragma pack()
+```
+
+**Size:** `STORESIZE = ((sizeof(STORE_BUF) + 0xFFF) / 0x1000)` pages
+
+### STORE_BUF_DUMP64 — 64-bit Crash Dump Variant
+
+For reading driver buffers from 64-bit crash dumps (pointer width differs):
+
+```c
+#pragma pack(1)
+typedef struct _store_dump64 {
+    ULONG           Signature;       // STORE_SIGNATURE
+    ULONG           UpdateSequence;
+    ULONGLONG       Next64;          // 8 bytes (64-bit kernel pointer)
+    ULONG           Len;
+    char            Data[MAX_STORE];
+} STORE_BUF_DUMP64, *PSTORE_BUF_DUMP64;
+#pragma pack()
+```
+
+### ENTRY — Individual Debug Output Record
+
+Each entry in `Data[]` is packed sequentially:
+
+```c
+#pragma pack(1)
+typedef struct {
+    ULONG           seq;        // Sequence number
+    LARGE_INTEGER   datetime;   // File time (100ns since 1601-01-01)
+    LARGE_INTEGER   perftime;   // Performance counter value
+    char            text[0];    // Null-terminated message string
+} ENTRY, *PENTRY;
+#pragma pack()
+```
+
+**Walking entries:** Advance by `sizeof(ENTRY) + strlen(entry->text) + 1`, aligned as needed. Validate that the next entry start does not exceed `Data + Len`.
+
+### WIN32OUTPUT — Win32 Shared Memory Record
+
+Used for DBWIN shared-memory capture (OutputDebugString):
+
+```c
+typedef struct _win32rec {
+    struct _win32rec * next;       // Linked list pointer
+    ULONG              sequence;   // Sequence number
+    LARGE_INTEGER      time;       // Timestamp
+    LARGE_INTEGER      perftime;   // Performance counter
+    char               text[];     // Flexible array — null-terminated message
+} WIN32OUTPUT, *PWIN32OUTPUT;
+```
+
+### CLIENT_RESOLUTION — Timer Resolution
+
+Shared between service and GUI/CLI for timestamp calibration:
+
+```c
+typedef struct {
+    LARGE_INTEGER   TimerResolution;
+} CLIENT_RESOLUTION, *PCLIENT_RESOLUTION;
+```
+
+---
+
+## Win32 DBWIN Shared Memory Protocol
+
+DbgViewCli captures `OutputDebugString` by creating these named objects:
+
+| Object Type | Name (Local Session) | Name (Global/Session 0) |
+|-------------|---------------------|------------------------|
+| Section (File Mapping) | `DBWIN_BUFFER` | `Global\DBWIN_BUFFER` |
+| Event (buffer ready) | `DBWIN_BUFFER_READY` | `Global\DBWIN_BUFFER_READY` |
+| Event (data ready) | `DBWIN_DATA_READY` | `Global\DBWIN_DATA_READY` |
+
+**Protocol:**
+1. Create the section and events with appropriate security descriptors
+2. Signal `DBWIN_BUFFER_READY` to indicate buffer is available
+3. Wait on `DBWIN_DATA_READY` — signaled when a process calls `OutputDebugString`
+4. Read PID (first 4 bytes) + message text from the shared section
+5. Signal `DBWIN_BUFFER_READY` again for the next message
+
+---
+
+## Boot Logging Registry Configuration
+
+When boot logging is enabled, the driver loads at boot:
+
+| Registry Value | Type | Data |
+|----------------|------|------|
+| `Start` | `REG_DWORD` | `0` (SERVICE_BOOT_START) |
+| `Group` | `REG_SZ` | `System Bus Extender` |
+| `Tag` | `REG_DWORD` | `1` |
+| `Type` | `REG_DWORD` | `1` |
+| `ImagePath` | `REG_EXPAND_SZ` | `System32\Drivers\Dbgv.sys` |
+
+The driver binary must be copied to `%SystemRoot%\System32\Drivers\` before enabling.

--- a/.github/skills/debugview/references/output-formats.md
+++ b/.github/skills/debugview/references/output-formats.md
@@ -1,0 +1,153 @@
+# Output Formats
+
+DbgViewCli supports three output formats selectable via `--format <text|csv|xml>`.
+
+---
+
+## Text Format (Default)
+
+Tab-separated fields written to stdout. This is the default when `--format text` or no format is specified.
+
+### Schema
+
+```
+<sequence>\t<timestamp>\t[<pid>]\t<message>\n
+```
+
+### Fields
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| Sequence | Monotonically increasing line number | `1`, `2`, `3` |
+| Timestamp | Depends on `--elapsed`, `--clock`, `--clock-ms` | `0.123`, `14:30:05`, `14:30:05.123` |
+| PID | Process ID in brackets (when `--pids` is on) | `[1234]` |
+| Message | The debug output string | `MyDriver: Init complete` |
+
+### Timestamp Modes
+
+| Mode | Flag | Format | Example |
+|------|------|--------|---------|
+| Elapsed | `--elapsed` (default) | Seconds since capture start | `12.456` |
+| Clock | `--clock` | Wall clock HH:MM:SS | `14:30:05` |
+| Clock+ms | `--clock-ms` | Wall clock with milliseconds | `14:30:05.123` |
+
+### Example Output
+
+```
+1	0.000	[4567]	MyApp: Starting initialization
+2	0.001	[4567]	MyApp: Loading configuration
+3	0.015	[4567]	MyApp: Configuration loaded
+4	1.203	[4567]	MyApp: Ready
+```
+
+---
+
+## CSV Format
+
+Comma-separated values with header row. Selected via `--format csv`.
+
+### Schema
+
+```
+"Sequence","Timestamp","PID","Message"
+<seq>,"<timestamp>","<pid>","<message>"
+```
+
+### Rules
+
+- All fields are quoted with double quotes
+- Embedded double quotes in message text are escaped as `""`
+- Newlines in messages are preserved within quotes
+- Header row is emitted first
+
+### Example Output
+
+```csv
+"Sequence","Timestamp","PID","Message"
+"1","0.000","4567","MyApp: Starting initialization"
+"2","0.001","4567","MyApp: Loading configuration"
+"3","0.015","4567","Config value=""debug_level=3"""
+"4","1.203","4567","MyApp: Ready"
+```
+
+---
+
+## XML Format
+
+Simple XML elements. Selected via `--format xml`.
+
+### Schema
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<debugoutput>
+  <entry seq="N" time="TIMESTAMP" pid="PID"><![CDATA[MESSAGE]]></entry>
+  ...
+</debugoutput>
+```
+
+### Elements
+
+| Element/Attribute | Description |
+|-------------------|-------------|
+| `<debugoutput>` | Root element wrapping all entries |
+| `<entry>` | Single debug output line |
+| `@seq` | Sequence number |
+| `@time` | Timestamp string (format depends on time mode) |
+| `@pid` | Process ID (omitted if `--no-pids`) |
+| CDATA content | The debug message text |
+
+### Special Characters
+
+- Message content is wrapped in `<![CDATA[...]]>` to avoid XML escaping issues
+- If the message contains the literal string `]]>`, it must be split across CDATA sections
+
+### Example Output
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<debugoutput>
+  <entry seq="1" time="0.000" pid="4567"><![CDATA[MyApp: Starting initialization]]></entry>
+  <entry seq="2" time="0.001" pid="4567"><![CDATA[MyApp: Loading configuration]]></entry>
+  <entry seq="3" time="0.015" pid="4567"><![CDATA[MyApp: Config loaded]]></entry>
+  <entry seq="4" time="1.203" pid="4567"><![CDATA[MyApp: Ready]]></entry>
+</debugoutput>
+```
+
+---
+
+## Log File Options
+
+All formats can be written to a log file simultaneously with stdout output.
+
+| Option | Description |
+|--------|-------------|
+| `--log <file>` | Write output to file |
+| `--log-append` | Append to existing file instead of overwriting |
+| `--log-limit <MB>` | Maximum log file size in megabytes |
+| `--log-wrap` | When limit reached, wrap to beginning (ring buffer) |
+| `--log-daily` | Create new file each day with date suffix (e.g., `debug_20250518.log`) |
+
+### Daily Log File Naming
+
+When `--log-daily` is used with `--log debug.log`:
+- Day 1: `debug_20250518.log`
+- Day 2: `debug_20250519.log`
+
+---
+
+## Status Output Format
+
+The `--status` command outputs machine-readable key=value pairs:
+
+```
+running=true
+paused=false
+elevated=true
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `running` | boolean | Whether a DbgViewCli instance is actively capturing |
+| `paused` | boolean | Whether the running instance is paused |
+| `elevated` | boolean | Whether the current process has admin privileges |

--- a/.github/skills/debugview/references/remote-protocol.md
+++ b/.github/skills/debugview/references/remote-protocol.md
@@ -1,0 +1,167 @@
+# Remote Monitoring Protocol
+
+DbgViewCli can connect to a remote machine running DbgView (GUI or service) and
+receive debug output over TCP. This document describes the wire protocol.
+
+---
+
+## Connection
+
+### Port Scanning
+
+The client scans TCP ports `DBGVPORTLO` (2020) through `DBGVPORTHI` (2030) on the
+target machine, attempting a connection on each until one succeeds.
+
+| Constant | Value |
+|----------|-------|
+| `DBGVPORTLO` | 2020 |
+| `DBGVPORTHI` | 2030 |
+| Connection Timeout | 10 seconds (`REMOTE_CONNECT_TIMEOUT`) |
+| Update Timeout | 30 minutes (`REMOTE_UPDATE_TIMEOUT`) |
+
+### Connection Sequence
+
+```
+Client                              Remote Agent (DbgView)
+  |                                       |
+  |--- TCP connect (port 2020-2030) ----->|
+  |                                       |
+  |--- DBGMON_version (DWORD) ----------->|   Request version
+  |<-- version (DWORD) ------------------|   Response
+  |                                       |
+  |--- DBGMON_hook (DWORD) -------------->|   Start kernel capture
+  |--- DBGMON_swallow/dontswallow ------->|   Configure pass-through
+  |--- DBGMON_forcecr/dontforcecr ------->|   Configure CR mode
+  |                                       |
+  |--- DBGMON_gettime (DWORD) ----------->|   Request timer resolution
+  |<-- CLIENT_RESOLUTION (16 bytes) -----|   Timer resolution response
+  |                                       |
+  |           ... connected ...           |
+```
+
+---
+
+## Version Handshake
+
+After TCP connection is established:
+
+1. Client sends `DBGMON_version` command (4 bytes, DWORD)
+2. Remote responds with its driver version (4 bytes, DWORD)
+
+### Version Interpretation
+
+| Response Value | Meaning |
+|----------------|---------|
+| `DEBUGVIEW_VERSION` (0x320) | Compatible version — proceed |
+| `0xFFFFFFFF & ~WIN9XVERSIONBIT` | Remote has no kernel driver loaded (Win32 only) |
+| Any other value | Incompatible version — disconnect |
+
+The high bit (`WIN9XVERSIONBIT = 0x80000000`) indicates a Windows 9x remote.
+
+---
+
+## Commands (Client → Remote)
+
+All commands are sent as a single DWORD (4 bytes, little-endian).
+
+| Command | IOCTL Value | Description |
+|---------|-------------|-------------|
+| `DBGMON_hook` | `CTL_CODE(0x8305, 0x00, ...)` | Start capturing kernel debug output |
+| `DBGMON_unhook` | `CTL_CODE(0x8305, 0x01, ...)` | Stop capturing kernel debug output |
+| `DBGMON_zerostats` | `CTL_CODE(0x8305, 0x02, ...)` | Clear output buffer |
+| `DBGMON_getstats` | `CTL_CODE(0x8305, 0x03, ...)` | Request buffered output data |
+| `DBGMON_swallow` | `CTL_CODE(0x8305, 0x04, ...)` | Suppress debug pass-through |
+| `DBGMON_dontswallow` | `CTL_CODE(0x8305, 0x05, ...)` | Allow debug pass-through |
+| `DBGMON_version` | `CTL_CODE(0x8305, 0x09, ...)` | Request version |
+| `DBGMON_gettime` | `CTL_CODE(0x8305, 0x0A, ...)` | Request timer resolution |
+| `DBGMON_remotequit` | `CTL_CODE(0x8305, 0x0B, ...)` | Tell remote agent to quit |
+| `DBGMON_forcecr` | `CTL_CODE(0x8305, 0x0D, ...)` | Enable forced CR |
+| `DBGMON_dontforcecr` | `CTL_CODE(0x8305, 0x0E, ...)` | Disable forced CR |
+
+---
+
+## Data Retrieval (Polling)
+
+The client periodically requests accumulated debug output:
+
+```
+Client                              Remote Agent
+  |                                       |
+  |--- DBGMON_getstats (DWORD) --------->|
+  |<-- STORE_BUF data (up to MAX_STORE) -|
+  |                                       |
+```
+
+### Response Format
+
+The remote sends raw `STORE_BUF.Data` content — a packed sequence of `ENTRY` records:
+
+```c
+typedef struct {
+    ULONG           seq;        // Sequence number
+    LARGE_INTEGER   datetime;   // File time
+    LARGE_INTEGER   perftime;   // Performance counter
+    char            text[0];    // Null-terminated message
+} ENTRY, *PENTRY;
+```
+
+**Walking the buffer:**
+```
+offset = 0
+while offset < bytesRead:
+    entry = (ENTRY*)(buffer + offset)
+    process entry->text
+    offset += sizeof(ENTRY) + strlen(entry->text) + 1
+```
+
+### Timeout
+
+The read uses a 500ms timeout. If no data arrives within that window, the client
+continues its main loop (checking duration limits, exit signals, etc.).
+
+---
+
+## Disconnection
+
+Graceful disconnect sequence:
+
+```
+Client                              Remote Agent
+  |                                       |
+  |--- DBGMON_unhook (DWORD) ----------->|   Stop capturing
+  |--- DBGMON_remotequit (DWORD) ------->|   Request agent exit
+  |                                       |
+  |--- closesocket() ------------------->|   TCP close
+```
+
+If the connection is broken (remote closed or network error), the client detects
+this via failed `ReadFile`/`WriteFile` and sets `Closing = TRUE` to prevent
+further operations on that slot.
+
+---
+
+## Multi-Remote Support
+
+DbgViewCli supports up to `MAXREMOTE` (10) simultaneous remote connections.
+Each connection occupies a slot in the `g_ComputerInfo[MAXREMOTE]` array.
+
+| Field | Description |
+|-------|-------------|
+| `Name` | Hostname or IP of the remote |
+| `IpAddress` | Resolved IPv4 address (network byte order) |
+| `Socket` | TCP socket handle |
+| `Config` | Per-connection capture configuration |
+| `NoDriver` | TRUE if remote has no kernel driver |
+| `Closing` | TRUE if connection is being torn down |
+| `Stats` | Allocated buffer for `DBGMON_getstats` responses |
+| `ReadEvent` | Overlapped I/O event for async reads |
+| `Time` | Remote's timer resolution |
+
+---
+
+## Security Considerations
+
+- Remote monitoring uses **unencrypted TCP**. Do not use over untrusted networks.
+- The remote agent must have DbgView running with network listening enabled.
+- No authentication is performed beyond the version handshake.
+- Consider using VPN or SSH tunneling for remote debug capture over WAN.

--- a/.github/skills/debugview/scripts/boot-logging-workflow.ps1
+++ b/.github/skills/debugview/scripts/boot-logging-workflow.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+    End-to-end boot-time debug logging workflow.
+
+.DESCRIPTION
+    Manages the full lifecycle of boot-time kernel debug logging:
+    1. Enable boot logging (requires Administrator)
+    2. Optionally prompt for reboot
+    3. After reboot, read captured boot log
+    4. Disable boot logging
+
+.PARAMETER Action
+    The workflow step to perform: Enable, Status, Read, Disable, or Full.
+    - Enable: Configure boot-time driver loading
+    - Status: Check if boot logging is currently enabled
+    - Read:   Read captured boot log after reboot
+    - Disable: Remove boot-time driver configuration
+    - Full:   Interactive full workflow (enable → prompt reboot → read → disable)
+
+.PARAMETER OutputFile
+    Path to save boot log output. Default: .\boot-debug-output.log
+
+.PARAMETER Format
+    Output format for reading boot log: text, csv, or xml. Default: text.
+
+.EXAMPLE
+    .\boot-logging-workflow.ps1 -Action Enable
+
+.EXAMPLE
+    .\boot-logging-workflow.ps1 -Action Read -OutputFile .\boot.csv -Format csv
+
+.EXAMPLE
+    .\boot-logging-workflow.ps1 -Action Full
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Enable', 'Status', 'Read', 'Disable', 'Full')]
+    [string]$Action,
+
+    [string]$OutputFile = '.\boot-debug-output.log',
+
+    [ValidateSet('text', 'csv', 'xml')]
+    [string]$Format = 'text'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Require elevation for all boot logging operations
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]$identity
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "Boot logging operations require Administrator privileges."
+    exit 1
+}
+
+# Detect binary
+$dbgviewcli = & "$PSScriptRoot\detect-dbgview.ps1"
+
+function Invoke-Enable {
+    Write-Host "Enabling boot-time kernel debug logging..." -ForegroundColor Cyan
+    & $dbgviewcli --boot-enable
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Boot logging enabled. Reboot to capture boot-time debug output." -ForegroundColor Green
+    } else {
+        Write-Error "Failed to enable boot logging (exit code: $LASTEXITCODE)."
+    }
+}
+
+function Invoke-Status {
+    Write-Host "Checking boot logging status..." -ForegroundColor Cyan
+    & $dbgviewcli --boot-status
+}
+
+function Invoke-Read {
+    Write-Host "Reading boot debug output..." -ForegroundColor Cyan
+    $readArgs = @('--no-banner', '--format', $Format)
+    if ($OutputFile) {
+        $readArgs += '--log', $OutputFile
+    }
+    # Boot log is captured by the driver; use kernel read to retrieve it
+    & $dbgviewcli @readArgs --kernel --duration 5
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to read boot log (exit code: $LASTEXITCODE)."
+        return
+    }
+    if (Test-Path $OutputFile) {
+        Write-Host "Boot log saved to: $OutputFile" -ForegroundColor Green
+    }
+}
+
+function Invoke-Disable {
+    Write-Host "Disabling boot-time kernel debug logging..." -ForegroundColor Cyan
+    & $dbgviewcli --boot-disable
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Boot logging disabled." -ForegroundColor Green
+    } else {
+        Write-Error "Failed to disable boot logging (exit code: $LASTEXITCODE)."
+    }
+}
+
+switch ($Action) {
+    'Enable'  { Invoke-Enable }
+    'Status'  { Invoke-Status }
+    'Read'    { Invoke-Read }
+    'Disable' { Invoke-Disable }
+    'Full' {
+        Invoke-Enable
+        Write-Host ""
+        Write-Host "Please reboot the system to capture boot-time debug output." -ForegroundColor Yellow
+        Write-Host "After reboot, run this script again with: -Action Read" -ForegroundColor Yellow
+        Write-Host "When finished, run with: -Action Disable" -ForegroundColor Yellow
+    }
+}

--- a/.github/skills/debugview/scripts/capture-wrapper.ps1
+++ b/.github/skills/debugview/scripts/capture-wrapper.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+    Convenience wrapper for common DbgViewCli agent capture patterns.
+
+.DESCRIPTION
+    Provides a safe, bounded capture invocation suitable for AI agent use.
+    Always enforces --no-banner and at least one bound (--duration or --max-lines).
+
+.PARAMETER Duration
+    Maximum capture duration in seconds. Default: 30.
+
+.PARAMETER MaxLines
+    Maximum number of lines to capture. Default: 0 (unlimited, but Duration still applies).
+
+.PARAMETER Filter
+    Include filter pattern (semicolon-separated wildcards).
+
+.PARAMETER Exclude
+    Exclude filter pattern (semicolon-separated wildcards).
+
+.PARAMETER PidFilter
+    Filter by specific process ID.
+
+.PARAMETER ProcessFilter
+    Filter by process name (substring match).
+
+.PARAMETER WaitFor
+    Stop capture when this wildcard pattern matches.
+
+.PARAMETER Tail
+    Only output the last N lines on exit.
+
+.PARAMETER Format
+    Output format: text, csv, or xml. Default: text.
+
+.PARAMETER LogFile
+    Path to log file. If specified, output is also written to this file.
+
+.PARAMETER Kernel
+    Enable kernel-mode debug capture (requires Administrator).
+
+.EXAMPLE
+    .\capture-wrapper.ps1 -Duration 60 -ProcessFilter "myapp.exe"
+
+.EXAMPLE
+    .\capture-wrapper.ps1 -Duration 120 -Kernel -Format csv -LogFile .\kernel.csv
+#>
+[CmdletBinding()]
+param(
+    [int]$Duration = 30,
+    [int]$MaxLines = 0,
+    [string]$Filter,
+    [string]$Exclude,
+    [int]$PidFilter = 0,
+    [string]$ProcessFilter,
+    [string]$WaitFor,
+    [int]$Tail = 0,
+    [ValidateSet('text', 'csv', 'xml')]
+    [string]$Format = 'text',
+    [string]$LogFile,
+    [switch]$Kernel
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Detect binary
+$dbgviewcli = & "$PSScriptRoot\detect-dbgview.ps1"
+
+# Build argument list
+$args = @('--no-banner', '--duration', $Duration)
+
+if ($MaxLines -gt 0) { $args += '--max-lines', $MaxLines }
+if ($Filter)         { $args += '--filter', $Filter }
+if ($Exclude)        { $args += '--exclude', $Exclude }
+if ($PidFilter -gt 0){ $args += '--pid-filter', $PidFilter }
+if ($ProcessFilter)  { $args += '--process-filter', $ProcessFilter }
+if ($WaitFor)        { $args += '--wait-for', $WaitFor }
+if ($Tail -gt 0)     { $args += '--tail', $Tail }
+if ($Format -ne 'text') { $args += '--format', $Format }
+if ($LogFile)        { $args += '--log', $LogFile }
+if ($Kernel)         { $args += '--kernel' }
+
+# Elevation check for kernel capture
+if ($Kernel) {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]$identity
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Write-Error "Kernel capture requires Administrator privileges. Run this script elevated."
+        exit 1
+    }
+}
+
+Write-Verbose "Executing: $dbgviewcli $($args -join ' ')"
+& $dbgviewcli @args

--- a/.github/skills/debugview/scripts/detect-dbgview.ps1
+++ b/.github/skills/debugview/scripts/detect-dbgview.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+    Detects DbgViewCli.exe on the system.
+
+.DESCRIPTION
+    Searches PATH, common Sysinternals installation directories, and the
+    Windows Apps folder for dbgviewcli.exe. Returns the full path if found,
+    or exits with code 1 if not found.
+
+.OUTPUTS
+    The absolute path to dbgviewcli.exe if found.
+
+.EXAMPLE
+    .\detect-dbgview.ps1
+    C:\Tools\dbgviewcli.exe
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$candidates = @(
+    # 1. Check PATH
+    (Get-Command 'dbgviewcli.exe' -ErrorAction SilentlyContinue)?.Source
+
+    # 2. Common Sysinternals locations
+    "$env:ProgramFiles\Sysinternals\dbgviewcli.exe"
+    "$env:ProgramFiles\SysinternalsSuite\dbgviewcli.exe"
+    "C:\Tools\dbgviewcli.exe"
+    "C:\SysinternalsSuite\dbgviewcli.exe"
+    "$env:LOCALAPPDATA\Microsoft\WindowsApps\dbgviewcli.exe"
+)
+
+$foundButUntrusted = $false
+
+foreach ($path in $candidates) {
+    if ($path -and (Test-Path -LiteralPath $path)) {
+        $sig = Get-AuthenticodeSignature -FilePath $path
+        if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notlike '*Microsoft Corporation*') {
+            Write-Warning "SKIPPED: '$path' is not signed by Microsoft Corporation."
+            $foundButUntrusted = $true
+            continue
+        }
+        Write-Output $path
+        exit 0
+    }
+}
+
+if ($foundButUntrusted) {
+    Write-Error "dbgviewcli.exe found but no candidate was signed by Microsoft Corporation."
+} else {
+    Write-Error "dbgviewcli.exe not found. Place it in PATH or a standard Sysinternals directory."
+}
+exit 1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Skills, custom agents, AGENTS.md templates, and MCP configurations for AI coding
 
 > **Blog post:** [Context-Driven Development: Agent Skills for Microsoft Foundry and Azure](https://devblogs.microsoft.com/all-things-azure/context-driven-development-agent-skills-for-microsoft-foundry-and-azure/)
 
-> **🔍 Skill Explorer:** [Browse all 174 skills with 1-click install](https://microsoft.github.io/skills/)
+> **🔍 Skill Explorer:** [Browse all 175 skills with 1-click install](https://microsoft.github.io/skills/)
 
 ## Quick Start
 
@@ -70,11 +70,11 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 ## Skill Catalog
 
-> 174 skills across language plugins — see [skill catalog](#skill-catalog) below for the full breakdown
+> 175 skills across language plugins — see [skill catalog](#skill-catalog) below for the full breakdown
 
 | Language | Count | Suffix |
 |----------|-------|--------|
-| [Core](#core) | 10 | — |
+| [Core](#core) | 11 | — |
 | [Foundry (Language-Agnostic)](#foundry-language-agnostic) | 11 | — |
 | [Python](#python) | 39 | `-py` |
 | [.NET](#net) | 28 | `-dotnet` |
@@ -86,11 +86,12 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 ### Core
 
-> 10 skills — tooling, infrastructure, language-agnostic
+> 11 skills — tooling, infrastructure, language-agnostic
 
 | Skill | Description |
 |-------|-------------|
 | [cloud-solution-architect](.github/skills/cloud-solution-architect/) | Design well-architected Azure cloud systems. Architecture styles, 44 design patterns, technology choices, mission-critical design, WAF pillars. |
+| [debugview](.github/skills/debugview/) | Sysinternals DebugView CLI — capture and analyze usermode/kernel-mode Windows debug output. Bounded execution, filtering, boot logging, remote monitoring. |
 | [copilot-sdk](.github/skills/copilot-sdk/) | Build applications powered by GitHub Copilot using the Copilot SDK. Session management, custom tools, streaming, hooks, MCP servers, BYOK, deployment patterns. |
 | [entra-agent-id](.github/skills/entra-agent-id/) | Microsoft Entra Agent ID (preview) — create OAuth2-capable AI agent identities via Microsoft Graph beta API. Blueprints, BlueprintPrincipals, permissions, WIF. |
 | [frontend-design-review](.github/skills/frontend-design-review/) | Review and create distinctive frontend interfaces. Design system compliance, quality pillars, accessibility, and creative aesthetics. |
@@ -653,11 +654,11 @@ pnpm test
 
 ### Test Coverage Summary
 
-**128 skills with 1158 test scenarios** — all skills have acceptance criteria and test scenarios.
+**129 skills with 1169 test scenarios** — all skills have acceptance criteria and test scenarios.
 
 | Language | Skills | Scenarios | Top Skills by Scenarios |
 |----------|--------|-----------|-------------------------|
-| Core | 7 | 72 | `copilot-sdk` (11), `podcast-generation` (8), `skill-creator` (8) |
+| Core | 8 | 83 | `copilot-sdk` (11), `debugview` (11), `podcast-generation` (8) |
 | Python | 41 | 331 | `azure-ai-projects-py` (12), `pydantic-models-py` (12), `azure-ai-translation-text-py` (11) |
 | .NET | 29 | 290 | `azure-resource-manager-sql-dotnet` (14), `azure-resource-manager-redis-dotnet` (14), `azure-servicebus-dotnet` (13) |
 | TypeScript | 25 | 270 | `azure-storage-blob-ts` (17), `azure-servicebus-ts` (14), `aspire-ts` (13) |

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 | Skill | Description |
 |-------|-------------|
 | [cloud-solution-architect](.github/skills/cloud-solution-architect/) | Design well-architected Azure cloud systems. Architecture styles, 44 design patterns, technology choices, mission-critical design, WAF pillars. |
-| [debugview](.github/skills/debugview/) | Sysinternals DebugView CLI — capture and analyze usermode/kernel-mode Windows debug output. Bounded execution, filtering, boot logging, remote monitoring. |
 | [copilot-sdk](.github/skills/copilot-sdk/) | Build applications powered by GitHub Copilot using the Copilot SDK. Session management, custom tools, streaming, hooks, MCP servers, BYOK, deployment patterns. |
+| [debugview](.github/skills/debugview/) | Sysinternals DebugView CLI — capture and analyze usermode/kernel-mode Windows debug output. Bounded execution, filtering, boot logging, remote monitoring. |
 | [entra-agent-id](.github/skills/entra-agent-id/) | Microsoft Entra Agent ID (preview) — create OAuth2-capable AI agent identities via Microsoft Graph beta API. Blueprints, BlueprintPrincipals, permissions, WIF. |
 | [frontend-design-review](.github/skills/frontend-design-review/) | Review and create distinctive frontend interfaces. Design system compliance, quality pillars, accessibility, and creative aesthetics. |
 | [github-issue-creator](.github/skills/github-issue-creator/) | Convert raw notes, error logs, or screenshots into structured GitHub issues. |

--- a/tests/scenarios/debugview/acceptance-criteria.md
+++ b/tests/scenarios/debugview/acceptance-criteria.md
@@ -1,0 +1,257 @@
+# Acceptance Criteria: debugview
+
+**Tool**: Sysinternals DebugView CLI (DbgViewCli)
+**Repository**: https://github.com/nicksysinern/dbgview (internal)
+**Purpose**: Validate correct usage of DbgView CLI skill for capturing Windows debug output
+
+---
+
+## 1. Bounded Execution Patterns
+
+### 1.1 Duration Limit
+
+#### ✅ CORRECT: Bounded capture with duration
+
+```bash
+dbgviewcli --no-banner --duration 30
+```
+
+#### ❌ INCORRECT: Unbounded capture (will run forever)
+
+```bash
+dbgviewcli
+```
+
+### 1.2 Line Limit
+
+#### ✅ CORRECT: Stop after N lines
+
+```bash
+dbgviewcli --no-banner --max-lines 1000
+```
+
+#### ❌ INCORRECT: No limit for automated use
+
+```bash
+dbgviewcli --no-banner
+# Missing --duration, --max-lines, or --wait-for
+```
+
+### 1.3 Pattern-Based Exit
+
+#### ✅ CORRECT: Exit when pattern matches
+
+```bash
+dbgviewcli --no-banner --wait-for "*FATAL*" --duration 120
+```
+
+#### ❌ INCORRECT: wait-for without a safety timeout
+
+```bash
+dbgviewcli --no-banner --wait-for "*FATAL*"
+# If pattern never matches, runs forever
+```
+
+---
+
+## 2. Privilege Awareness
+
+### 2.1 Kernel Capture
+
+#### ✅ CORRECT: Acknowledge admin requirement
+
+```bash
+# Run as Administrator for kernel capture
+dbgviewcli --kernel --no-banner --duration 30
+```
+
+#### ❌ INCORRECT: Kernel capture without elevation note
+
+```bash
+dbgviewcli --kernel --duration 30
+# Will fail silently or error without admin
+```
+
+### 2.2 Boot Logging
+
+#### ✅ CORRECT: Admin-only boot operations
+
+```bash
+# Must be run as Administrator
+dbgviewcli --boot-enable
+dbgviewcli --boot-status
+dbgviewcli --boot-disable
+```
+
+#### ❌ INCORRECT: Boot logging without elevation
+
+```bash
+dbgviewcli --boot-enable
+# Will fail — registry access denied
+```
+
+---
+
+## 3. Output Format Patterns
+
+### 3.1 Machine-Readable Output
+
+#### ✅ CORRECT: Clean output for parsing
+
+```bash
+dbgviewcli --no-banner --format csv --duration 10
+dbgviewcli --no-banner --format xml --duration 10
+```
+
+#### ❌ INCORRECT: Text format with banner for programmatic use
+
+```bash
+dbgviewcli --format csv
+# Banner text on stderr will confuse naive parsers
+```
+
+### 3.2 Status Check
+
+#### ✅ CORRECT: Machine-readable status
+
+```bash
+dbgviewcli --status
+# Output: running=true\npaused=false\nelevated=true
+```
+
+#### ❌ INCORRECT: Parsing process list to detect DbgView
+
+```bash
+tasklist | findstr dbgview
+# Fragile — use --status instead
+```
+
+---
+
+## 4. Filtering Patterns
+
+### 4.1 Process-Specific Capture
+
+#### ✅ CORRECT: PID or process name filter
+
+```bash
+dbgviewcli --no-banner --pid-filter 4567 --duration 30
+dbgviewcli --no-banner --process-filter "myservice.exe" --duration 30
+```
+
+#### ❌ INCORRECT: Capture all then grep
+
+```bash
+dbgviewcli --no-banner --duration 30 | findstr "myservice"
+# Inefficient — use built-in filters instead
+```
+
+### 4.2 Wildcard Include/Exclude
+
+#### ✅ CORRECT: Semicolon-separated patterns
+
+```bash
+dbgviewcli --no-banner --filter "MyDriver*;Network*" --exclude "verbose*;trace*"
+```
+
+#### ❌ INCORRECT: Regex syntax (not supported)
+
+```bash
+dbgviewcli --filter "MyDriver|Network"
+# Filters use wildcard glob, not regex
+```
+
+---
+
+## 5. Resource Cleanup Patterns
+
+### 5.1 Graceful Shutdown
+
+#### ✅ CORRECT: Bounded execution ensures cleanup
+
+```bash
+dbgviewcli --no-banner --duration 30
+# Ctrl+C also triggers graceful shutdown (driver unload, file close)
+```
+
+#### ❌ INCORRECT: Kill process without cleanup
+
+```bash
+taskkill /F /IM dbgviewcli.exe
+# May leave kernel driver loaded or log file unclosed
+```
+
+### 5.2 Boot Logging Cleanup
+
+#### ✅ CORRECT: Always disable boot logging when done
+
+```bash
+dbgviewcli --boot-enable
+# ... reboot and capture ...
+dbgviewcli --boot-disable
+```
+
+#### ❌ INCORRECT: Leave boot logging enabled indefinitely
+
+```bash
+dbgviewcli --boot-enable
+# Forgot to disable — driver loads on every boot
+```
+
+---
+
+## 6. Remote Monitoring Patterns
+
+### 6.1 Remote Connection
+
+#### ✅ CORRECT: Remote with bounded execution
+
+```bash
+dbgviewcli --connect SERVER01 --no-banner --duration 60
+```
+
+#### ❌ INCORRECT: Remote without bounds
+
+```bash
+dbgviewcli --connect SERVER01
+# Unbounded remote capture
+```
+
+---
+
+## 7. Logging Patterns
+
+### 7.1 File Logging with Limits
+
+#### ✅ CORRECT: Bounded log file
+
+```bash
+dbgviewcli --no-banner --log debug.log --log-limit 100 --log-wrap --duration 3600
+```
+
+#### ❌ INCORRECT: Unbounded log file
+
+```bash
+dbgviewcli --log debug.log
+# No size limit — can fill disk
+```
+
+---
+
+## 8. Combined Safety Patterns
+
+### 8.1 Defense-in-Depth Bounds
+
+#### ✅ CORRECT: Multiple bounds for safety
+
+```bash
+dbgviewcli --no-banner --duration 60 --max-lines 10000 --wait-for "*COMPLETE*"
+# Whichever triggers first wins
+```
+
+#### ❌ INCORRECT: Single point of failure
+
+```bash
+dbgviewcli --no-banner --wait-for "*COMPLETE*"
+# If pattern never matches, runs forever
+```

--- a/tests/scenarios/debugview/scenarios.yaml
+++ b/tests/scenarios/debugview/scenarios.yaml
@@ -1,0 +1,508 @@
+config:
+  model: gpt-4
+  max_tokens: 2000
+  temperature: 0.3
+
+scenarios:
+  - name: basic_win32_capture
+    prompt: |
+      I need to capture OutputDebugString output from a Windows application
+      for 30 seconds using the command line. Show me how.
+    expected_patterns:
+      - "dbgviewcli"
+      - "--no-banner"
+      - "--duration"
+    forbidden_patterns:
+      - "Linux"
+      - "macOS"
+      - "syslog"
+    tags:
+      - basic
+      - win32
+    mock_response: |
+      dbgviewcli --no-banner --duration 30
+
+  - name: kernel_capture_elevated
+    prompt: |
+      I want to capture kernel-mode debug output (DbgPrint) from my
+      Windows driver for 60 seconds and save it to a CSV file.
+    expected_patterns:
+      - "--kernel"
+      - "--no-banner"
+      - "--duration"
+      - "--format csv"
+      - "admin"
+    forbidden_patterns:
+      - "usermode only"
+      - "not supported"
+    tags:
+      - kernel
+      - privileges
+      - logging
+    mock_response: |
+      # Run as Administrator
+      dbgviewcli --kernel --no-banner --duration 60 --format csv --log kernel_output.csv
+
+  - name: process_filter_by_pid
+    prompt: |
+      I only want to see debug output from process ID 5678. Capture for
+      10 seconds with no banner.
+    expected_patterns:
+      - "--pid-filter"
+      - "5678"
+      - "--no-banner"
+      - "--duration"
+    forbidden_patterns:
+      - "findstr"
+      - "grep"
+    tags:
+      - filtering
+      - pid
+    mock_response: |
+      dbgviewcli --no-banner --pid-filter 5678 --duration 10
+
+  - name: process_filter_by_name
+    prompt: |
+      Capture debug output only from myservice.exe for up to 500 lines.
+    expected_patterns:
+      - "--process-filter"
+      - "myservice"
+      - "--max-lines"
+      - "--no-banner"
+    forbidden_patterns:
+      - "tasklist"
+      - "findstr"
+    tags:
+      - filtering
+      - process-name
+    mock_response: |
+      dbgviewcli --no-banner --process-filter "myservice.exe" --max-lines 500
+
+  - name: wait_for_pattern
+    prompt: |
+      I need to capture debug output until I see an error message containing
+      "FATAL ERROR" in the output. Add a safety timeout of 2 minutes.
+    expected_patterns:
+      - "--wait-for"
+      - "FATAL"
+      - "--duration"
+      - "--no-banner"
+    forbidden_patterns:
+      - "unbounded"
+      - "forever"
+    tags:
+      - pattern
+      - bounded
+    mock_response: |
+      dbgviewcli --no-banner --wait-for "*FATAL ERROR*" --duration 120
+
+  - name: tail_recent_output
+    prompt: |
+      I want to capture debug output for 30 seconds but only show me
+      the last 50 lines when it finishes.
+    expected_patterns:
+      - "--tail"
+      - "50"
+      - "--duration"
+      - "--no-banner"
+    tags:
+      - tail
+      - recent
+    mock_response: |
+      dbgviewcli --no-banner --tail 50 --duration 30
+
+  - name: boot_logging_workflow
+    prompt: |
+      I need to enable boot-time debug logging to capture driver output
+      during Windows startup. Show me the full workflow.
+    expected_patterns:
+      - "--boot-enable"
+      - "--boot-disable"
+      - "admin"
+    forbidden_patterns:
+      - "regedit"
+      - "registry editor"
+    tags:
+      - boot
+      - advanced
+      - privileges
+    mock_response: |
+      # Step 1: Enable boot logging (requires Administrator)
+      dbgviewcli --boot-enable
+
+      # Step 2: Reboot the system
+      # The driver will capture debug output during boot
+
+      # Step 3: After reboot, read the captured boot log
+      dbgviewcli --load <boot_log_path>
+
+      # Step 4: Disable boot logging when done
+      dbgviewcli --boot-disable
+
+  - name: status_check
+    prompt: |
+      How do I check if DbgView is already running and what its state is?
+    expected_patterns:
+      - "--status"
+      - "running"
+      - "paused"
+    forbidden_patterns:
+      - "tasklist"
+      - "Get-Process"
+    tags:
+      - status
+      - detection
+    mock_response: |
+      dbgviewcli --status
+      # Output (key=value, machine-readable):
+      # running=true
+      # paused=false
+      # elevated=true
+
+  - name: remote_monitoring
+    prompt: |
+      I want to monitor debug output from a remote machine named DEVSERVER01
+      for 2 minutes.
+    expected_patterns:
+      - "--connect"
+      - "DEVSERVER01"
+      - "--duration"
+      - "--no-banner"
+    tags:
+      - remote
+      - monitoring
+    mock_response: |
+      dbgviewcli --connect DEVSERVER01 --no-banner --duration 120
+
+  - name: include_exclude_filters
+    prompt: |
+      Capture debug output but only include lines from "NetworkDriver" or
+      "StorageDriver" and exclude any lines containing "verbose" or "trace".
+    expected_patterns:
+      - "--filter"
+      - "--exclude"
+      - "--no-banner"
+    forbidden_patterns:
+      - "regex"
+      - "findstr"
+      - "|"
+    tags:
+      - filtering
+      - wildcards
+    mock_response: |
+      dbgviewcli --no-banner --filter "NetworkDriver*;StorageDriver*" --exclude "verbose*;trace*" --duration 60
+
+  - name: combined_safety_bounds
+    prompt: |
+      I want to capture kernel debug output with multiple safety limits:
+      max 2 minutes, max 5000 lines, and stop if I see "BUGCHECK".
+      Save to XML format.
+    expected_patterns:
+      - "--kernel"
+      - "--duration"
+      - "--max-lines"
+      - "--wait-for"
+      - "--format xml"
+      - "--no-banner"
+      - "admin"
+    tags:
+      - combined
+      - safety
+      - advanced
+    mock_response: |
+      # Run as Administrator
+      dbgviewcli --kernel --no-banner --duration 120 --max-lines 5000 --wait-for "*BUGCHECK*" --format xml --log kernel_debug.xml
+
+  - name: log_file_with_rotation
+    prompt: |
+      Set up a long-running debug capture that logs to a file with a
+      100MB size limit and wraps when full.
+    expected_patterns:
+      - "--log"
+      - "--log-limit"
+      - "--log-wrap"
+      - "--no-banner"
+    forbidden_patterns:
+      - "unlimited"
+    tags:
+      - logging
+      - rotation
+    mock_response: |
+      dbgviewcli --no-banner --log debug_output.log --log-limit 100 --log-wrap --duration 3600
+
+  - name: runtime_pause_resume
+    prompt: |
+      I have a DbgViewCli instance running in another terminal. I want to
+      pause it temporarily and then resume it later. How do I do that?
+    expected_patterns:
+      - "--pause"
+      - "--resume"
+    forbidden_patterns:
+      - "taskkill"
+      - "Ctrl+C"
+    tags:
+      - runtime-control
+      - pause
+    mock_response: |
+      # Pause the running DbgViewCli instance
+      dbgviewcli --pause
+
+      # Resume it when ready
+      dbgviewcli --resume
+
+  - name: runtime_stop
+    prompt: |
+      I need to gracefully stop a DbgViewCli instance running in another
+      terminal from my current terminal session.
+    expected_patterns:
+      - "--stop"
+    forbidden_patterns:
+      - "taskkill"
+      - "kill"
+      - "Ctrl+C"
+    tags:
+      - runtime-control
+      - stop
+    mock_response: |
+      # Gracefully stop the running instance
+      dbgviewcli --stop
+
+  - name: eula_acceptance_unattended
+    prompt: |
+      I need to run DbgViewCli in an automated CI/CD pipeline where there
+      is no user to accept the EULA. How do I handle this?
+    expected_patterns:
+      - "--accepteula"
+      - "--no-banner"
+    forbidden_patterns:
+      - "interactive"
+      - "click"
+    tags:
+      - automation
+      - eula
+    mock_response: |
+      # Accept EULA non-interactively for automated deployments
+      dbgviewcli --accepteula --no-banner --duration 30
+
+  - name: crashdump_analysis
+    prompt: |
+      I have a crash dump file at C:\dumps\memory.dmp and I want to
+      extract any debug output that was captured before the crash.
+    expected_patterns:
+      - "--crashdump"
+      - "--no-banner"
+    forbidden_patterns:
+      - "WinDbg"
+      - "kd"
+    tags:
+      - crashdump
+      - analysis
+    mock_response: |
+      dbgviewcli --no-banner --crashdump "C:\dumps\memory.dmp"
+
+  - name: csv_output_to_file
+    prompt: |
+      Capture kernel debug output for 2 minutes, format as CSV, and save
+      to a file for later analysis in Excel.
+    expected_patterns:
+      - "--kernel"
+      - "--format csv"
+      - "--log"
+      - "--duration"
+      - "--no-banner"
+      - "admin"
+    tags:
+      - output-format
+      - logging
+      - kernel
+    mock_response: |
+      # Run as Administrator
+      dbgviewcli --kernel --no-banner --duration 120 --format csv --log kernel_output.csv
+
+  - name: xml_format_output
+    prompt: |
+      I want to capture debug output in XML format for 15 seconds so I
+      can parse it with an XML library.
+    expected_patterns:
+      - "--format xml"
+      - "--no-banner"
+      - "--duration"
+    tags:
+      - output-format
+      - xml
+    mock_response: |
+      dbgviewcli --no-banner --format xml --duration 15
+
+  - name: clock_time_display
+    prompt: |
+      Capture debug output showing wall-clock time with milliseconds
+      instead of elapsed time, for 30 seconds.
+    expected_patterns:
+      - "--clock-ms"
+      - "--no-banner"
+      - "--duration"
+    tags:
+      - time-display
+      - basic
+    mock_response: |
+      dbgviewcli --no-banner --clock-ms --duration 30
+
+  - name: global_win32_capture
+    prompt: |
+      I need to capture OutputDebugString output from services running
+      in session 0, not just my own user session.
+    expected_patterns:
+      - "--global"
+      - "--no-banner"
+      - "--duration"
+    forbidden_patterns:
+      - "session 1"
+    tags:
+      - win32
+      - global
+      - advanced
+    mock_response: |
+      # Global Win32 capture includes session 0 (services)
+      dbgviewcli --global --no-banner --duration 60
+
+  # ============================================================
+  # NEGATIVE SCENARIOS — Agent should refuse or correct these
+  # ============================================================
+
+  - name: negative_unbounded_capture
+    prompt: |
+      Just start capturing debug output and show me everything.
+      Don't worry about stopping — I'll kill it manually.
+    expected_patterns:
+      - "--duration"
+      - "--max-lines"
+      - "--no-banner"
+    forbidden_patterns:
+      - "dbgviewcli\n"
+      - "run indefinitely"
+      - "kill"
+      - "taskkill"
+    tags:
+      - negative
+      - bounded
+      - safety
+    mock_response: |
+      # Always use bounded execution for automated/agent use
+      dbgviewcli --no-banner --duration 60 --max-lines 10000
+      # Never run unbounded — use --duration, --max-lines, or --wait-for
+
+  - name: negative_wrong_platform_linux
+    prompt: |
+      I'm running Ubuntu 22.04. How do I use DbgView to capture
+      debug output from my Linux application?
+    expected_patterns:
+      - "Windows"
+      - "not supported"
+    forbidden_patterns:
+      - "dbgviewcli"
+      - "sudo"
+      - "apt"
+      - "--duration"
+    tags:
+      - negative
+      - platform
+    mock_response: |
+      DbgViewCli is a Windows-only tool for capturing OutputDebugString and
+      kernel DbgPrint output. It is not available on Linux.
+
+      For Linux debug output, consider:
+      - strace / ltrace for system call tracing
+      - journalctl for systemd journal
+      - dmesg for kernel messages
+      - Application-specific logging (syslog, stderr)
+
+  - name: negative_wrong_platform_macos
+    prompt: |
+      Can I use DebugView on my Mac to capture debug logs from my
+      macOS application?
+    expected_patterns:
+      - "Windows"
+      - "not supported"
+    forbidden_patterns:
+      - "dbgviewcli"
+      - "brew"
+      - "--duration"
+    tags:
+      - negative
+      - platform
+    mock_response: |
+      DbgViewCli is a Windows-only tool. It cannot run on macOS.
+
+      For macOS debug output, consider:
+      - Console.app for system log viewing
+      - log stream / log show for unified logging
+      - os_log for application instrumentation
+      - lldb for debugger-attached output
+
+  - name: negative_kernel_without_elevation
+    prompt: |
+      Capture kernel debug output for 30 seconds. I'm running as a
+      standard user, not administrator.
+    expected_patterns:
+      - "admin"
+      - "elevat"
+      - "--kernel"
+    forbidden_patterns:
+      - "dbgviewcli --kernel --no-banner --duration 30\n"
+    tags:
+      - negative
+      - privileges
+      - kernel
+    mock_response: |
+      Kernel capture requires Administrator privileges. You must:
+
+      1. Open an elevated (Run as Administrator) terminal
+      2. Then run:
+         dbgviewcli --kernel --no-banner --duration 30
+
+      Without elevation, the kernel driver cannot be loaded and
+      kernel debug output will not be captured.
+
+  - name: negative_waitfor_without_timeout
+    prompt: |
+      Capture debug output and stop only when you see "COMPLETED"
+      in the output. No time limit needed.
+    expected_patterns:
+      - "--wait-for"
+      - "--duration"
+    forbidden_patterns:
+      - "dbgviewcli --no-banner --wait-for"
+    tags:
+      - negative
+      - bounded
+      - safety
+    mock_response: |
+      # Always pair --wait-for with a safety --duration timeout
+      dbgviewcli --no-banner --wait-for "*COMPLETED*" --duration 300
+
+      # IMPORTANT: Never use --wait-for alone. If the pattern never
+      # matches, the capture would run indefinitely. Always add a
+      # --duration safety limit.
+
+  - name: negative_etw_tracing_request
+    prompt: |
+      I need to capture ETW trace events from my Windows application
+      using DebugView.
+    expected_patterns:
+      - "ETW"
+      - "not"
+    forbidden_patterns:
+      - "dbgviewcli"
+      - "--duration"
+    tags:
+      - negative
+      - scope
+    mock_response: |
+      DbgViewCli captures OutputDebugString and kernel DbgPrint output only.
+      It does not capture ETW (Event Tracing for Windows) events.
+
+      For ETW tracing, use:
+      - WPR (Windows Performance Recorder) for capture
+      - WPA (Windows Performance Analyzer) for analysis
+      - xperf for command-line ETW tracing
+      - logman for trace session management


### PR DESCRIPTION
Adds a skill for Sysinternals DebugView CLI (dbgviewcli.exe) - a command-line tool for capturing real-time Win32 (OutputDebugString) and kernel-mode (DbgPrint/KdPrint) debug output on Windows.

This skill enables AI coding agents to invoke DebugView with correct command-line parameters for common debugging workflows: bounded capture, PID/process filtering, boot-time logging, remote monitoring, and structured output (CSV/XML).

What's included:

1. SKILL.md - full command reference, usage examples, best practices, and troubleshooting
2. Reference docs (driver IOCTLs, output formats, remote protocol)
3. Helper scripts (capture wrapper, boot-logging workflow, binary detection)
4. Test scenarios with acceptance criteria
5. README catalog registration under Core skills