### PR TITLE
fix: skill install command

### DIFF
--- a/docs-site/e2e/copy.spec.ts
+++ b/docs-site/e2e/copy.spec.ts
@@ -8,7 +8,7 @@ test.describe('Copy to Clipboard', () => {
   });
 
   test('copy button is visible on skill cards', async ({ page }) => {
-    const skillCard = page.locator('.skills-grid a').first();
+    const skillCard = page.locator('.skills-grid > div').first();
     await skillCard.waitFor({ state: 'visible', timeout: 10000 });
 
     await skillCard.hover();
@@ -18,7 +18,7 @@ test.describe('Copy to Clipboard', () => {
   });
 
   test('clicking copy button shows success feedback', async ({ page }) => {
-    const skillCard = page.locator('.skills-grid a').first();
+    const skillCard = page.locator('.skills-grid > div').first();
     await skillCard.waitFor({ state: 'visible', timeout: 10000 });
     await skillCard.hover();
 
@@ -30,17 +30,22 @@ test.describe('Copy to Clipboard', () => {
     await expect(copiedButton).toBeVisible({ timeout: 3000 });
   });
 
-  test('copy button copies correct install command', async ({ page }) => {
-    const skillCard = page.locator('.skills-grid a').first();
-    await skillCard.waitFor({ state: 'visible', timeout: 10000 });
-    await skillCard.hover();
+  const commandCases = [
+    { source: 'direct', name: 'mcp-builder', command: 'npx skills add microsoft/skills --skill mcp-builder' },
+    { source: 'azure-skills plugin', name: 'microsoft-foundry', command: 'npx skills add microsoft/azure-skills --skill microsoft-foundry' },
+    { source: 'generic plugin', name: 'azure-ai-projects-py', command: 'npx skills add https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-python/skills/azure-ai-projects-py' },
+  ];
 
-    const copyButton = skillCard.locator('button:has-text("Copy")');
-    await expect(copyButton).toBeVisible();
-    await copyButton.click();
+  for (const { source, name, command } of commandCases) {
+    test(`copy button has exact install command for ${source} skill (${name})`, async ({ page }) => {
+      await page.getByTestId('search-input').fill(name);
+      const skillCard = page.locator('.skills-grid > div').filter({
+        has: page.getByRole('heading', { level: 3, name, exact: true }),
+      });
+      await skillCard.waitFor({ state: 'visible', timeout: 10000 });
 
-    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
-    
-    expect(clipboardText).toMatch(/^npx skills add (microsoft\/(azure-)?skills --skill |https:\/\/github\.com\/microsoft\/skills\/tree\/main\/)/);
-  });
+      const copyButton = skillCard.getByRole('button', { name: 'Copy' });
+      await expect(copyButton).toHaveAttribute('title', `Copy: ${command}`);
+    });
+  }
 });

--- a/docs-site/e2e/copy.spec.ts
+++ b/docs-site/e2e/copy.spec.ts
@@ -41,6 +41,6 @@ test.describe('Copy to Clipboard', () => {
 
     const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
     
-    expect(clipboardText).toMatch(/npx skills add microsoft\/skills --skill/);
+    expect(clipboardText).toMatch(/^npx skills add (microsoft\/(azure-)?skills --skill |https:\/\/github\.com\/microsoft\/skills\/tree\/main\/)/);
   });
 });

--- a/docs-site/src/components/SkillCard.tsx
+++ b/docs-site/src/components/SkillCard.tsx
@@ -56,13 +56,24 @@ export const LANG_LABELS: Record<string, string> = {
   core: 'Core',
 };
 
+// Skills come from different sources/plugins.
+// First matching prefix wins, and default to this repo's root.
+export function getInstallCommand(skill: Pick<Skill, 'name' | 'path'>): string {
+  const sources: [prefix: string, command: () => string][] = [
+    ['.github/plugins/azure-skills/', () => `npx skills add microsoft/azure-skills --skill ${skill.name}`],
+    ['.github/plugins/', () => `npx skills add https://github.com/microsoft/skills/tree/main/${skill.path}`],
+  ];
+  const match = sources.find(([prefix]) => skill.path.startsWith(prefix));
+  return match ? match[1]() : `npx skills add microsoft/skills --skill ${skill.name}`;
+}
+
 export function SkillCard({ skill, onClick }: SkillCardProps) {
   const [copied, setCopied] = useState(false);
   
   const langStyle = LANG_STYLES[skill.language] || LANG_STYLES.core;
   const langLabel = LANG_LABELS[skill.language] || skill.language;
   
-  const installCommand = `npx skills add microsoft/skills --skill ${skill.name}`;
+  const installCommand = getInstallCommand(skill);
   
   const handleCopy = useCallback(async (e: React.MouseEvent) => {
     e.preventDefault();

--- a/docs-site/src/components/SkillDetailModal.tsx
+++ b/docs-site/src/components/SkillDetailModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import type { Skill } from './SkillCard';
-import { LANG_STYLES, LANG_LABELS } from './SkillCard';
+import { LANG_STYLES, LANG_LABELS, getInstallCommand } from './SkillCard';
 
 interface SkillDetailModalProps {
   skill: Skill | null;
@@ -30,7 +30,7 @@ export function SkillDetailModal({ skill, onClose }: SkillDetailModalProps) {
     }
   }, [onClose]);
 
-  const installCommand = skill ? `npx skills add microsoft/skills --skill ${skill.name}` : '';
+  const installCommand = skill ? getInstallCommand(skill) : '';
 
   const handleCopy = useCallback(async () => {
     try {


### PR DESCRIPTION
Fix #363

- For direct skills, keep `npx skills add microsoft/skills`
- For plugins, use their own install commands `npx skills add microsoft/azure-skills ...` or `npx skills add https://github.com/microsoft/skills/tree/main/...`