### PR TITLE
fix(frontend-design-review): use colorblind-safe status indicators

### DIFF
--- a/.github/skills/frontend-design-review/references/review-output-format.md
+++ b/.github/skills/frontend-design-review/references/review-output-format.md
@@ -32,11 +32,11 @@
 
 | Pillar | Status | Notes |
 |--------|--------|-------|
-| Frictionless | 🟢/🟠/⚫ | Task completion efficient, primary action clear |
-| Quality Craft | 🟢/🟠/⚫ | Design system compliant, aesthetic distinctive, accessible |
-| Trustworthy | 🟢/🟠/⚫ | AI disclaimers present, errors actionable |
+| Frictionless | ✅/⚠️/❌ | Task completion efficient, primary action clear |
+| Quality Craft | ✅/⚠️/❌ | Design system compliant, aesthetic distinctive, accessible |
+| Trustworthy | ✅/⚠️/❌ | AI disclaimers present, errors actionable |
 
-**Legend:** 🟢 Pass | 🟠 Needs attention | ⚫ Blocking issue
+**Legend:** ✅ Pass | ⚠️ Needs attention | ❌ Blocking issue
 
 ### Design Critique
 **Verdict:** [Pass / Needs work / Reach out to design for more support]
@@ -44,9 +44,9 @@
 **Rationale:** [Brief explanation based on pillar assessment, design system compliance, and aesthetic direction]
 
 **Criteria:**
-- **Pass**: All pillars 🟢 or minor 🟠 that don't block user tasks, design system compliant, clear aesthetic direction
-- **Needs work**: Multiple 🟠 or any critical workflow issues, design system deviations, or generic aesthetic choices
-- **Reach out to design for more support**: Any ⚫ blocking issues, fundamental pattern problems, major design system violations, or need for aesthetic direction
+- **Pass**: All pillars ✅ or minor ⚠️ that don't block user tasks, design system compliant, clear aesthetic direction
+- **Needs work**: Multiple ⚠️ or any critical workflow issues, design system deviations, or generic aesthetic choices
+- **Reach out to design for more support**: Any ❌ blocking issues, fundamental pattern problems, major design system violations, or need for aesthetic direction
 
 ### Issues
 


### PR DESCRIPTION
## Summary

Pillar status in the frontend design review output format used filled-circle emoji (🟢 / 🟠 / ⚫) that differ mainly by hue. Under protanopia/deuteranopia those circles are hard to tell apart at small sizes.

This PR swaps them for distinct-shape emoji that stay readable without relying on color alone:

| Before | After | Meaning |
|--------|-------|---------|
| 🟢 | ✅ | Pass |
| 🟠 | ⚠️ | Needs attention |
| ⚫ | ❌ | Blocking issue |

Legend text labels are unchanged. Review template structure and wording are otherwise the same.

Fixes #397

## Test plan

- [x] Confirmed indicators only appear in `.github/skills/frontend-design-review/references/review-output-format.md` within that skill
- [x] Diff is limited to the seven status/legend/criteria references
- [x] No open prior PR for #397 at open time
- [x] Markdown table/legend still render clearly in GitHub preview