### PR TITLE
fix(deep-wiki): raise diagram zoom controls above SVG content

### DIFF
--- a/.github/plugins/deep-wiki/commands/build.md
+++ b/.github/plugins/deep-wiki/commands/build.md
@@ -531,6 +531,8 @@ Theme variables don't cover everything. Force dark fills on all SVG shapes:
   overflow: hidden;
 }
 .diagram-zoom-controls {
+  position: relative;
+  z-index: 10000;
   display: flex;
   gap: 8px;
   padding: 8px 12px;


### PR DESCRIPTION
Fixes #367

## Summary

- Add `position: relative` and `z-index: 10000` to `.diagram-zoom-controls` in the deep-wiki build template
- Keeps zoom/close buttons clickable when a panned or zoomed Mermaid SVG overlaps the control bar (the overlay already uses `z-index: 9999`, but the controls bar had no stacking context)

## Test plan

- [ ] Generate a deep-wiki site with a Mermaid diagram (`/deep-wiki:build`)
- [ ] Click a diagram to open the zoom modal
- [ ] Pan the diagram upward and/or zoom in until the SVG overlaps the control bar
- [ ] Confirm `+`, `−`, `Reset`, and `✕` buttons remain clickable
- [ ] Confirm Esc and overlay click-to-close still work


Made with [Cursor](https://cursor.com)