### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/.github/docs/agent-integration.md
+++ b/.github/docs/agent-integration.md
@@ -54,6 +54,30 @@ For Azure Cosmos DB work, load the `azure-cosmos-db-py` skill.
 For FastAPI endpoints, load the `fastapi-router-py` skill.
 ```
 
+## Autohand Code Discovery
+
+Autohand Code discovers skills from user-level and project-level skill directories:
+
+```text
+~/.autohand/skills/<skill>/
+<project>/.autohand/skills/<skill>/
+```
+
+Use the cataloged overview skill when you want high-level Microsoft SDK grounding:
+
+```bash
+autohand --skill-install microsoft-skills
+autohand --skill-install microsoft-skills --project
+```
+
+For a specific repository skill, copy or symlink only the skill directories relevant to the current project:
+
+```bash
+git clone https://github.com/microsoft/skills.git microsoft-skills
+mkdir -p your-project/.autohand/skills
+cp -r microsoft-skills/.github/skills/azure-cosmos-db-py your-project/.autohand/skills/
+```
+
 ## Progressive Disclosure
 
 Skills use a three-tier loading strategy to manage context efficiently:
@@ -131,8 +155,13 @@ npx skills add microsoft/agent-skills
 # Copy specific skills
 cp -r agent-skills/.github/skills/azure-cosmos-db-py your-project/.github/skills/
 
+# Copy specific skills for Autohand Code
+mkdir -p your-project/.autohand/skills
+cp -r agent-skills/.github/skills/azure-cosmos-db-py your-project/.autohand/skills/
+
 # Or symlink for multi-project setups
 ln -s /path/to/agent-skills/.github/skills/mcp-builder /path/to/your-project/.github/skills/mcp-builder
+ln -s /path/to/agent-skills/.github/skills/mcp-builder /path/to/your-project/.autohand/skills/mcp-builder
 ```
 
 ## Skill Naming Convention

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ npx skills add microsoft/skills
 
 Select the skills you need from the wizard. Skills are installed to your chosen agent's directory (e.g., `.github/skills/` for GitHub Copilot) and symlinked if you use multiple agents.
 
+Autohand Code users can install the cataloged Microsoft Skills overview with:
+
+```bash
+autohand --skill-install microsoft-skills
+autohand --skill-install microsoft-skills --project
+```
+
 <details>
 <summary>Alternative installation methods</summary>
 
@@ -32,12 +39,19 @@ Select the skills you need from the wizard. Skills are installed to your chosen 
 git clone https://github.com/microsoft/skills.git
 cp -r agent-skills/.github/skills/azure-cosmos-db-py your-project/.github/skills/
 
+# Copy a specific skill into an Autohand Code project
+git clone https://github.com/microsoft/skills.git microsoft-skills
+mkdir -p your-project/.autohand/skills
+cp -r microsoft-skills/.github/skills/azure-cosmos-db-py your-project/.autohand/skills/
+
 # Or use symlinks for multi-project setups
 ln -s /path/to/agent-skills/.github/skills/mcp-builder /path/to/your-project/.github/skills/mcp-builder
+ln -s /path/to/microsoft-skills/.github/skills/mcp-builder /path/to/your-project/.autohand/skills/mcp-builder
 
 # Share skills across different agent configs in the same repo
 ln -s ../.github/skills .opencode/skills
 ln -s ../.github/skills .claude/skills
+ln -s ../.github/skills .autohand/skills
 ```
 
 </details>


### PR DESCRIPTION
Hi, thanks for maintaining this skills collection. I noticed the public Autohand Skills index already includes a `microsoft-skills` overview entry, and the repo also supports direct skill-directory installs, so this adds Autohand Code guidance to the existing install docs.

What changed:
- document `autohand --skill-install microsoft-skills` and `--project` in the Quick Start
- add project-local `.autohand/skills/` copy and symlink examples for specific skills
- add an Autohand Code discovery section to `.github/docs/agent-integration.md`

Validation:
- `git diff --check`

I did not run the docs-site build because this patch only changes Markdown docs, not Astro/source data or generated site artifacts.