### PR TITLE
skill-creator: lifecycle guidance and Azure SDK patterns reference

### DIFF
--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -204,7 +204,7 @@ Every Python Azure SDK skill MUST open its `## Authentication & Lifecycle` secti
 
 > **🔑 Two rules apply to every code sample below:**
 >
-> 1. **Prefer `DefaultAzureCredential`.** It works locally (Azure CLI / VS Code / Developer CLI) and in Azure (managed identity, workload identity) with no code change. Avoid connection strings, account/API keys — they bypass Entra audit and rotation.
+> 1. **Prefer `DefaultAzureCredential` for local development.** It works as-is with Azure CLI / VS Code / Developer CLI. For production, either constrain `DefaultAzureCredential` to production-safe credentials or use a specific credential directly. Avoid connection strings, account/API keys — they bypass Entra audit and rotation.
 >    - Local dev: `DefaultAzureCredential` works as-is.
 >    - Production: set `AZURE_TOKEN_CREDENTIALS=prod` (or `AZURE_TOKEN_CREDENTIALS=<specific_credential>`) to constrain the credential chain to production-safe credentials.
 > 2. **Wrap every client in a context manager** so HTTP transports, sockets, and token caches are released deterministically:
@@ -625,7 +625,7 @@ AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used i
 
 > **🔑 Two rules apply to every code sample below:**
 >
-> 1. **Prefer `DefaultAzureCredential`.** It works locally (Azure CLI / VS Code / Developer CLI) and in Azure (managed identity, workload identity) with no code change. Avoid connection strings, account/API keys — they bypass Entra audit and rotation.
+> 1. **Prefer `DefaultAzureCredential` for local development.** It works as-is with Azure CLI / VS Code / Developer CLI. For production, either constrain `DefaultAzureCredential` to production-safe credentials or use a specific credential directly. Avoid connection strings, account/API keys — they bypass Entra audit and rotation.
 >    - Local dev: `DefaultAzureCredential` works as-is.
 >    - Production: set `AZURE_TOKEN_CREDENTIALS=prod` (or `AZURE_TOKEN_CREDENTIALS=<specific_credential>`) to constrain the credential chain to production-safe credentials.
 > 2. **Wrap every client in a context manager** so HTTP transports, sockets, and token caches are released deterministically:
@@ -1019,20 +1019,13 @@ After creating the skill:
    - Update test coverage summary (line ~622: `**N skills with N test scenarios**`)
    - Update test coverage table — update skill count, scenario count, and top skills for the language
 
-2. **Regenerate GitHub Pages data** — Run the extraction script to update the docs site
+2. **Regenerate GitHub Pages data** — Run the extraction script and rebuild the docs site from one scoped directory change
 
    ```bash
-   cd docs-site && npx tsx scripts/extract-skills.ts
+   (cd docs-site && npx tsx scripts/extract-skills.ts && npm run build)
    ```
 
-   This updates `docs-site/src/data/skills.json` which feeds the Astro-based docs site.
-   Then rebuild the docs site:
-
-   ```bash
-   cd docs-site && npm run build
-   ```
-
-   This outputs to `docs/` which is served by GitHub Pages.
+   This updates `docs-site/src/data/skills.json` which feeds the Astro-based docs site, then rebuilds the site into `docs/`, which is served by GitHub Pages.
 
 3. **Verify AGENTS.md** — Ensure the skill count is accurate
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -170,13 +170,14 @@ If one pattern handles ~80% of use cases:
 
 If no single pattern dominates:
 
-1. Pick the most common workflow for SKILL.md
-2. Acknowledge other approaches in a `/references/workflows-comparison.md` that explains trade-offs (e.g., "Local dev uses DeveloperToolsCredential; production uses ManagedIdentityCredential")
-3. Do NOT treat valid alternatives as "advanced" — they're equally valid, just different contexts
+1. Include every hero scenario in SKILL.md, even when that means multiple equally valid workflows
+2. Show one complete, runnable example for each hero scenario in SKILL.md
+3. Use `/references/workflows-comparison.md` for trade-offs, secondary variations, and deeper context that would otherwise bloat the main file
+4. Do NOT treat valid alternatives as "advanced" when they are core to real usage — they're equally valid, just different contexts
 
-**Example**: Azure Identity SDK has 8 credential types. Pick `DefaultAzureCredential` for SKILL.md for local development; for production, direct users to specific credentials (`ManagedIdentityCredential`, `WorkloadIdentityCredential`) or configure `DefaultAzureCredential` with `AZURE_TOKEN_CREDENTIALS=prod`. Document `AzureCliCredential`, etc. in `/references/credential-types.md` without ranking them.
+**Example**: Azure Identity SDK has several hero scenarios. Keep the primary local-development and production-safe credential flows in SKILL.md, then use `/references/credential-types.md` for deeper comparisons across `AzureCliCredential`, workload identity, service principal variants, and other secondary credential choices.
 
-**Decision rule**: If you're unsure, ask: "Would a user choosing the other approach call what I wrote wrong?" If no, both are core workflows—acknowledge both with trade-offs.
+**Decision rule**: If you're unsure, ask: "Would a user choosing the other approach call what I wrote wrong?" If yes, it's another hero scenario and belongs in SKILL.md. If no, it can be summarized and linked from `/references/`.
 
 ---
 
@@ -400,7 +401,7 @@ Use a token counter or model playground to measure each section. Compare to the 
 
 **3. Example count audit:**
 
-- [ ] 1 complete example per core workflow (up to 2 only when Case 2 documents multiple equally valid workflows). For Python SDKs that support both sync and async, the paired sync + async examples for the same core workflow count as one workflow, not two.
+- [ ] 1 complete example per hero scenario / core workflow documented in SKILL.md. For Python SDKs that support both sync and async, the paired sync + async examples for the same workflow count as one workflow, not two.
 - [ ] Feature table includes 3-5 core methods (not comprehensive API)
 - [ ] Max 1 example per best practice bullet
 
@@ -413,9 +414,10 @@ Use a token counter or model playground to measure each section. Compare to the 
 
 **4b. Authentication guidance validation** (critical for all credentials):
 
-- [ ] If skill uses Azure Identity credentials, verify guidance against [official credential-chains docs](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/credential-chains#usage-guidance-for-defaultazurecredential)
-- [ ] Development guidance: OK to recommend `DefaultAzureCredential` (supports multiple dev credential types)
-- [ ] Production guidance: `DefaultAzureCredential` alone (unconstrained) is not sufficient; require either `AZURE_TOKEN_CREDENTIALS=prod` (or a specific target credential) to constrain the chain, or a specific credential (e.g., `ManagedIdentityCredential`) used directly
+- [ ] If skill uses Azure Identity credentials, verify guidance against the current official credential docs for that language/package (Microsoft Learn where available; otherwise the upstream SDK repo or package docs)
+- [ ] For Python skills, development guidance may recommend `DefaultAzureCredential` (supports multiple dev credential types)
+- [ ] For Python skills, production guidance: `DefaultAzureCredential` alone (unconstrained) is not sufficient; require either `AZURE_TOKEN_CREDENTIALS=prod` (or a specific target credential) to constrain the chain, or a specific credential (e.g., `ManagedIdentityCredential`) used directly
+- [ ] For Rust skills, development/production guidance reflects the actual supported credentials (`DeveloperToolsCredential` for local dev; a specific production credential such as `ManagedIdentityCredential` for production)
 - [ ] Link to `/references/auth-strategies.md` or official docs for production credential selection
 
 **4c. Run Vally lint/eval (if the skill has a spec under `tests/scenarios/<skill-name>/vally/`):**
@@ -1080,7 +1082,7 @@ Regeneration is not complete when snippets compile — it is complete when the s
 
 Before finalizing any regenerated skill:
 
-1. Identify **hero scenarios** from current Learn quickstarts/tutorials/samples for that SDK.
+1. Identify **hero scenarios** from the current authoritative docs/samples for that SDK (Microsoft Learn where available; otherwise the upstream SDK repo and package documentation).
 2. Ensure each hero scenario is represented in the skill with copy-pastable snippets (or an explicit link to a bundled reference file when too large).
 3. Add/refresh test scenarios so hero flows are validated by harness patterns.
 4. Add at least **one important non-hero scenario** (for example: update/patch, delete/cleanup, export/import, advanced auth mode, paging/filtering, retries/error handling, or LRO monitoring) when supported by the SDK. For Python SDKs that support both sync and async clients, present both forms with equal priority; do not treat either as universally preferred.
@@ -1281,7 +1283,7 @@ Before completing a skill:
 - [ ] Authentication follows language rules (`DefaultAzureCredential` for Python/.NET/Java/TS/Go local dev; `DeveloperToolsCredential` local dev + `ManagedIdentityCredential` production for Rust)
 - [ ] Includes cleanup/delete in examples
 - [ ] References organized by feature (`capabilities.md` index + dedicated deep-dive files)
-- [ ] Hero scenarios from current Learn docs are explicitly covered in snippets and tests
+- [ ] Hero scenarios from the current authoritative docs/samples for that SDK are explicitly covered in snippets and tests
 - [ ] At least one high-value non-hero scenario is included when the SDK supports a distinct non-hero scenario (otherwise note that no distinct non-hero scenario applies)
 - [ ] For Azure SDK skills, `references/capabilities.md` indexes hero/non-hero coverage and links to dedicated non-hero docs
 - [ ] For Azure SDK skills, `references/non-hero-scenarios.md` contains concrete non-hero examples distinct from hero snippets

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -449,7 +449,7 @@ Azure SDKs use consistent verbs across all languages:
 
 See `references/azure-sdk-patterns.md` for detailed patterns including:
 
-- **Python**: `ItemPaged`, `LROPoller`, context managers, Sphinx docstrings. Pick **sync or async** for the whole skill and stick with it — never mix. Always show `with` / `async with` context managers first.
+- **Python**: `ItemPaged`, `LROPoller`, context managers, Sphinx docstrings. Present both sync and async forms as first-class options; do not express a preference for either. Do not mix sync and async within a single code example. Always show `with` / `async with` context managers.
 - **.NET**: `Response<T>`, `Pageable<T>`, `Operation<T>`, mocking support
 - **Java**: Builder pattern, `PagedIterable`/`PagedFlux`, Reactor types
 - **TypeScript**: `PagedAsyncIterableIterator`, `AbortSignal`, browser considerations
@@ -467,7 +467,7 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 **Standard wording (Python; adapt for other languages):**
 
 ```markdown
-1. **Pick sync OR async and stay consistent.** Do not mix `azure.xxx` sync clients with `azure.xxx.aio` async clients in the same call path. Choose one mode per module.
+1. **Do not mix sync and async clients in the same call path.** Use either `azure.xxx` sync clients or `azure.xxx.aio` async clients within a single call path — do not combine both. Present both forms with equal priority in the skill itself.
 2. **Always use context managers for clients and async credentials.** Wrap every client in `with Client(...) as client:` (sync) or `async with Client(...) as client:` (async). For async `DefaultAzureCredential` from `azure.identity.aio`, also use `async with credential:` so tokens and transports are cleaned up.
 3. **Use `DefaultAzureCredential`** for code that runs locally. Use a specific token credential (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`) for code that runs in Azure.
 ```
@@ -486,7 +486,7 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 
 **Enforcement in code examples.** Every code example inside the skill must itself obey both rules, so the skill demonstrates what it prescribes:
 
-- Do not show sync and async calls interleaved in the same example. If you must show both modes, keep the primary example in one mode and isolate the alternative into a single `### Async variant` (or `### Sync variant`) subsection with its own complete example.
+- Do not interleave sync and async calls within a single example. Show each mode in its own complete, self-contained example — a `### Sync` subsection and an `### Async` subsection — giving both equal prominence.
 - Every client instantiation in every example must be wrapped in `with` / `async with`. The only permitted exception is the mandatory Authentication snippet (which illustrates the credential + client construction pattern) and framework lifespan patterns where a client is owned by the app (e.g. FastAPI `lifespan`).
 - When async credentials from `azure.identity.aio` appear in an example, wrap them in `async with credential:` alongside the client.
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -89,17 +89,96 @@ For Azure SDK skills, follow the **Skill Section Order** below. For domain skill
 
 ### Bundled Resources (Optional)
 
-| Type          | When to Include           | Examples                   |
-| ------------- | ------------------------- | -------------------------- |
-| `scripts/`    | Reused code patterns      | Auth setup, CLI scripts    |
-| `references/` | Detailed patterns/schemas | API docs, migration guides |
-| `assets/`     | Output templates          | Boilerplate code, images   |
+| Type          | When to Include                          | Examples                                                   |
+| ------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| `scripts/`    | Reused code patterns                     | Auth setup, CLI scripts                                    |
+| `references/` | Feature deep-dives and overflow examples | `capabilities.md` index, `non-hero-scenarios.md`, API docs |
+| `assets/`     | Output templates                         | Boilerplate code, images                                   |
 
 ---
 
 ## Creating Azure SDK Skills
 
 When creating skills for Azure SDKs, follow these patterns consistently.
+
+### Token Budget Guidelines (REQUIRED)
+
+Every Azure SDK skill MUST stay within these token limits:
+
+| Section                       | Target           | Absolute Max     |
+| ----------------------------- | ---------------- | ---------------- |
+| Installation + Env Vars       | 100 tokens       | 150              |
+| Authentication & Lifecycle    | 200 tokens       | 300              |
+| Core Workflow (1 example)     | 300 tokens       | 400              |
+| Feature Tables                | 200 tokens       | 300              |
+| Best Practices (6-8 items)    | 200 tokens       | 250              |
+| References (reference/ links) | 100 tokens       | 150              |
+| **Total SKILL.md**            | **~1100 tokens** | **~1500 tokens** |
+
+**Enforcement**:
+
+- Exceeding max limit → refactor into `/references/` subdirectories
+- When approaching 500 lines → move entire sections to reference files
+- Annotate with `# Token Count: ~XXXX` at top of completed skill
+
+---
+
+### Reference Extraction Guide (REQUIRED)
+
+Decide what goes in SKILL.md vs. `/references/` using these signals:
+
+| Signal         | Move to `/references/`              | Keep in SKILL.md       |
+| -------------- | ----------------------------------- | ---------------------- |
+| Use frequency  | <20% of typical use                 | ~80%+ of workflows     |
+| Cognitive load | Advanced patterns, multiple options | Single happy path      |
+| Example length | >10 lines, multiple paths           | 1-5 lines, single path |
+
+**Content extraction rules:**
+
+- **Batch operations** → `/references/batch-operations.md`
+- **Error handling** (beyond try-except) → `/references/error-handling.md`
+- **Performance tuning** → `/references/performance.md`
+- **Alternative workflows** → `/references/workflows-comparison.md`
+- **Streaming/events** → `/references/streaming.md`
+- **Advanced auth** → `/references/auth-strategies.md`
+- **Tool integration** → `/references/tools.md`
+- **Breaking changes** → `/references/migration.md`
+
+**Decision:** Keep common case in SKILL.md, move edge cases to `/references/`.
+
+---
+
+### Core Workflow Discipline (REQUIRED)
+
+Every Azure SDK skill must clarify which workflow(s) it documents.
+
+**Case 1: Single clear "core workflow"** (majority of services)
+
+If one pattern handles ~80% of use cases:
+
+1. Designate it as the core workflow
+2. Show ONLY this workflow in SKILL.md (one complete, runnable example)
+3. Defer alternatives to `/references/`:
+   - Batch operations → `/references/batch-operations.md`
+   - Error handling → `/references/error-handling.md`
+   - Performance tuning → `/references/performance.md`
+   - Alternative workflows → `/references/other-workflows.md`
+
+**Example**: Azure Key Vault Secrets (core workflow: retrieve a secret using managed identity). Alternative workflows in `/references/`: API-key auth, certificate auth, service principal auth.
+
+**Case 2: Multiple equally-valid "core workflows"** (e.g., authentication strategies, deployment targets)
+
+If no single pattern dominates:
+
+1. Pick the most common workflow for SKILL.md
+2. Acknowledge other approaches in a `/references/workflows-comparison.md` that explains trade-offs (e.g., "Local dev uses DeveloperToolsCredential; production uses ManagedIdentityCredential")
+3. Do NOT treat valid alternatives as "advanced" — they're equally valid, just different contexts
+
+**Example**: Azure Identity SDK has 8 credential types. Pick `DefaultAzureCredential` for SKILL.md (covers most local + production scenarios). Document `ManagedIdentityCredential`, `WorkloadIdentityCredential`, `AzureCliCredential`, etc. in `/references/credential-types.md` without ranking them.
+
+**Decision rule**: If you're unsure, ask: "Would a user choosing the other approach call what I wrote wrong?" If no, both are core workflows—acknowledge both with trade-offs.
+
+---
 
 ### Skill Section Order
 
@@ -109,10 +188,10 @@ Follow this structure (based on existing Azure SDK skills):
 2. **Installation** — `pip install`, `npm install`, etc.
 3. **Environment Variables** — Required configuration, with an inline comment explaining when it's required . If using `DefaultAzureCredential`in production,include `AZURE_TOKEN_CREDENTIALS` (set to `prod` or `<specific_credential>`)
 4. **Authentication & Lifecycle** — Use a specific Microsoft Entra Token credential like `ManagedIdentityCredential` or `WorkloadIdentityCredential` for production. `DefaultAzureCredential` is only recommended for local development. To use DefaultAzureCredential in production, set the environment variable `AZURE_TOKEN_CREDENTIALS` to `prod` or the specific target credential. **For Python skills, this section MUST start with the standard callout block** (see [Required Authentication & Lifecycle Callout (Python)](#required-authentication--lifecycle-callout-python) below).
-5. **Core Workflow** — Minimal viable example
+5. **Core Workflow** — Minimal viable example (per core workflow discipline above)
 6. **Feature Tables** — Clients, methods, tools
 7. **Best Practices** — Numbered list
-8. **Reference Links** — Table linking to `/references/*.md`
+8. **Reference Links** — Table linking to `/references/*.md` (for Azure SDK skills, include `capabilities.md` + `non-hero-scenarios.md`)
 
 ### Required Authentication & Lifecycle Callout (Python)
 
@@ -262,6 +341,97 @@ let client = BlobServiceClient::new(
 
 **Never hardcode credentials. Use environment variables.**
 
+### Anti-Patterns: What NOT to Do (REQUIRED Reading)
+
+**These patterns cause bloat and inefficiency. Every skill author must review this section before writing.**
+
+#### Anti-Pattern 1: "Exhaustive API Reference"
+
+- ❌ **Don't**: List all 50 SDK methods in a feature table with code samples for every variant
+- ✅ **Do**: Show 3-5 core methods in a table; link to official Azure API reference for exhaustive list
+- **Token cost**: Listing all methods + examples = 400-600 tokens wasted
+- **User impact**: Overwhelming cognitive load; users don't know what to use
+
+#### Anti-Pattern 2: "Multiple Ways to Solve One Problem"
+
+- ❌ **Don't**: "Here's approach A, B, C, and D to paginate results" in the main body
+- ✅ **Do**: "Use `ItemPaged` for sync pagination" (primary example); link alternatives to `/references/`
+- **Token cost**: Each alternate approach = 50-100 tokens; 5 approaches = skill becomes inefficient
+- **User impact**: Decision paralysis; users re-read everything
+
+#### Anti-Pattern 3: "Beginner + Intermediate + Advanced in One Skill"
+
+- ❌ **Don't**: Skill that goes from "what is a client?" to "custom retry policies" to "circuit breaker patterns"
+- ✅ **Do**: Core workflow covers 80% use case; advanced patterns in `/references/`
+- **Token cost**: Every skill level adds 200-300 tokens; three levels = 600-900 extra tokens
+- **User impact**: Experts bored, beginners overwhelmed; nobody gets what they need
+
+#### Anti-Pattern 4: "Restating Official Documentation"
+
+- ❌ **Don't**: "The CosmosClient constructor takes an endpoint (string) and credential (TokenCredential). The endpoint identifies the Azure Cosmos resource..."
+- ✅ **Do**: Show code: `client = CosmosClient(endpoint, credential)`. Link to official docs: `microsoft-docs` MCP.
+- **Token cost**: Verbose explanation = 50-100 tokens per parameter; large APIs waste 300+ tokens
+- **User impact**: Redundant; official docs are authoritative, skill should show usage not repeat them
+
+#### Anti-Pattern 5: "Verbose Explanation When Example Suffices"
+
+- ❌ **Don't**: "To create a client, you first instantiate the class using the constructor, passing the endpoint and credential parameters. The endpoint is a string that identifies your resource..."
+- ✅ **Do**: Show code immediately: `with CosmosClient(endpoint, credential) as client:`
+
+---
+
+### Vally Efficiency Validation (REQUIRED - Phase 2)
+
+**During authoring, validate skill efficiency against vally framework before publication.**
+
+**1. Measure token count:**
+
+Use a token counter or model playground to measure each section. Compare to the Token Budget Guidelines targets above. If any section exceeds max, move content to `/references/`.
+
+**2. Run anti-pattern checklist:**
+
+- [ ] No exhaustive API reference (show 3-5 core methods, not 50)
+- [ ] No multiple solutions to one problem in SKILL.md
+- [ ] No beginner+intermediate+advanced mixed
+- [ ] No restating official docs (code first, link to microsoft-docs)
+- [ ] No verbose prose (examples first, minimal text)
+
+**3. Example count audit:**
+
+- [ ] 1-2 complete examples in core workflow (not 5+)
+- [ ] Feature table includes 3-5 core methods (not comprehensive API)
+- [ ] Max 1 example per best practice bullet
+
+**4. Frontmatter validation:**
+
+- [ ] `name` matches `.github/skills/<name>/SKILL.md`
+- [ ] `description` includes trigger keywords
+- [ ] `description` is ≤200 chars
+- [ ] Optional `benchmark_tokens` and `benchmark_quality` included
+
+**4b. Authentication guidance validation** (critical for all credentials):
+
+- [ ] If skill uses Azure Identity credentials, verify guidance against [official credential-chains docs](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/credential-chains#usage-guidance-for-defaultazurecredential)
+- [ ] Development guidance: OK to recommend `DefaultAzureCredential` (supports multiple dev credential types)
+- [ ] Production guidance: Must NOT recommend `DefaultAzureCredential` alone; recommend specific credential (e.g., `ManagedIdentityCredential`)
+- [ ] Link to `/references/auth-strategies.md` or official docs for production credential selection
+
+**5. Spot check:**
+
+- [ ] Can a user copy the core workflow and run it immediately?
+- [ ] Do all examples follow best practices (context managers, appropriate credentials)?
+- [ ] Are all environment variables documented?
+
+**Output:** After validation, annotate the skill header with measured token count:
+
+```markdown
+# Azure Service SDK
+
+<!-- Token Count: ~1180 (target: 1100, max: 1500) -->
+```
+
+---
+
 ### Standard Verb Patterns
 
 Azure SDKs use consistent verbs across all languages:
@@ -304,15 +474,15 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 
 **Variants to apply when the SDK shape differs:**
 
-| Skill type                                           | Adjust item #1 to                                                                                                                | Adjust item #2 to                                                                                                                                                                                                              |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Async-only SDK (e.g. voicelive)                      | "This SDK is async-only; use the `.aio` namespace throughout."                                                                   | keep standard                                                                                                                                                                                                                  |
-| Async-first framework (agent framework, m365-agents) | "This SDK is async-first — use `async def` handlers and `async with` throughout."                                                | keep standard                                                                                                                                                                                                                  |
-| Provider-pattern (OpenTelemetry exporters/distro)    | keep standard                                                                                                                    | "Call `provider.shutdown()` / `flush()` at process exit to flush telemetry — providers are not context managers."                                                                                                              |
-| REST-over-httpx skills                               | keep standard                                                                                                                    | "Use `with httpx.Client(...) as client:` (sync) or `async with httpx.AsyncClient(...) as client:` (async) so connections pool and close deterministically."                                                                    |
-| Identity skill                                       | keep standard                                                                                                                    | "Use credentials as context managers (`with DefaultAzureCredential() as credential:`) when they own token caches / HTTP transports you want cleaned up; for async, use `async with` on credentials from `azure.identity.aio`." |
-| FastAPI (non-Azure)                                  | "Pick `def` or `async def` per endpoint based on whether you call async I/O; do not mix sync and blocking calls in one handler." | "Manage long-lived resources (DB pools, HTTP clients) in `lifespan` and inject via `Depends`; use `with`/`async with` for per-request resources."                                                                              |
-| Pure model/schema skill (no I/O, e.g. pydantic)      | **skip both** — not applicable                                                                                                   | **skip**                                                                                                                                                                                                                       |
+| Skill type                                                                    | Adjust item #1 to                                                                                                                   | Adjust item #2 to                                                                                                                                                                                                              |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Async-only SDK (e.g. voicelive)                                               | "This SDK is async-only; use the `.aio` namespace throughout."                                                                      | keep standard                                                                                                                                                                                                                  |
+| Framework guidance that is async-oriented (for example some agent frameworks) | "Use the framework's documented async patterns where required, but do not claim async is globally preferred for Azure Python SDKs." | keep standard                                                                                                                                                                                                                  |
+| Provider-pattern (OpenTelemetry exporters/distro)                             | keep standard                                                                                                                       | "Call `provider.shutdown()` / `flush()` at process exit to flush telemetry — providers are not context managers."                                                                                                              |
+| REST-over-httpx skills                                                        | keep standard                                                                                                                       | "Use `with httpx.Client(...) as client:` (sync) or `async with httpx.AsyncClient(...) as client:` (async) so connections pool and close deterministically."                                                                    |
+| Identity skill                                                                | keep standard                                                                                                                       | "Use credentials as context managers (`with DefaultAzureCredential() as credential:`) when they own token caches / HTTP transports you want cleaned up; for async, use `async with` on credentials from `azure.identity.aio`." |
+| FastAPI (non-Azure)                                                           | "Pick `def` or `async def` per endpoint based on whether you call async I/O; do not mix sync and blocking calls in one handler."    | "Manage long-lived resources (DB pools, HTTP clients) in `lifespan` and inject via `Depends`; use `with`/`async with` for per-request resources."                                                                              |
+| Pure model/schema skill (no I/O, e.g. pydantic)                               | **skip both** — not applicable                                                                                                      | **skip**                                                                                                                                                                                                                       |
 
 **Enforcement in code examples.** Every code example inside the skill must itself obey both rules, so the skill demonstrates what it prescribes:
 
@@ -335,6 +505,30 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 5. **Assign appropriate RBAC roles for Entra ID auth.** For production authentication using Entra ID, ensure the identity has the necessary RBAC role assigned (e.g., "Storage Blob Data Contributor" for blob write access).
 
 6. **Always verify package versions using crates.io.** Before using a package, check its version on [crates.io](https://crates.io/) to ensure you are using a stable and supported release.
+
+### Example Effective Skills (Benchmark These)
+
+**Study these 4 skills for conciseness, focus, and efficiency.** Your new skills should match this profile or explicitly explain why they're larger.
+
+| Skill                       | Est. Tokens | Tokens Δ    | Quality Δ  | Key Pattern to Copy                                       |
+| --------------------------- | ----------- | ----------- | ---------- | --------------------------------------------------------- |
+| `azure-ai-ml-py`            | ~1,200      | **-39%** ✅ | Maintained | Single workflow: train + register model; concise examples |
+| `azure-ai-textanalytics-py` | ~1,100      | **-39%** ✅ | Maintained | Feature table (5-7 core methods); minimal prose           |
+| `azure-ai-contentsafety-py` | ~1,150      | **-37%** ✅ | Maintained | Compact use-case focus; each example is 1-2 lines         |
+| `azure-appconfiguration-py` | ~1,180      | **-34%** ✅ | Maintained | Strategic link to references; no comprehensive API doc    |
+
+**Why these are effective**:
+
+1. Stay under 1,200 tokens (core limit)
+2. Show ONE canonical workflow, not 5 variants
+3. Show 1-2 examples per concept, not 3-5
+4. Use tables for API summary (not prose descriptions)
+5. Link to official docs via `microsoft-docs` MCP instead of duplicating
+6. Move advanced patterns to `/references/`
+
+**Before writing your skill**: Ask "Which of these 4 is my use case most similar to?" then mirror that structure.
+
+---
 
 ### Handling Deprecated or Rebranded SDKs
 
@@ -471,10 +665,12 @@ item = client.create_item(name="example", data={...})
 
 ## Reference Files
 
-| File                                               | Contents                 |
-| -------------------------------------------------- | ------------------------ |
-| [references/tools.md](references/tools.md)         | Tool integrations        |
-| [references/streaming.md](references/streaming.md) | Event streaming patterns |
+| File                                                                 | Contents                                               |
+| -------------------------------------------------------------------- | ------------------------------------------------------ |
+| [references/capabilities.md](references/capabilities.md)             | Capability index (hero coverage + links to deep-dives) |
+| [references/non-hero-scenarios.md](references/non-hero-scenarios.md) | Concrete non-hero examples                             |
+| [references/tools.md](references/tools.md)                           | Tool integrations                                      |
+| [references/streaming.md](references/streaming.md)                   | Event streaming patterns                               |
 ```
 
 ---
@@ -577,16 +773,42 @@ Skills are organized by **language** and **product area** in the `skills/` direc
 
 **Write bundled resources first**, then SKILL.md.
 
-**Frontmatter:**
+**Quality assurance before finalizing:**
+
+1. Measure section token counts as you write (use model playground token counter)
+2. Compare to Token Budget Guidelines targets
+3. Validate against anti-patterns checklist (see Anti-Patterns section)
+4. Extract to `/references/` if section exceeds max tokens
+5. Run Vally efficiency validation checklist (see Vally Efficiency Validation)
+6. Update frontmatter with `benchmark_tokens` and `benchmark_quality` metadata
+7. Add token count comment to skill header for future maintenance
+
+**Frontmatter (Enhanced with Benchmarking Metadata):**
 
 ```yaml
 ---
-name: skill-name-py
+name: azure-service-py
 description: |
   Azure Service SDK for Python. Use for [specific features].
   Triggers: "service name", "create resource", "specific operation".
+benchmark_tokens:
+  estimated: 1180
+  target: 1100
+  max: 1500
+benchmark_quality:
+  single_core_workflow: true
+  examples_focused: true
+  no_prose_bloat: true
+  anti_patterns_checked: true
 ---
 ```
+
+**Metadata fields:**
+
+- `benchmark_tokens.estimated` — Actual measured token count
+- `benchmark_tokens.target` — Target efficiency (typically 1100)
+- `benchmark_tokens.max` — Absolute ceiling (1500; split if exceeded)
+- `benchmark_quality.*` — Boolean checklist for validation
 
 ### Step 5: Categorize with Symlinks
 
@@ -628,6 +850,8 @@ ls -la skills/python/foundry/agents
 #### 6.1 Create Acceptance Criteria
 
 **Location:** `tests/scenarios/<skill-name>/acceptance-criteria.md`
+
+> Keep acceptance criteria in the `tests/` tree (never beside `SKILL.md` inside the skill folder).
 
 **Source materials** (in priority order):
 
@@ -827,7 +1051,36 @@ For Azure SDK language skills, use official upstream source docs and examples as
 - Update "Best Practices" and "Reference Links" when upstream recommendations change
 - For Rust, if code uses `azure_core` types/imports directly, ensure `azure_core` is present in `Cargo.toml`; if only service-crate re-exports are used, direct `azure_core` dependency is optional
 
-3. **Validate regenerated skill behavior**
+### API Surface Parity Gate (required for every regenerated skill)
+
+Treat Microsoft Learn API reference as the contract for every snippet in the regenerated skill.
+
+Before finalizing any regenerated skill:
+
+1. Identify each SDK type/method shown in snippets (clients, operation groups, model constructors, enum members, long-running methods like `begin_*`).
+2. Verify each symbol and signature against current Microsoft Learn API reference pages for that package.
+3. If Learn shows a different shape (for example nested `properties=...` models, renamed methods, `begin_*` LRO methods), update the snippet to the Learn shape.
+4. Re-check imports so model/client modules match Learn exactly.
+5. Do not keep compatibility shortcuts that contradict Learn examples in primary snippets.
+
+### Scenario Coverage Gate (required for every regenerated skill, all languages)
+
+Regeneration is not complete when snippets compile — it is complete when the skill demonstrates real usage breadth.
+
+Before finalizing any regenerated skill:
+
+1. Identify **hero scenarios** from current Learn quickstarts/tutorials/samples for that SDK.
+2. Ensure each hero scenario is represented in the skill with copy-pastable snippets (or an explicit link to a bundled reference file when too large).
+3. Add/refresh test scenarios so hero flows are validated by harness patterns.
+4. Add at least **one important non-hero scenario** (for example: update/patch, delete/cleanup, export/import, advanced auth mode, paging/filtering, retries/error handling, or LRO monitoring) when supported by the SDK. For Python SDKs that support both sync and async clients, present both forms with equal priority; do not treat either as universally preferred.
+5. For Azure SDK skills, structure `references/` as:
+   - `references/capabilities.md` as a concise index (hero scenarios + links to deeper non-hero references, no historical/migration narration).
+   - `references/non-hero-scenarios.md` for concrete non-hero examples that are intentionally kept out of the main `SKILL.md`.
+   - Additional `references/*.md` files for specialized deep-dives (operation groups, tools, evaluator matrices, etc.).
+6. If the SDK has broad operation-group coverage (common in management SDKs), include an operation-group table and explicitly call out which groups are covered in snippets vs. referenced only.
+7. Never claim "full API surface" unless the skill genuinely demonstrates all major operation groups; otherwise state that the skill is optimized for hero workflows plus selected secondary scenarios.
+
+8. **Validate regenerated skill behavior**
 
 ```bash
 cd tests
@@ -865,6 +1118,66 @@ In the PR/commit notes, include:
 - Which upstream docs/examples were used
 - Which snippets/signatures were corrected
 - Which tests/evals were run and their outcomes
+
+#### Python plugin batch recipe: `azure-sdk-python`
+
+Use this when the request is "regenerate all Python skills under azure-sdk-python."
+
+1. **Scope the exact targets first**
+
+```bash
+# Canonical source of truth for Python plugin skills
+ls .github/plugins/azure-sdk-python/skills/*/SKILL.md
+```
+
+- Treat `.github/plugins/azure-sdk-python/skills/` as canonical.
+- Keep `.github/skills/<name>` links in sync after edits (symlink check/fix step below).
+
+2. **For each skill, refresh from authoritative sources**
+
+- Always use `microsoft-docs` MCP first for current Microsoft Learn API guidance.
+- Verify installed package API surface with `pip show <package>` before finalizing snippets.
+- For Azure SDK skills, prefer package overview + official SDK repo examples.
+- For non-Azure Python skills in this plugin (for example `fastapi-router-py`, `pydantic-models-py`), keep language-specific best-practice variants and skip Azure-specific auth callouts when lifecycle/auth is not applicable.
+
+3. **Apply Python enforcement rules consistently**
+
+- Keep the standard section order for Azure SDK Python skills.
+- Ensure `## Authentication & Lifecycle` starts with the required callout block (verbatim) when applicable.
+- Ensure every client example uses `with` / `async with` lifecycle patterns.
+- Ensure `## Best Practices` starts with the two required user-facing rules (or the documented variant for async-only/provider-pattern skills).
+- Ensure each regenerated Azure SDK Python skill has `references/capabilities.md` (index) and `references/non-hero-scenarios.md` (concrete non-hero examples).
+- Keep existing references/assets/scripts unless stale or incorrect.
+
+4. **Validate all regenerated Python skills**
+
+```bash
+# Fast frontmatter/structure validation for every Python skill
+python .github/skills/skill-creator/scripts/quick_validate.py .github/plugins/azure-sdk-python/skills/<skill-name>
+
+# Run Python skill harness in mock mode (all *-py scenarios)
+cd tests
+pwsh ./run-harness-by-language.ps1 -Language py -Mock
+```
+
+5. **Sync skill links and docs artifacts**
+
+```bash
+# Ensure .github/skills links point at plugin canonical skills
+python .github/scripts/sync_skill_links.py --plugin azure-sdk-python --check
+python .github/scripts/sync_skill_links.py --plugin azure-sdk-python --apply
+
+# Refresh docs site data after content changes
+cd docs-site && npx tsx scripts/extract-skills.ts
+cd docs-site && npm run build
+```
+
+6. **Completion criteria for batch regeneration**
+
+- Every targeted `.github/plugins/azure-sdk-python/skills/*/SKILL.md` is updated or explicitly confirmed current.
+- Harness mock run for `-py` skills passes without regressions.
+- Skill links are in sync for `azure-sdk-python`.
+- PR notes include upstream docs used, signature corrections, and validation outcomes.
 
 ---
 
@@ -938,6 +1251,9 @@ azure-ai-agents/
 | Use wrong import paths                                                         | Azure SDKs have specific module structures                                          |
 | Omit sync/async + context-manager bullets from Best Practices in Python skills | End users won't follow rules that aren't written down; examples alone aren't enough |
 | Mix sync and async in the same Python example                                  | Demonstrates the anti-pattern the skill is supposed to prevent                      |
+| Ship regenerated skills with zero test scenarios                               | Hero workflows and regressions cannot be validated                                  |
+| Claim full API coverage from a single happy-path sample                        | Hides operation-group and non-hero gaps users need for production                   |
+| Omit `references/*.md` coverage for non-hero capabilities                      | Forces advanced capabilities out of context and leaves API breadth undocumented     |
 
 ---
 
@@ -949,6 +1265,7 @@ Before completing a skill:
 
 - [ ] User provided SDK package name or documentation URL
 - [ ] Verified SDK patterns via `microsoft-docs` MCP
+- [ ] Verified every snippet's API surface against current Microsoft Learn API reference pages for that SDK
 
 **Skill Creation:**
 
@@ -956,7 +1273,12 @@ Before completing a skill:
 - [ ] SKILL.md under 500 lines
 - [ ] Authentication follows language rules (`DefaultAzureCredential` for Python/.NET/Java/TS/Go local dev; `DeveloperToolsCredential` local dev + `ManagedIdentityCredential` production for Rust)
 - [ ] Includes cleanup/delete in examples
-- [ ] References organized by feature
+- [ ] References organized by feature (`capabilities.md` index + dedicated deep-dive files)
+- [ ] Hero scenarios from current Learn docs are explicitly covered in snippets and tests
+- [ ] At least one high-value non-hero scenario is included (or explicitly documented as intentionally out of scope)
+- [ ] For Azure SDK skills, `references/capabilities.md` indexes hero/non-hero coverage and links to dedicated non-hero docs
+- [ ] For Azure SDK skills, `references/non-hero-scenarios.md` contains concrete non-hero examples distinct from hero snippets
+- [ ] For broad SDKs (especially management SDKs), operation-group coverage is explicit (covered in snippets vs. reference-only)
 - [ ] **(Python skills only) Best Practices section contains the two user-facing rules** (sync-or-async consistency + context managers for clients and async credentials), using the variant matched to the skill type
 - [ ] For Rust skills: `## Best Practices` starts with cargo dependency rule + `azure_core` direct-import rule
 
@@ -970,6 +1292,7 @@ Before completing a skill:
 
 - [ ] `tests/scenarios/<skill-name>/acceptance-criteria.md` created with correct/incorrect patterns
 - [ ] `tests/scenarios/<skill-name>/scenarios.yaml` created
+- [ ] At least one hero scenario and one non-hero scenario are test-covered (when the SDK supports both)
 - [ ] All scenarios pass (`pnpm harness <skill> --mock`)
 - [ ] Import paths documented precisely
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -508,25 +508,25 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 
 ### Example Effective Skills (Benchmark These)
 
-**Study these 4 skills for conciseness, focus, and efficiency.** Your new skills should match this profile or explicitly explain why they're larger.
+**Study these skills for conciseness, focus, and efficiency.** Your new skills should match this profile or explicitly explain why they're larger.
 
-| Skill                       | Est. Tokens | Tokens Δ    | Quality Δ  | Key Pattern to Copy                                       |
-| --------------------------- | ----------- | ----------- | ---------- | --------------------------------------------------------- |
-| `azure-ai-ml-py`            | ~1,200      | **-39%** ✅ | Maintained | Single workflow: train + register model; concise examples |
-| `azure-ai-textanalytics-py` | ~1,100      | **-39%** ✅ | Maintained | Feature table (5-7 core methods); minimal prose           |
-| `azure-ai-contentsafety-py` | ~1,150      | **-37%** ✅ | Maintained | Compact use-case focus; each example is 1-2 lines         |
-| `azure-appconfiguration-py` | ~1,180      | **-34%** ✅ | Maintained | Strategic link to references; no comprehensive API doc    |
+| Skill                          | Est. Tokens | Key Pattern to Copy                                              |
+| ------------------------------ | ----------- | ---------------------------------------------------------------- |
+| `azure-keyvault-secrets-rust`  | ~1,400      | CRUD workflow (set/update/delete/list); RBAC table; concise snippets |
+| `azure-identity-rust`          | ~1,400      | Credential-type table as the core structure; 3 short code examples; minimal prose |
+| `azure-cosmos-rust`            | ~1,470      | Client hierarchy table + single CRUD workflow; one code block per operation |
+| `azure-storage-queue-rust`     | ~1,700      | Send/receive/peek/delete flow; pagination pattern; RBAC table    |
 
 **Why these are effective**:
 
-1. Stay under 1,200 tokens (core limit)
-2. Show ONE canonical workflow, not 5 variants
+1. Stay under 1,200–1,800 tokens
+2. Cover the hero workflow (CRUD or primary operations), not every feature variant
 3. Show 1-2 examples per concept, not 3-5
-4. Use tables for API summary (not prose descriptions)
+4. Use tables for API summary (credential types, RBAC roles, client hierarchy)
 5. Link to official docs via `microsoft-docs` MCP instead of duplicating
 6. Move advanced patterns to `/references/`
 
-**Before writing your skill**: Ask "Which of these 4 is my use case most similar to?" then mirror that structure.
+**Before writing your skill**: Ask "Which of these is my use case most similar to?" then mirror that structure.
 
 ---
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -187,7 +187,7 @@ Follow this structure (based on existing Azure SDK skills):
 1. **Title** — `# SDK Name`
 2. **Installation** — `pip install`, `npm install`, etc.
 3. **Environment Variables** — Required configuration, with an inline comment explaining when it's required . If using `DefaultAzureCredential`in production,include `AZURE_TOKEN_CREDENTIALS` (set to `prod` or `<specific_credential>`)
-4. **Authentication & Lifecycle** — Use a specific Microsoft Entra Token credential like `ManagedIdentityCredential` or `WorkloadIdentityCredential` for production. `DefaultAzureCredential` is only recommended for local development. To use DefaultAzureCredential in production, set the environment variable `AZURE_TOKEN_CREDENTIALS` to `prod` or the specific target credential. **For Python skills, this section MUST start with the standard callout block** (see [Required Authentication & Lifecycle Callout (Python)](#required-authentication--lifecycle-callout-python) below).
+4. **Authentication & Lifecycle** — For Python skills, prefer `DefaultAzureCredential`: use it as-is for local development, and constrain it for production by setting `AZURE_TOKEN_CREDENTIALS` to `prod` (or a specific target credential name). A specific Microsoft Entra Token credential such as `ManagedIdentityCredential` or `WorkloadIdentityCredential` may be used directly instead. **For Python skills, this section MUST start with the standard callout block** (see [Required Authentication & Lifecycle Callout (Python)](#required-authentication--lifecycle-callout-python) below).
 5. **Core Workflow** — Minimal viable example (per core workflow discipline above)
 6. **Feature Tables** — Clients, methods, tools
 7. **Best Practices** — Numbered list
@@ -380,9 +380,9 @@ let client = BlobServiceClient::new(
 
 ---
 
-### Vally Efficiency Validation (REQUIRED - Phase 2)
+### Efficiency Validation (REQUIRED - Phase 2)
 
-**During authoring, validate skill efficiency against vally framework before publication.**
+**During authoring, validate skill efficiency manually, then run the Vally eval if the skill has one under `tests/scenarios/<skill-name>/vally/`.**
 
 **1. Measure token count:**
 
@@ -398,7 +398,7 @@ Use a token counter or model playground to measure each section. Compare to the 
 
 **3. Example count audit:**
 
-- [ ] 1 complete example per core workflow (up to 2 only when Case 2 documents multiple equally valid workflows)
+- [ ] 1 complete example per core workflow (up to 2 only when Case 2 documents multiple equally valid workflows). For Python SDKs that support both sync and async, the paired sync + async examples for the same core workflow count as one workflow, not two.
 - [ ] Feature table includes 3-5 core methods (not comprehensive API)
 - [ ] Max 1 example per best practice bullet
 
@@ -406,15 +406,26 @@ Use a token counter or model playground to measure each section. Compare to the 
 
 - [ ] `name` matches `.github/skills/<name>/SKILL.md`
 - [ ] `description` includes trigger keywords
-- [ ] `description` is ≤200 chars
-- [ ] Optional `benchmark_tokens` and `benchmark_quality` included
+- [ ] `description` is concise (~200 chars is a good target; schema max is 1,024 chars)
+- [ ] Optional `benchmark_tokens_*` and `benchmark_quality_*` metadata fields included (flat strings under `metadata`)
 
 **4b. Authentication guidance validation** (critical for all credentials):
 
 - [ ] If skill uses Azure Identity credentials, verify guidance against [official credential-chains docs](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/credential-chains#usage-guidance-for-defaultazurecredential)
 - [ ] Development guidance: OK to recommend `DefaultAzureCredential` (supports multiple dev credential types)
-- [ ] Production guidance: Must NOT recommend `DefaultAzureCredential` alone; recommend specific credential (e.g., `ManagedIdentityCredential`)
+- [ ] Production guidance: `DefaultAzureCredential` alone (unconstrained) is not sufficient; require either `AZURE_TOKEN_CREDENTIALS=prod` (or a specific target credential) to constrain the chain, or a specific credential (e.g., `ManagedIdentityCredential`) used directly
 - [ ] Link to `/references/auth-strategies.md` or official docs for production credential selection
+
+**4c. Run Vally lint/eval (if the skill has a spec under `tests/scenarios/<skill-name>/vally/`):**
+
+```bash
+vally lint --eval-spec tests/scenarios/<skill-name>/vally/eval.yaml
+vally eval --eval-spec tests/scenarios/<skill-name>/vally/eval.yaml
+```
+
+- [ ] `vally lint` passes with no errors
+- [ ] `vally eval` passes (no error-severity findings) when `COPILOT_TOKEN` is available; otherwise lint-only is acceptable, matching the [`Vally Evaluation`](../../workflows/vally-evaluation.yml) workflow behavior
+- [ ] Skills without a `vally/` spec skip this step — it is optional per skill, not required for every skill
 
 **5. Spot check:**
 
@@ -515,11 +526,11 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 | `azure-keyvault-secrets-rust`  | ~1,400      | CRUD workflow (set/update/delete/list); RBAC table; concise snippets |
 | `azure-identity-rust`          | ~1,400      | Credential-type table as the core structure; 3 short code examples; minimal prose |
 | `azure-cosmos-rust`            | ~1,470      | Client hierarchy table + single CRUD workflow; one code block per operation |
-| `azure-storage-queue-rust`     | ~1,700      | Send/receive/peek/delete flow; pagination pattern; RBAC table    |
+| `azure-eventhub-rust`          | ~1,475      | Send/receive workflow; key-concepts table; minimal prose         |
 
 **Why these are effective**:
 
-1. Stay under 1,200–1,800 tokens
+1. Stay at or under the 1,500-token absolute max (see Token Budget Guidelines above)
 2. Cover the hero workflow (CRUD or primary operations), not every feature variant
 3. Show 1-2 examples per concept, not 3-5
 4. Use tables for API summary (credential types, RBAC roles, client hierarchy)
@@ -779,8 +790,8 @@ Skills are organized by **language** and **product area** in the `skills/` direc
 2. Compare to Token Budget Guidelines targets
 3. Validate against anti-patterns checklist (see Anti-Patterns section)
 4. Extract to `/references/` if section exceeds max tokens
-5. Run Vally efficiency validation checklist (see Vally Efficiency Validation)
-6. Optionally add `benchmark_tokens` and `benchmark_quality` under the frontmatter's `metadata` mapping
+5. Run Efficiency Validation checklist, including `vally lint`/`vally eval` if the skill has a spec (see Efficiency Validation)
+6. Optionally add `benchmark_tokens_*` and `benchmark_quality_*` fields under the frontmatter's `metadata` mapping (flat string values)
 7. Add token count comment to skill header for future maintenance
 
 **Frontmatter (Enhanced with Benchmarking Metadata):**
@@ -792,24 +803,22 @@ description: |
   Azure Service SDK for Python. Use for [specific features].
   Triggers: "service name", "create resource", "specific operation".
 metadata:
-  benchmark_tokens:
-    estimated: 1180
-    target: 1100
-    max: 1500
-  benchmark_quality:
-    single_core_workflow: true
-    examples_focused: true
-    no_prose_bloat: true
-    anti_patterns_checked: true
+  benchmark_tokens_estimated: "1180"
+  benchmark_tokens_target: "1100"
+  benchmark_tokens_max: "1500"
+  benchmark_quality_single_core_workflow: "true"
+  benchmark_quality_examples_focused: "true"
+  benchmark_quality_no_prose_bloat: "true"
+  benchmark_quality_anti_patterns_checked: "true"
 ---
 ```
 
-**Metadata fields:**
+**Metadata fields:** (all values are strings, per the Agent Skills `metadata` spec — string keys mapped to string values)
 
-- `benchmark_tokens.estimated` — Actual measured token count
-- `benchmark_tokens.target` — Target efficiency (typically 1100)
-- `benchmark_tokens.max` — Absolute ceiling (1500; split if exceeded)
-- `benchmark_quality.*` — Boolean checklist for validation
+- `benchmark_tokens_estimated` — Actual measured token count
+- `benchmark_tokens_target` — Target efficiency (typically 1100)
+- `benchmark_tokens_max` — Absolute ceiling (1500; split if exceeded)
+- `benchmark_quality_*` — Individual anti-pattern checks, each a `"true"`/`"false"` string (e.g., `benchmark_quality_single_core_workflow`)
 
 ### Step 5: Categorize with Symlinks
 
@@ -1084,11 +1093,10 @@ Before finalizing any regenerated skill:
 6. If the SDK has broad operation-group coverage (common in management SDKs), include an operation-group table and explicitly call out which groups are covered in snippets vs. referenced only.
 7. Never claim "full API surface" unless the skill genuinely demonstrates all major operation groups; otherwise state that the skill is optimized for hero workflows plus selected secondary scenarios.
 
-3. **Validate regenerated skill behavior**
+### Regeneration Workflow Step 3: Validate Regenerated Skill Behavior
 
 ```bash
-cd tests
-pnpm harness <skill-name> --mock --verbose
+(cd tests && pnpm harness <skill-name> --mock --verbose)
 ```
 
 If the skill has a Vally scenario, run that eval as well (locally or in CI) before finalizing.
@@ -1108,14 +1116,13 @@ rg -n "Use `cargo add` to manage dependencies, never edit `Cargo.toml` directly|
 
 The regeneration is not complete unless both lines are present in each affected Rust skill.
 
-4. **Regenerate docs artifacts after refresh**
+### Regeneration Workflow Step 4: Regenerate Docs Artifacts After Refresh
 
 ```bash
-cd docs-site && npx tsx scripts/extract-skills.ts
-cd docs-site && npm run build
+(cd docs-site && npx tsx scripts/extract-skills.ts && npm run build)
 ```
 
-5. **Record what changed**
+### Regeneration Workflow Step 5: Record What Changed
 
 In the PR/commit notes, include:
 
@@ -1160,8 +1167,7 @@ ls .github/plugins/azure-sdk-python/skills/*/SKILL.md
 python .github/skills/skill-creator/scripts/quick_validate.py .github/plugins/azure-sdk-python/skills/<skill-name>
 
 # Run Python skill harness in mock mode (all *-py scenarios)
-cd tests
-pwsh ./run-harness-by-language.ps1 -Language py -Mock
+(cd tests && pwsh ./run-harness-by-language.ps1 -Language py -Mock)
 ```
 
 5. **Sync skill links and docs artifacts**
@@ -1172,8 +1178,7 @@ python .github/scripts/sync_skill_links.py --plugin azure-sdk-python --check
 python .github/scripts/sync_skill_links.py --plugin azure-sdk-python --apply
 
 # Refresh docs site data after content changes
-cd docs-site && npx tsx scripts/extract-skills.ts
-cd docs-site && npm run build
+(cd docs-site && npx tsx scripts/extract-skills.ts && npm run build)
 ```
 
 6. **Completion criteria for batch regeneration**
@@ -1269,7 +1274,7 @@ Before completing a skill:
 
 - [ ] User provided SDK package name or documentation URL
 - [ ] Verified SDK patterns via `microsoft-docs` MCP
-- [ ] Verified every snippet's API surface against current Microsoft Learn API reference pages for that SDK
+- [ ] Verified every snippet's API surface against the current official language-specific API reference for that SDK (Microsoft Learn where available, otherwise the upstream SDK repo — see canonical sources above)
 
 **Skill Creation:**
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -407,7 +407,7 @@ Use a token counter or model playground to measure each section. Compare to the 
 - [ ] `name` matches `.github/skills/<name>/SKILL.md`
 - [ ] `description` includes trigger keywords
 - [ ] `description` is concise (~200 chars is a good target; schema max is 1,024 chars)
-- [ ] Optional `benchmark_tokens_*` and `benchmark_quality_*` metadata fields included (flat strings under `metadata`)
+- [ ] If included, optional `benchmark_tokens_*` and `benchmark_quality_*` metadata fields are flat strings under `metadata`
 
 **4b. Authentication guidance validation** (critical for all credentials):
 
@@ -517,18 +517,11 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 
 6. **Always verify package versions using crates.io.** Before using a package, check its version on [crates.io](https://crates.io/) to ensure you are using a stable and supported release.
 
-### Example Effective Skills (Benchmark These)
+### Example Effective Skills (Benchmark Only Structure-Compliant Skills)
 
-**Study these skills for conciseness, focus, and efficiency.** Your new skills should match this profile or explicitly explain why they're larger.
+**Only benchmark Azure SDK skills that already use the required `references/` layout** (`references/capabilities.md` plus `references/non-hero-scenarios.md`). Older skills that predate that structure can still be useful for style ideas, but do not mirror them directly until they are brought into compliance.
 
-| Skill                          | Est. Tokens | Key Pattern to Copy                                              |
-| ------------------------------ | ----------- | ---------------------------------------------------------------- |
-| `azure-keyvault-secrets-rust`  | ~1,400      | CRUD workflow (set/update/delete/list); RBAC table; concise snippets |
-| `azure-identity-rust`          | ~1,400      | Credential-type table as the core structure; 3 short code examples; minimal prose |
-| `azure-cosmos-rust`            | ~1,470      | Client hierarchy table + single CRUD workflow; one code block per operation |
-| `azure-eventhub-rust`          | ~1,475      | Send/receive workflow; key-concepts table; minimal prose         |
-
-**Why these are effective**:
+**A valid benchmark skill should**:
 
 1. Stay at or under the 1,500-token absolute max (see Token Budget Guidelines above)
 2. Cover the hero workflow (CRUD or primary operations), not every feature variant
@@ -536,6 +529,7 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 4. Use tables for API summary (credential types, RBAC roles, client hierarchy)
 5. Link to official docs via `microsoft-docs` MCP instead of duplicating
 6. Move advanced patterns to `/references/`
+7. Include `references/capabilities.md` and `references/non-hero-scenarios.md`
 
 **Before writing your skill**: Ask "Which of these is my use case most similar to?" then mirror that structure.
 
@@ -1080,7 +1074,7 @@ Before finalizing any regenerated skill:
 3. Add/refresh test scenarios so hero flows are validated by harness patterns.
 4. Add at least **one important non-hero scenario** (for example: update/patch, delete/cleanup, export/import, advanced auth mode, paging/filtering, retries/error handling, or LRO monitoring) when supported by the SDK. For Python SDKs that support both sync and async clients, present both forms with equal priority; do not treat either as universally preferred.
 5. For Azure SDK skills, structure `references/` as:
-   - `references/capabilities.md` as a concise index (hero scenarios + links to deeper non-hero references, no historical/migration narration).
+   - `references/capabilities.md` as a concise index that records each hero scenario and where it is covered (`SKILL.md` or a bundled reference), plus links to deeper non-hero references, with no historical/migration narration.
    - `references/non-hero-scenarios.md` for concrete non-hero examples that are intentionally kept out of the main `SKILL.md`.
    - Additional `references/*.md` files for specialized deep-dives (operation groups, tools, evaluator matrices, etc.).
 6. If the SDK has broad operation-group coverage (common in management SDKs), include an operation-group table and explicitly call out which groups are covered in snippets vs. referenced only.
@@ -1277,7 +1271,7 @@ Before completing a skill:
 - [ ] Includes cleanup/delete in examples
 - [ ] References organized by feature (`capabilities.md` index + dedicated deep-dive files)
 - [ ] Hero scenarios from current Learn docs are explicitly covered in snippets and tests
-- [ ] At least one high-value non-hero scenario is included (or explicitly documented as intentionally out of scope)
+- [ ] At least one high-value non-hero scenario is included when the SDK supports a distinct non-hero scenario (otherwise note that no distinct non-hero scenario applies)
 - [ ] For Azure SDK skills, `references/capabilities.md` indexes hero/non-hero coverage and links to dedicated non-hero docs
 - [ ] For Azure SDK skills, `references/non-hero-scenarios.md` contains concrete non-hero examples distinct from hero snippets
 - [ ] For broad SDKs (especially management SDKs), operation-group coverage is explicit (covered in snippets vs. reference-only)

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -174,7 +174,7 @@ If no single pattern dominates:
 2. Acknowledge other approaches in a `/references/workflows-comparison.md` that explains trade-offs (e.g., "Local dev uses DeveloperToolsCredential; production uses ManagedIdentityCredential")
 3. Do NOT treat valid alternatives as "advanced" — they're equally valid, just different contexts
 
-**Example**: Azure Identity SDK has 8 credential types. Pick `DefaultAzureCredential` for SKILL.md (covers most local + production scenarios). Document `ManagedIdentityCredential`, `WorkloadIdentityCredential`, `AzureCliCredential`, etc. in `/references/credential-types.md` without ranking them.
+**Example**: Azure Identity SDK has 8 credential types. Pick `DefaultAzureCredential` for SKILL.md for local development; for production, direct users to specific credentials (`ManagedIdentityCredential`, `WorkloadIdentityCredential`) or configure `DefaultAzureCredential` with `AZURE_TOKEN_CREDENTIALS=prod`. Document `AzureCliCredential`, etc. in `/references/credential-types.md` without ranking them.
 
 **Decision rule**: If you're unsure, ask: "Would a user choosing the other approach call what I wrote wrong?" If no, both are core workflows—acknowledge both with trade-offs.
 
@@ -449,7 +449,7 @@ Azure SDKs use consistent verbs across all languages:
 
 See `references/azure-sdk-patterns.md` for detailed patterns including:
 
-- **Python**: `ItemPaged`, `LROPoller`, context managers, Sphinx docstrings. Present both sync and async forms as first-class options; do not express a preference for either. Do not mix sync and async within a single code example. Always show `with` / `async with` context managers.
+- **Python**: `ItemPaged`, `LROPoller`, context managers, Sphinx docstrings. When the SDK provides both sync and async clients, present both forms as first-class options; do not express a preference for either. When the SDK is sync-only or async-only, document the available mode only. Do not mix sync and async within a single code example. Always show `with` / `async with` context managers.
 - **.NET**: `Response<T>`, `Pageable<T>`, `Operation<T>`, mocking support
 - **Java**: Builder pattern, `PagedIterable`/`PagedFlux`, Reactor types
 - **TypeScript**: `PagedAsyncIterableIterator`, `AbortSignal`, browser considerations
@@ -467,7 +467,7 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 **Standard wording (Python; adapt for other languages):**
 
 ```markdown
-1. **Do not mix sync and async clients in the same call path.** Use either `azure.xxx` sync clients or `azure.xxx.aio` async clients within a single call path — do not combine both. Present both forms with equal priority in the skill itself.
+1. **Do not mix sync and async clients in the same call path.** Use either `azure.xxx` sync clients or `azure.xxx.aio` async clients within a single call path — do not combine both.
 2. **Always use context managers for clients and async credentials.** Wrap every client in `with Client(...) as client:` (sync) or `async with Client(...) as client:` (async). For async `DefaultAzureCredential` from `azure.identity.aio`, also use `async with credential:` so tokens and transports are cleaned up.
 3. **Use `DefaultAzureCredential`** for code that runs locally. Use a specific token credential (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`) for code that runs in Azure.
 ```
@@ -486,7 +486,7 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 
 **Enforcement in code examples.** Every code example inside the skill must itself obey both rules, so the skill demonstrates what it prescribes:
 
-- Do not interleave sync and async calls within a single example. Show each mode in its own complete, self-contained example — a `### Sync` subsection and an `### Async` subsection — giving both equal prominence.
+- Do not interleave sync and async calls within a single example. When the SDK provides both sync and async clients, show each mode in its own complete, self-contained example — a `### Sync` subsection and an `### Async` subsection — giving both equal prominence. When the SDK is sync-only or async-only, show only the available mode.
 - Every client instantiation in every example must be wrapped in `with` / `async with`. The only permitted exception is the mandatory Authentication snippet (which illustrates the credential + client construction pattern) and framework lifespan patterns where a client is owned by the app (e.g. FastAPI `lifespan`).
 - When async credentials from `azure.identity.aio` appear in an example, wrap them in `async with credential:` alongside the client.
 
@@ -1054,15 +1054,18 @@ For Azure SDK language skills, use official upstream source docs and examples as
 
 ### API Surface Parity Gate (required for every regenerated skill)
 
-Treat Microsoft Learn API reference as the contract for every snippet in the regenerated skill.
+Use the language-specific authoritative source as the contract for every snippet in the regenerated skill:
+
+- **Python, .NET, Java, TypeScript, Go**: Treat the current Microsoft Learn API reference as the contract.
+- **Rust**: Treat the official SDK repository (`https://github.com/Azure/azure-sdk-for-rust`) and crates.io documentation as the contract; Rust packages do not have Learn API-reference pages.
 
 Before finalizing any regenerated skill:
 
 1. Identify each SDK type/method shown in snippets (clients, operation groups, model constructors, enum members, long-running methods like `begin_*`).
-2. Verify each symbol and signature against current Microsoft Learn API reference pages for that package.
-3. If Learn shows a different shape (for example nested `properties=...` models, renamed methods, `begin_*` LRO methods), update the snippet to the Learn shape.
-4. Re-check imports so model/client modules match Learn exactly.
-5. Do not keep compatibility shortcuts that contradict Learn examples in primary snippets.
+2. Verify each symbol and signature against the authoritative source for that language/package (see above).
+3. If the authoritative source shows a different shape (for example nested `properties=...` models, renamed methods, `begin_*` LRO methods), update the snippet to match.
+4. Re-check imports so model/client modules match the authoritative source exactly.
+5. Do not keep compatibility shortcuts that contradict authoritative examples in primary snippets.
 
 ### Scenario Coverage Gate (required for every regenerated skill, all languages)
 
@@ -1081,7 +1084,7 @@ Before finalizing any regenerated skill:
 6. If the SDK has broad operation-group coverage (common in management SDKs), include an operation-group table and explicitly call out which groups are covered in snippets vs. referenced only.
 7. Never claim "full API surface" unless the skill genuinely demonstrates all major operation groups; otherwise state that the skill is optimized for hero workflows plus selected secondary scenarios.
 
-8. **Validate regenerated skill behavior**
+3. **Validate regenerated skill behavior**
 
 ```bash
 cd tests

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -119,7 +119,7 @@ Every Azure SDK skill MUST stay within these token limits:
 
 - Exceeding max limit → refactor into `/references/` subdirectories
 - When approaching 500 lines → move entire sections to reference files
-- Annotate with `# Token Count: ~XXXX` at top of completed skill
+- Annotate with `<!-- Token Count: ~XXXX (target: 1100, max: 1500) -->` immediately below the skill's H1
 
 ---
 
@@ -162,9 +162,9 @@ If one pattern handles ~80% of use cases:
    - Batch operations → `/references/batch-operations.md`
    - Error handling → `/references/error-handling.md`
    - Performance tuning → `/references/performance.md`
-   - Alternative workflows → `/references/other-workflows.md`
+   - Alternative workflows → `/references/workflows-comparison.md`
 
-**Example**: Azure Key Vault Secrets (core workflow: retrieve a secret using managed identity). Alternative workflows in `/references/`: API-key auth, certificate auth, service principal auth.
+**Example**: Azure Key Vault Secrets (core workflow: retrieve a secret using managed identity). Alternative authentication workflows in `/references/`: local development with `DefaultAzureCredential`, workload identity, and service-principal credentials (client secret or certificate).
 
 **Case 2: Multiple equally-valid "core workflows"** (e.g., authentication strategies, deployment targets)
 
@@ -398,7 +398,7 @@ Use a token counter or model playground to measure each section. Compare to the 
 
 **3. Example count audit:**
 
-- [ ] 1-2 complete examples in core workflow (not 5+)
+- [ ] 1 complete example per core workflow (up to 2 only when Case 2 documents multiple equally valid workflows)
 - [ ] Feature table includes 3-5 core methods (not comprehensive API)
 - [ ] Max 1 example per best practice bullet
 
@@ -780,7 +780,7 @@ Skills are organized by **language** and **product area** in the `skills/` direc
 3. Validate against anti-patterns checklist (see Anti-Patterns section)
 4. Extract to `/references/` if section exceeds max tokens
 5. Run Vally efficiency validation checklist (see Vally Efficiency Validation)
-6. Update frontmatter with `benchmark_tokens` and `benchmark_quality` metadata
+6. Optionally add `benchmark_tokens` and `benchmark_quality` under the frontmatter's `metadata` mapping
 7. Add token count comment to skill header for future maintenance
 
 **Frontmatter (Enhanced with Benchmarking Metadata):**
@@ -791,15 +791,16 @@ name: azure-service-py
 description: |
   Azure Service SDK for Python. Use for [specific features].
   Triggers: "service name", "create resource", "specific operation".
-benchmark_tokens:
-  estimated: 1180
-  target: 1100
-  max: 1500
-benchmark_quality:
-  single_core_workflow: true
-  examples_focused: true
-  no_prose_bloat: true
-  anti_patterns_checked: true
+metadata:
+  benchmark_tokens:
+    estimated: 1180
+    target: 1100
+    max: 1500
+  benchmark_quality:
+    single_core_workflow: true
+    examples_focused: true
+    no_prose_bloat: true
+    anti_patterns_checked: true
 ---
 ```
 
@@ -1136,7 +1137,7 @@ ls .github/plugins/azure-sdk-python/skills/*/SKILL.md
 2. **For each skill, refresh from authoritative sources**
 
 - Always use `microsoft-docs` MCP first for current Microsoft Learn API guidance.
-- Verify installed package API surface with `pip show <package>` before finalizing snippets.
+- Verify the installed package version with `pip show <package>`, then inspect the installed package or official API reference to verify every symbol and signature used in snippets.
 - For Azure SDK skills, prefer package overview + official SDK repo examples.
 - For non-Azure Python skills in this plugin (for example `fastapi-router-py`, `pydantic-models-py`), keep language-specific best-practice variants and skip Azure-specific auth callouts when lifecycle/auth is not applicable.
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -186,7 +186,7 @@ Follow this structure (based on existing Azure SDK skills):
 
 1. **Title** — `# SDK Name`
 2. **Installation** — `pip install`, `npm install`, etc.
-3. **Environment Variables** — Required configuration, with an inline comment explaining when it's required . If using `DefaultAzureCredential`in production,include `AZURE_TOKEN_CREDENTIALS` (set to `prod` or `<specific_credential>`)
+3. **Environment Variables** — Required configuration, with an inline comment explaining when it's required. If using `DefaultAzureCredential` in production, include `AZURE_TOKEN_CREDENTIALS` (set to `prod` or `<specific_credential>`)
 4. **Authentication & Lifecycle** — For Python skills, prefer `DefaultAzureCredential`: use it as-is for local development, and constrain it for production by setting `AZURE_TOKEN_CREDENTIALS` to `prod` (or a specific target credential name). A specific Microsoft Entra Token credential such as `ManagedIdentityCredential` or `WorkloadIdentityCredential` may be used directly instead. **For Python skills, this section MUST start with the standard callout block** (see [Required Authentication & Lifecycle Callout (Python)](#required-authentication--lifecycle-callout-python) below).
 5. **Core Workflow** — Minimal viable example (per core workflow discipline above)
 6. **Feature Tables** — Clients, methods, tools
@@ -238,8 +238,10 @@ If configuring a Rust skill, use `DeveloperToolsCredential` for local developmen
 ```python
 # Python — note: client is wrapped in `with` for deterministic cleanup
 from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
-# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
-credential = DefaultAzureCredential(require_envvar=True)
+# Local dev: DefaultAzureCredential works as-is.
+credential = DefaultAzureCredential()
+# Production alternative: constrain DefaultAzureCredential with AZURE_TOKEN_CREDENTIALS.
+# credential = DefaultAzureCredential(require_envvar=True)
 # Or use a specific credential directly in production:
 # See https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes
 # credential = ManagedIdentityCredential()
@@ -419,8 +421,15 @@ Use a token counter or model playground to measure each section. Compare to the 
 **4c. Run Vally lint/eval (if the skill has a spec under `tests/scenarios/<skill-name>/vally/`):**
 
 ```bash
-vally lint --eval-spec tests/scenarios/<skill-name>/vally/eval.yaml
-vally eval --eval-spec tests/scenarios/<skill-name>/vally/eval.yaml
+# If the eval spec uses the shared Rust custom grader plugin, build it first.
+(cd tests/scenarios/_shared/vally/grader-plugins/rust-cargo-build-failure && npm install && npm run build)
+
+vally lint --eval-spec tests/scenarios/<skill-name>/vally/eval.yaml \
+  --grader-plugin tests/scenarios/_shared/vally/grader-plugins/rust-cargo-build-failure \
+  --strict
+
+vally eval --eval-spec tests/scenarios/<skill-name>/vally/eval.yaml \
+  --grader-plugin tests/scenarios/_shared/vally/grader-plugins/rust-cargo-build-failure
 ```
 
 - [ ] `vally lint` passes with no errors
@@ -480,7 +489,7 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 ```markdown
 1. **Do not mix sync and async clients in the same call path.** Use either `azure.xxx` sync clients or `azure.xxx.aio` async clients within a single call path — do not combine both.
 2. **Always use context managers for clients and async credentials.** Wrap every client in `with Client(...) as client:` (sync) or `async with Client(...) as client:` (async). For async `DefaultAzureCredential` from `azure.identity.aio`, also use `async with credential:` so tokens and transports are cleaned up.
-3. **Use `DefaultAzureCredential`** for code that runs locally. Use a specific token credential (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`) for code that runs in Azure.
+3. **Use `DefaultAzureCredential`** for code that runs locally. For code that runs in Azure, either constrain `DefaultAzureCredential` with `AZURE_TOKEN_CREDENTIALS=prod` (or a specific target credential) or use a specific token credential directly (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`).
 ```
 
 **Variants to apply when the SDK shape differs:**
@@ -531,7 +540,7 @@ Add both items verbatim (adapted only for language/SDK specifics) as the **first
 6. Move advanced patterns to `/references/`
 7. Include `references/capabilities.md` and `references/non-hero-scenarios.md`
 
-**Before writing your skill**: Ask "Which of these is my use case most similar to?" then mirror that structure.
+**Before writing your skill**: Apply the checklist above directly, then mirror only the structure patterns that fit your use case.
 
 ---
 
@@ -632,9 +641,11 @@ AZURE_TOKEN_CREDENTIALS=prod # Required only if DefaultAzureCredential is used i
 from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.ai.example import ExampleClient
 
-# Local dev: DefaultAzureCredential. Production: set AZURE_TOKEN_CREDENTIALS=prod or AZURE_TOKEN_CREDENTIALS=<specific_credential>
+# Local dev: DefaultAzureCredential works as-is.
+credential = DefaultAzureCredential()
 
-credential = DefaultAzureCredential(require_envvar=True)
+# Production alternative: constrain DefaultAzureCredential with AZURE_TOKEN_CREDENTIALS.
+# credential = DefaultAzureCredential(require_envvar=True)
 
 # Or use a specific credential directly in production:
 

--- a/.github/skills/skill-creator/references/azure-sdk-patterns.md
+++ b/.github/skills/skill-creator/references/azure-sdk-patterns.md
@@ -9,14 +9,15 @@ Reference for creating skills that teach agents to write code following official
 ## Table of Contents
 
 1. [Core Principles (All Languages)](#core-principles-all-languages)
-2. [Standard Naming Conventions](#standard-naming-conventions)
-3. [Python Patterns](#python-patterns)
-4. [.NET (C#) Patterns](#net-c-patterns)
-5. [Java Patterns](#java-patterns)
-6. [TypeScript/JavaScript Patterns](#typescriptjavascript-patterns)
-7. [Rust Patterns](#rust-patterns)
-8. [Authentication (All Languages)](#authentication-all-languages)
-9. [Quick Reference Tables](#quick-reference-tables)
+2. [Skill Reference Directory Pattern](#skill-reference-directory-pattern)
+3. [Standard Naming Conventions](#standard-naming-conventions)
+4. [Python Patterns](#python-patterns)
+5. [.NET (C#) Patterns](#net-c-patterns)
+6. [Java Patterns](#java-patterns)
+7. [TypeScript/JavaScript Patterns](#typescriptjavascript-patterns)
+8. [Rust Patterns](#rust-patterns)
+9. [Authentication (All Languages)](#authentication-all-languages)
+10. [Quick Reference Tables](#quick-reference-tables)
 
 ---
 
@@ -33,6 +34,20 @@ Azure SDKs follow five design principles. Skills should reinforce these:
 | **Dependable** | No breaking changes without major version bump |
 
 **Consistency Priority:** Language conventions > Service conventions > Cross-language conventions
+
+---
+
+## Skill Reference Directory Pattern
+
+For Azure SDK skills, keep `SKILL.md` focused on hero flows and use `references/` for overflow details:
+
+- `references/capabilities.md` is an index only: hero scenarios covered in `SKILL.md`, non-hero scenario list, and links to deep-dive reference files.
+- `references/non-hero-scenarios.md` contains concrete non-hero examples intentionally kept out of `SKILL.md`.
+- Additional `references/*.md` files are optional for specialized topics (operation groups, evaluator/tool matrices, migration notes).
+
+Use present-tense guidance in reference files; avoid historical migration notes in user-facing capability indexes.
+
+For Python SDK skills that provide both sync and async clients, present both forms as first-class options. Do not encode a blanket preference for either mode in capability prioritization.
 
 ---
 

--- a/.github/skills/skill-creator/references/azure-sdk-patterns.md
+++ b/.github/skills/skill-creator/references/azure-sdk-patterns.md
@@ -96,7 +96,7 @@ class AsyncConfigurationClient:
     pass
 ```
 
-### Sync vs Async: Pick One, Don't Mix
+### Sync vs Async: Don't Mix Within a Call Path
 
 **Rule:** Within a single module, script, or code path, use **either** the sync client **or** the async client — never both.
 
@@ -140,7 +140,7 @@ async def run_also_bad():
         await client.agents.get_agent("agent-id")  # credential.get_token() will block
 ```
 
-When writing a skill, pick one model based on the target runtime (FastAPI/async framework → async; scripts/CLIs → sync) and make every example in the skill consistent with that choice.
+When writing a skill, present both sync and async forms as first-class options with equal priority. Do not encode a preference for either mode.
 
 ### Pagination: ItemPaged / AsyncItemPaged
 

--- a/.github/skills/skill-creator/references/azure-sdk-patterns.md
+++ b/.github/skills/skill-creator/references/azure-sdk-patterns.md
@@ -41,7 +41,7 @@ Azure SDKs follow five design principles. Skills should reinforce these:
 
 For Azure SDK skills, keep `SKILL.md` focused on hero flows and use `references/` for overflow details:
 
-- `references/capabilities.md` is an index only: hero scenarios covered in `SKILL.md`, non-hero scenario list, and links to deep-dive reference files.
+- `references/capabilities.md` is an index only: each hero scenario plus where it is covered (`SKILL.md` or a bundled reference), the non-hero scenario list, and links to deep-dive reference files.
 - `references/non-hero-scenarios.md` contains concrete non-hero examples intentionally kept out of `SKILL.md`.
 - Additional `references/*.md` files are optional for specialized topics (operation groups, evaluator/tool matrices, migration notes).
 

--- a/.github/skills/skill-creator/references/azure-sdk-patterns.md
+++ b/.github/skills/skill-creator/references/azure-sdk-patterns.md
@@ -47,7 +47,7 @@ For Azure SDK skills, keep `SKILL.md` focused on hero flows and use `references/
 
 Use present-tense guidance in reference files; avoid historical migration notes in user-facing capability indexes.
 
-For Python SDK skills that provide both sync and async clients, present both forms as first-class options. Do not encode a blanket preference for either mode in capability prioritization.
+For Python SDK skills that provide both sync and async clients, present both forms as first-class options with equal priority. Do not encode a blanket preference for either mode in capability prioritization. When the SDK is sync-only or async-only, document the available mode only.
 
 ---
 
@@ -140,7 +140,7 @@ async def run_also_bad():
         await client.agents.get_agent("agent-id")  # credential.get_token() will block
 ```
 
-When writing a skill, present both sync and async forms as first-class options with equal priority. Do not encode a preference for either mode.
+When writing a skill, present both sync and async forms as first-class options with equal priority when the SDK provides both. Do not encode a preference for either mode. When the SDK is sync-only or async-only, document the available mode only.
 
 ### Pagination: ItemPaged / AsyncItemPaged
 

--- a/tests/pnpm-workspace.yaml
+++ b/tests/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: set this to true or false

--- a/tests/pnpm-workspace.yaml
+++ b/tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false

--- a/tests/pnpm-workspace.yaml
+++ b/tests/pnpm-workspace.yaml
@@ -1,5 +1,2 @@
-packages:
-  - .
-
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: set this to true or false

--- a/tests/pnpm-workspace.yaml
+++ b/tests/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
-allowBuilds:
-  esbuild: set this to true or false
+packages:
+  - .
+
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
Split from #375 (1 of 5).

Adds skill lifecycle guidance to skill-creator and a new Azure SDK patterns reference.

Files:
- .github/skills/skill-creator/SKILL.md
- .github/skills/skill-creator/references/azure-sdk-patterns.md